### PR TITLE
feat(layout): add pruneLongEdges tool

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "simulator",
       "source": "./plugins/simulator",
       "description": "Simulator.Company platform assistant. Exposes the Simulator REST API as an MCP server and provides skills for managing actors, forms, graph structures, and financial accounts.",
-      "version": "1.3.1",
+      "version": "1.3.5",
       "author": {
         "name": "Simulator.Company",
         "url": "https://simulator.company"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## [1.3.5]
+
+- Add `pruneLongEdges(layerId, maxDistancePx?, bucketThreshold?, preserveParentEdges?, dryRun?)` MCP tool. Walks every edge on a layer, deletes those whose Manhattan distance between endpoints exceeds `maxDistancePx` (default 600 px). By default keeps edges where either endpoint is a hierarchy bucket (≥ `bucketThreshold` incoming edges, default 3). `dryRun:true` previews without deleting. Returns scanned/deleted/kept_short/kept_parent counts plus up to 10 example deletions.
+
+## [1.3.1]
+
+- Rename edge title fields to camelCase.
+
+## [1.3.0]
+
+- Rebrand to simulator-ai-plugin and ship MCP server.

--- a/plugins/simulator/.claude-plugin/plugin.json
+++ b/plugins/simulator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simulator",
-  "version": "1.3.1",
+  "version": "1.3.5",
   "description": "Simulator.Company platform assistant. Exposes the Simulator REST API as an MCP server and provides skills for managing actors, forms, graph structures, and financial accounts.",
   "author": {
     "name": "Simulator.Company",

--- a/plugins/simulator/mcp-server/app/mcp-server/prune_edges.go
+++ b/plugins/simulator/mcp-server/app/mcp-server/prune_edges.go
@@ -1,0 +1,209 @@
+package mcpserver
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// pruneLongEdges removes edges on a layer whose Manhattan distance between
+// endpoints exceeds `maxDistancePx`. Optionally, `preserveParentEdges:true`
+// (default) keeps any edge where either endpoint is a "bucket" (an actor with
+// `>= bucketThreshold` incoming edges) — those are usually hierarchical and
+// rightly span the canvas.
+//
+// Output: {scanned, deleted, kept_short, kept_parent, errors[]}.
+//
+// Use case: after a layout pass moves clusters apart, leftover cross-cluster
+// edges turn into long diagonals that visually obscure the graph. This tool
+// trims those diagonals while preserving meaningful parent → child wiring.
+
+type pruneStats struct {
+	Scanned     int      `json:"scanned"`
+	Deleted     int      `json:"deleted"`
+	KeptShort   int      `json:"kept_short"`
+	KeptParent  int      `json:"kept_parent"`
+	Errors      []string `json:"errors,omitempty"`
+	DryRun      bool     `json:"dryRun"`
+	Examples    []string `json:"deletedExamples,omitempty"`
+}
+
+func handlePruneLongEdges(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	if authResult := ensureAuth(ctx); authResult != nil {
+		return authResult, nil
+	}
+	args := req.GetArguments()
+	layerID, _ := args["layerId"].(string)
+	if layerID == "" {
+		return mcp.NewToolResultError("[Error] layerId is required"), nil
+	}
+	maxDist := toInt(args["maxDistancePx"])
+	if maxDist <= 0 {
+		maxDist = 600
+	}
+	bucketThreshold := toInt(args["bucketThreshold"])
+	if bucketThreshold == 0 {
+		bucketThreshold = 3
+	}
+	dryRun, _ := args["dryRun"].(bool)
+	preserveParents := true
+	if v, ok := args["preserveParentEdges"].(bool); ok {
+		preserveParents = v
+	}
+
+	client := &http.Client{
+		Timeout: 60 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+	apiGet := func(url string) ([]byte, error) {
+		hr, _ := http.NewRequestWithContext(ctx, "GET", url, nil)
+		hr.Header.Set("Authorization", globalApiConfig.Authorization)
+		resp, err := client.Do(hr)
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close()
+		b, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode >= 300 {
+			return nil, fmt.Errorf("HTTP %d: %.200s", resp.StatusCode, b)
+		}
+		return b, nil
+	}
+	apiDelete := func(url string) error {
+		hr, _ := http.NewRequestWithContext(ctx, "DELETE", url, nil)
+		hr.Header.Set("Authorization", globalApiConfig.Authorization)
+		resp, err := client.Do(hr)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		b, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode >= 300 {
+			return fmt.Errorf("HTTP %d: %.200s", resp.StatusCode, b)
+		}
+		return nil
+	}
+
+	// 1) Pull all placements (for positions).
+	type plac struct {
+		ID    string `json:"id"`
+		Title string `json:"title"`
+		Position struct {
+			X int `json:"x"`
+			Y int `json:"y"`
+		} `json:"position"`
+	}
+	positionOf := map[string]struct{ X, Y int }{}
+	titleOf := map[string]string{}
+	const limit = 100
+	offset := 0
+	for {
+		u := fmt.Sprintf("%s/graph_layers/paginated/%s?type=nodes&limit=%d&offset=%d",
+			buildBaseURL(), layerID, limit, offset)
+		body, err := apiGet(u)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("[Error] fetch placements: %v", err)), nil
+		}
+		var page struct {
+			Data []plac `json:"data"`
+		}
+		if err := json.Unmarshal(body, &page); err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("[Error] parse placements: %v", err)), nil
+		}
+		for _, p := range page.Data {
+			positionOf[p.ID] = struct{ X, Y int }{X: p.Position.X, Y: p.Position.Y}
+			titleOf[p.ID] = p.Title
+		}
+		if len(page.Data) < limit {
+			break
+		}
+		offset += limit
+	}
+
+	// 2) Pull all edges.
+	type edgeRow struct {
+		ID     string `json:"id"`
+		Source string `json:"source"`
+		Target string `json:"target"`
+	}
+	var edges []edgeRow
+	offset = 0
+	for {
+		u := fmt.Sprintf("%s/graph_layers/paginated/%s?type=edges&limit=%d&offset=%d",
+			buildBaseURL(), layerID, limit, offset)
+		body, err := apiGet(u)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("[Error] fetch edges: %v", err)), nil
+		}
+		var page struct {
+			Data []edgeRow `json:"data"`
+		}
+		if err := json.Unmarshal(body, &page); err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("[Error] parse edges: %v", err)), nil
+		}
+		edges = append(edges, page.Data...)
+		if len(page.Data) < limit {
+			break
+		}
+		offset += limit
+	}
+
+	// 3) Compute incoming-edge counts to decide buckets.
+	incoming := map[string]int{}
+	for _, e := range edges {
+		incoming[e.Target]++
+	}
+	isBucket := func(id string) bool {
+		return incoming[id] >= bucketThreshold
+	}
+
+	stats := pruneStats{DryRun: dryRun}
+
+	// 4) For each edge: compute Manhattan distance, decide.
+	abs := func(a int) int { if a < 0 { return -a }; return a }
+	for _, e := range edges {
+		stats.Scanned++
+		ps, sok := positionOf[e.Source]
+		pt, tok := positionOf[e.Target]
+		if !sok || !tok {
+			// Edge endpoints missing from layer — leave it alone.
+			stats.KeptShort++
+			continue
+		}
+		dist := abs(ps.X-pt.X) + abs(ps.Y-pt.Y)
+		if dist <= maxDist {
+			stats.KeptShort++
+			continue
+		}
+		if preserveParents && (isBucket(e.Source) || isBucket(e.Target)) {
+			stats.KeptParent++
+			continue
+		}
+		// Delete it.
+		if !dryRun {
+			u := fmt.Sprintf("%s/actors/link/%s", buildBaseURL(), e.ID)
+			if err := apiDelete(u); err != nil {
+				stats.Errors = append(stats.Errors,
+					fmt.Sprintf("%s→%s: %v", titleOf[e.Source], titleOf[e.Target], err))
+				continue
+			}
+		}
+		stats.Deleted++
+		if len(stats.Examples) < 10 {
+			stats.Examples = append(stats.Examples,
+				fmt.Sprintf("%s → %s (d=%d)",
+					titleOf[e.Source], titleOf[e.Target], dist))
+		}
+	}
+
+	out, _ := json.Marshal(stats)
+	return mcp.NewToolResultText(string(out)), nil
+}

--- a/plugins/simulator/mcp-server/app/mcp-server/server.go
+++ b/plugins/simulator/mcp-server/app/mcp-server/server.go
@@ -791,6 +791,18 @@ func LoadSwaggerServer(mcpServer *server.MCPServer, swaggerSpec models.SwaggerSp
 		handleUploadActorPicture,
 	)
 
+	mcpServer.AddTool(
+		mcp.NewTool("pruneLongEdges",
+			mcp.WithDescription("Delete edges whose Manhattan distance between endpoints exceeds `maxDistancePx` (default 600). By default `preserveParentEdges:true` keeps edges where either endpoint is a hierarchy bucket (>= bucketThreshold incoming edges, default 3) — those usually span the canvas legitimately. Use `dryRun:true` to preview without deleting. Returns scanned/deleted/kept_short/kept_parent counts plus up to 10 example deletions."),
+			mcp.WithString("layerId", mcp.Description("UUID of the layer."), mcp.Required()),
+			mcp.WithNumber("maxDistancePx", mcp.Description("Distance threshold in pixels (Manhattan). Edges above this are candidates for deletion. Default 600.")),
+			mcp.WithNumber("bucketThreshold", mcp.Description("Min incoming-edge count for an actor to count as a hierarchy bucket. Default 3.")),
+			mcp.WithBoolean("preserveParentEdges", mcp.Description("Keep long edges where either endpoint is a bucket. Default true.")),
+			mcp.WithBoolean("dryRun", mcp.Description("Don't delete; just count what would be deleted. Default false.")),
+		),
+		handlePruneLongEdges,
+	)
+
 	// Add MCP resources capability
 	initializeResources(mcpServer)
 


### PR DESCRIPTION
## Summary
- New `pruneLongEdges(layerId, maxDistancePx?, bucketThreshold?, preserveParentEdges?, dryRun?)` MCP tool.
- Walks every edge on the layer, computes Manhattan distance between endpoint positions, and deletes edges above `maxDistancePx` (default 600 px).
- `preserveParentEdges:true` (default) keeps edges where either endpoint is a hierarchy bucket (`>= bucketThreshold` incoming edges, default 3) — these usually span the canvas legitimately and shouldn't be pruned.
- `dryRun:true` previews without deleting.
- Returns `{scanned, deleted, kept_short, kept_parent, errors, deletedExamples}`.

## Why
After auto-layout (PR #6 `compactGraphLayout`) or any cluster repositioning, edges that used to be short can become long diagonals across the canvas that obscure the structure. Manually pruning them via `bulkDeleteLinks` requires harvesting positions and computing distances client-side; this tool does it in one MCP call with sensible defaults.

## Test plan
- [x] `go build ./...` clean.
- [ ] Reviewer to run with `dryRun:true` on a busy layer and confirm the report identifies long non-parent edges. Then re-run without `dryRun` and verify deletions.
- [ ] Confirm `preserveParentEdges:true` keeps long edges that touch hierarchy buckets.

## Composability
Designed to compose with PR #4 (position sync fix) and PR #6 (auto-layout): layout the canvas → prune leftover diagonals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)