### PR TITLE
feat(mcp-server): field selection (`filter`) on all read tools — token-saving

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "simulator",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "source": {
         "source": "local",
         "path": "./plugins/simulator"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "simulator",
       "source": "./plugins/simulator",
       "description": "Simulator.Company platform assistant. Exposes the Simulator REST API as an MCP server and provides skills for managing actors, forms, graph structures, and financial accounts.",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "author": {
         "name": "Simulator.Company",
         "url": "https://simulator.company"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Added
+- **Server-side field selection (`filter`) on every read tool — token-saving.** All read/lookup/list tools now expose an optional `filter` query parameter: a comma-separated allow-list of fields to return (e.g. `id,title,data.status`; dotted paths pick nested `data` fields). The backend prunes the response to just those fields via `filterActorData` / `filterData`, so a tool call can fetch only what it needs instead of the full entity. Centralised as `fieldFilterParam` in `internal/tools/op.go`.
+  - Tools whose backend already supported `filter`: added it to `getActor`, `getBalance`, `getTransactions`, `searchActors`, `searchLayerActors`, `filterActors`, and **fixed** the two pre-existing `filter` params on `getAccounts` and `getRelatedActors` whose descriptions wrongly called them data-filter expressions (the backend always treats `filter` as field selection).
+  - **Added `filter` support in pong-server** for the remaining read routes and wired the matching tools: `getActorByRef`, `getForm`, `getForms`, `searchForms`, `getCurrencies`, `getAccountNames`, `getTransfer`, `getEdgeTypes`, `getLayerActors`, `listSmartForms`, `searchAll`, `getWorkspaces`. Each backend route declares `filter` on its Fastify querystring schema and applies `filterActorData` (actor/node responses: `getActorByRef`, `getLayerActors` nodes, `searchAll` actor results — user results untouched, `objType` preserved) or `filterData` (everything else); `workspaces` clones session-held objects before projection.
+  - The drift gate (`(method, path, operationId)` only) still passes; refresh `testdata/papi-openapi.json` via pong-server's `yarn dump-openapi` once the backend changes deploy so the dumped spec carries the new params. Documented in README / `docs/ARCHITECTURE.md`.
+
 ### Removed
 - **`software-migration-onramp` skill.** Dropped the migration discovery facilitator skill (and its `prompts/` specs); the plugin now ships 6 skills. Removed its references from README / `docs/ARCHITECTURE.md` / AGENTS / the `simulator` skill and regenerated the discovery artifacts (`public/`).
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,16 @@ scenarios — forms, actors, accounts, transactions, graph building, application
 — rather than the entire REST surface. Each tool maps to a backend operation by its
 `operationId`; a drift gate keeps the set in sync with the live `/papi/1.0` contract.
 
+Read tools take an optional **`filter`** parameter — a comma-separated allow-list of fields
+to return (e.g. `id,title,data.status`; dotted paths pick nested `data` fields). The backend
+prunes the response to just those fields, so prefer it whenever only part of an entity is
+needed to keep responses (and token cost) small. Available on every read/lookup/list tool:
+`getActor`, `getActorByRef`, `searchActors`, `searchLayerActors`, `filterActors`, `getForm`,
+`getForms`, `searchForms`, `getAccounts`, `getBalance`, `getCurrencies`, `getAccountNames`,
+`getTransactions`, `getTransfer`, `getRelatedActors`, `getLayerActors`, `getEdgeTypes`,
+`listSmartForms`, `searchAll`, `getWorkspaces`. (For `getLayerActors`/`searchAll` it projects
+the actor/node items.)
+
 **Curated API operations** (one tool per backend operation):
 
 | Domain        | Tools                                                                                  |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -188,7 +188,16 @@ Conventions baked into the registry:
 
 - `accId` path/query params default to the active workspace when omitted;
 - a POST/PUT whose object-body fields are all omitted still sends `{}`;
-- required params missing → a clear error result (not a malformed request).
+- required params missing → a clear error result (not a malformed request);
+- every read operation exposes a `filter` field-selection param (`fieldFilterParam` in
+  `op.go`): a comma-separated allow-list of fields the backend prunes the response to
+  (`filterActorData` / `filterData` server-side), with dotted paths like `data.status`
+  for nested fields. It is optional and meant to be used actively to keep responses —
+  and token cost — small. On the single/lookup, list, and search tools across forms,
+  actors, accounts, transactions, graph, apps, search and workspaces (for `getLayerActors`
+  and `searchAll` it projects the actor/node items). The backend support for these routes
+  was added in pong-server alongside this change; refresh `testdata/papi-openapi.json`
+  (`yarn dump-openapi`) once that deploys so the dumped spec reflects the new params.
 
 ### 3.4 Workspace & auth context
 

--- a/plugins/simulator/.claude-plugin/plugin.json
+++ b/plugins/simulator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simulator",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Simulator.Company platform assistant. Exposes the Simulator REST API as an MCP server and provides skills for managing actors, forms, graph structures, and financial accounts.",
   "author": {
     "name": "Simulator.Company",

--- a/plugins/simulator/.codex-plugin/plugin.json
+++ b/plugins/simulator/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simulator",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Simulator.Company platform assistant. Exposes the Simulator REST API as an MCP server and provides skills for managing actors, forms, graph structures, and financial accounts.",
   "author": {
     "name": "Simulator.Company",

--- a/plugins/simulator/mcp-server/internal/tools/accounts.go
+++ b/plugins/simulator/mcp-server/internal/tools/accounts.go
@@ -37,7 +37,7 @@ var accountOps = []Operation{
 			{Name: "total", In: InQuery, Type: "boolean", Desc: "Return the total count instead of the list."},
 			{Name: "limit", In: InQuery, Type: "number", Desc: "Page size (max 100)."},
 			{Name: "offset", In: InQuery, Type: "number", Desc: "Page offset."},
-			{Name: "filter", In: InQuery, Type: "string", Desc: "Filter expression on accounts."},
+			fieldFilterParam("id,amount,currencyId,nameId"),
 			{Name: "highPrecision", In: InQuery, Type: "boolean", Desc: "Return transaction sums with high precision."},
 		},
 	},
@@ -48,6 +48,7 @@ var accountOps = []Operation{
 			{Name: "actorId", In: InPath, Type: "string", Required: true, Desc: "Actor UUID."},
 			{Name: "currencyId", In: InPath, Type: "number", Required: true, Desc: "Currency id."},
 			{Name: "nameId", In: InPath, Type: "string", Required: true, Desc: "Account name id."},
+			fieldFilterParam("id,amount,currencyId,nameId"),
 		},
 	},
 	{
@@ -92,6 +93,7 @@ var accountOps = []Operation{
 			{Name: "accId", In: InPath, Type: "string", Required: true, Desc: "Workspace id. Defaults to the configured workspace if omitted."},
 			{Name: "limit", In: InQuery, Type: "number", Desc: "Page size."},
 			{Name: "offset", In: InQuery, Type: "number", Desc: "Page offset."},
+			fieldFilterParam("id,name,symbol"),
 		},
 	},
 	{
@@ -110,6 +112,7 @@ var accountOps = []Operation{
 			{Name: "accId", In: InPath, Type: "string", Required: true, Desc: "Workspace id. Defaults to the configured workspace if omitted."},
 			{Name: "limit", In: InQuery, Type: "number", Desc: "Page size."},
 			{Name: "offset", In: InQuery, Type: "number", Desc: "Page offset."},
+			fieldFilterParam("id,name,abbreviation"),
 		},
 	},
 }

--- a/plugins/simulator/mcp-server/internal/tools/actors.go
+++ b/plugins/simulator/mcp-server/internal/tools/actors.go
@@ -66,17 +66,19 @@ var actorOps = []Operation{
 	},
 	{
 		Name: "getActor", Method: "GET", Path: "/actors/{actorId}",
-		Summary: "Get an actor by its UUID.",
+		Summary: "Get an actor by its UUID. Pass `filter` to fetch only the fields you need and keep the response small.",
 		Params: []Param{
 			{Name: "actorId", In: InPath, Type: "string", Required: true, Desc: "Actor UUID."},
+			fieldFilterParam("id,title,data.status"),
 		},
 	},
 	{
 		Name: "getActorByRef", Method: "GET", Path: "/actors/ref/{formId}/{ref}",
-		Summary: "Look up an actor by its (formId, ref) external reference.",
+		Summary: "Look up an actor by its (formId, ref) external reference. Pass `filter` to fetch only the fields you need.",
 		Params: []Param{
 			{Name: "formId", In: InPath, Type: "number", Required: true, Desc: "Form id."},
 			{Name: "ref", In: InPath, Type: "string", Required: true, Desc: "External reference."},
+			fieldFilterParam("id,title,data.status"),
 		},
 	},
 	{
@@ -115,6 +117,7 @@ var actorOps = []Operation{
 			{Name: "query", In: InPath, Type: "string", Required: true, Desc: "Search query (title or fragment)."},
 			{Name: "limit", In: InQuery, Type: "number", Desc: "Page size (max 200)."},
 			{Name: "offset", In: InQuery, Type: "number", Desc: "Page offset."},
+			fieldFilterParam("id,title,formId"),
 		},
 	},
 	{
@@ -125,6 +128,7 @@ var actorOps = []Operation{
 			{Name: "query", In: InPath, Type: "string", Required: true, Desc: "Search query (title or fragment)."},
 			{Name: "limit", In: InQuery, Type: "number", Desc: "Page size (max 200)."},
 			{Name: "offset", In: InQuery, Type: "number", Desc: "Page offset."},
+			fieldFilterParam("id,title,formId"),
 		},
 	},
 	{
@@ -157,6 +161,7 @@ var actorOps = []Operation{
 			{Name: "withForm", In: InQuery, Type: "boolean", Desc: "Include each actor's form template in the response."},
 			{Name: "limit", In: InQuery, Type: "number", Desc: "Page size (0-200, default 20)."},
 			{Name: "offset", In: InQuery, Type: "number", Desc: "Page offset."},
+			fieldFilterParam("id,title,data.status"),
 		},
 	},
 }

--- a/plugins/simulator/mcp-server/internal/tools/apps.go
+++ b/plugins/simulator/mcp-server/internal/tools/apps.go
@@ -33,6 +33,7 @@ var appOps = []Operation{
 		Summary: "List smart forms installed in the workspace.",
 		Params: []Param{
 			{Name: "accId", In: InPath, Type: "string", Required: true, Desc: "Workspace id. Defaults to the configured workspace if omitted."},
+			fieldFilterParam("id,title,ref"),
 		},
 	},
 	{

--- a/plugins/simulator/mcp-server/internal/tools/forms.go
+++ b/plugins/simulator/mcp-server/internal/tools/forms.go
@@ -23,10 +23,11 @@ var formOps = []Operation{
 	},
 	{
 		Name: "getForm", Method: "GET", Path: "/forms/{formId}",
-		Summary: "Get a form template by its integer id.",
+		Summary: "Get a form template by its integer id. Pass `filter` to fetch only the fields you need (form templates can be large).",
 		Params: []Param{
 			{Name: "formId", In: InPath, Type: "number", Required: true, Desc: "Form id."},
 			{Name: "withRelations", In: InQuery, Type: "boolean", Desc: "Include related entities."},
+			fieldFilterParam("id,title,sections"),
 		},
 	},
 	{
@@ -39,6 +40,7 @@ var formOps = []Operation{
 			{Name: "status", In: InQuery, Type: "string", Desc: "Filter by form status."},
 			{Name: "formTypes", In: InQuery, Type: "string", Desc: "Filter by form types."},
 			{Name: "withRelations", In: InQuery, Type: "boolean", Desc: "Include related entities."},
+			fieldFilterParam("id,title,status"),
 		},
 	},
 	{
@@ -73,6 +75,7 @@ var formOps = []Operation{
 		Params: []Param{
 			{Name: "accId", In: InPath, Type: "string", Required: true, Desc: "Workspace id. Defaults to the configured workspace if omitted."},
 			{Name: "q", In: InPath, Type: "string", Required: true, Desc: "Search query (form name or fragment)."},
+			fieldFilterParam("id,title,status"),
 		},
 	},
 }

--- a/plugins/simulator/mcp-server/internal/tools/graph.go
+++ b/plugins/simulator/mcp-server/internal/tools/graph.go
@@ -75,14 +75,16 @@ var graphOps = []Operation{
 		Params: []Param{
 			{Name: "accId", In: InPath, Type: "string", Required: true, Desc: "Workspace id. Defaults to the configured workspace if omitted."},
 			{Name: "isSystem", In: InQuery, Type: "boolean", Desc: "Only system edge types."},
+			fieldFilterParam("id,name"),
 		},
 	},
 	{
 		Name: "getLayerActors", Method: "GET", Path: "/graph_layers/{actorId}",
-		Summary: "List the actors placed on a layer (the layer is itself an actor).",
+		Summary: "List the actors placed on a layer (the layer is itself an actor). `filter` projects the fields of each placed actor (node), keeping the response small.",
 		Params: []Param{
 			{Name: "actorId", In: InPath, Type: "string", Required: true, Desc: "Layer actor UUID."},
 			{Name: "noDuplicate", In: InQuery, Type: "boolean", Desc: "Deduplicate placements."},
+			fieldFilterParam("id,title,formId"),
 		},
 	},
 	{
@@ -112,7 +114,7 @@ var graphOps = []Operation{
 			{Name: "limit", In: InQuery, Type: "number", Desc: "Page size (max 200)."},
 			{Name: "offset", In: InQuery, Type: "number", Desc: "Page offset."},
 			{Name: "pinned", In: InQuery, Type: "boolean", Desc: "Only pinned edges."},
-			{Name: "filter", In: InQuery, Type: "string", Desc: "Data filter expression on actor fields."},
+			fieldFilterParam("id,title,formId,data.status"),
 		},
 	},
 }

--- a/plugins/simulator/mcp-server/internal/tools/op.go
+++ b/plugins/simulator/mcp-server/internal/tools/op.go
@@ -53,6 +53,25 @@ type Operation struct {
 	Resolve func(ctx context.Context, args map[string]any, c *apiclient.Client) error
 }
 
+// fieldFilterParam returns the standard `filter` query parameter for read
+// operations whose backend supports server-side field selection (projection).
+//
+// The pong-server API applies `filter` via filterActorData / filterData: it is a
+// comma-separated allow-list of top-level fields to keep in the response. Dotted
+// paths like `data.status` select nested fields inside the free-form `data`
+// object (its parent `data` is preserved, pruned to the listed sub-fields).
+// Using it keeps responses — and token cost — small, so prefer it whenever only
+// part of the entity is needed. `example` shows entity-appropriate field names.
+func fieldFilterParam(example string) Param {
+	return Param{
+		Name: "filter", In: InQuery, Type: "string",
+		Desc: "Comma-separated allow-list of fields to return (server-side projection). " +
+			"Only the listed fields are kept; use dotted paths like `data.status` for nested data fields. " +
+			"Prefer setting this to just the fields you need — it sharply reduces response size and token cost. " +
+			"Omit to return the full object. Example: \"" + example + "\".",
+	}
+}
+
 // register builds the MCP tool for op and wires its handler to the client.
 func register(s *server.MCPServer, c *apiclient.Client, op Operation) {
 	opts := []mcp.ToolOption{mcp.WithDescription(op.Summary)}

--- a/plugins/simulator/mcp-server/internal/tools/search.go
+++ b/plugins/simulator/mcp-server/internal/tools/search.go
@@ -6,7 +6,7 @@ package tools
 var searchOps = []Operation{
 	{
 		Name: "searchAll", Method: "GET", Path: "/search/{accId}/{query}",
-		Summary: "Global workspace search across actors (and users) — text or semantic. Use to find existing entities before creating. `filters` selects what to search.",
+		Summary: "Global workspace search across actors (and users) — text or semantic. Use to find existing entities before creating. `filters` selects what to search; `filter` projects the fields of the actor results (user results are unaffected) to keep the response small.",
 		Params: []Param{
 			{Name: "accId", In: InPath, Type: "string", Required: true, Desc: "Workspace id. Defaults to the configured workspace if omitted."},
 			{Name: "query", In: InPath, Type: "string", Required: true, Desc: "Search text (min 2 chars)."},
@@ -15,6 +15,7 @@ var searchOps = []Operation{
 			{Name: "formId", In: InQuery, Type: "string", Desc: "Restrict the search to actors of this form."},
 			{Name: "limit", In: InQuery, Type: "number", Desc: "Page size (1-100)."},
 			{Name: "offset", In: InQuery, Type: "number", Desc: "Page offset."},
+			fieldFilterParam("id,title,formId"),
 		},
 	},
 }

--- a/plugins/simulator/mcp-server/internal/tools/testdata/papi-openapi.json
+++ b/plugins/simulator/mcp-server/internal/tools/testdata/papi-openapi.json
@@ -17,6 +17,15 @@
     "schemas": {}
   },
   "paths": {
+    "/papi/1.0/config": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      }
+    },
     "/papi/1.0/config/system": {
       "post": {
         "requestBody": {
@@ -95,6 +104,14 @@
             },
             "in": "query",
             "name": "withStats",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "filter",
             "required": false
           }
         ],
@@ -2297,6 +2314,14 @@
           },
           {
             "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "filter",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "integer"
             },
             "in": "path",
@@ -2329,6 +2354,14 @@
             },
             "in": "query",
             "name": "edgeTypes",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "filter",
             "required": false
           },
           {
@@ -7403,6 +7436,14 @@
             "schema": {
               "type": "string"
             },
+            "in": "query",
+            "name": "filter",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
             "in": "path",
             "name": "accId",
             "required": true
@@ -7522,6 +7563,14 @@
             },
             "in": "query",
             "name": "isSystem",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "filter",
             "required": false
           },
           {
@@ -9443,6 +9492,14 @@
         "parameters": [
           {
             "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "filter",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string",
               "format": "uuid"
             },
@@ -9611,6 +9668,14 @@
             "schema": {
               "type": "string"
             },
+            "in": "query",
+            "name": "filter",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
             "in": "path",
             "name": "accId",
             "required": true
@@ -9669,6 +9734,14 @@
             },
             "in": "query",
             "name": "withRelations",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "filter",
             "required": false
           },
           {
@@ -10210,6 +10283,14 @@
             },
             "in": "query",
             "name": "withRelations",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "filter",
             "required": false
           },
           {
@@ -10947,6 +11028,14 @@
             },
             "in": "query",
             "name": "status",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "filter",
             "required": false
           },
           {
@@ -12316,6 +12405,14 @@
             "schema": {
               "type": "string"
             },
+            "in": "query",
+            "name": "filter",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
             "in": "path",
             "name": "accId",
             "required": true
@@ -12656,6 +12753,14 @@
             },
             "in": "query",
             "name": "graphFolderId",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "filter",
             "required": false
           },
           {
@@ -13706,6 +13811,14 @@
             "schema": {
               "type": "string"
             },
+            "in": "query",
+            "name": "filter",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
             "in": "path",
             "name": "accId",
             "required": true
@@ -14511,6 +14624,14 @@
       "get": {
         "operationId": "listSmartForms",
         "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "filter",
+            "required": false
+          },
           {
             "schema": {
               "type": "string"

--- a/plugins/simulator/mcp-server/internal/tools/transactions.go
+++ b/plugins/simulator/mcp-server/internal/tools/transactions.go
@@ -41,6 +41,7 @@ var transactionOps = []Operation{
 			{Name: "incomeType", In: InQuery, Type: "string", Enum: []string{"debit", "credit"}, Desc: "Filter by direction."},
 			{Name: "limit", In: InQuery, Type: "number", Desc: "Page size."},
 			{Name: "offset", In: InQuery, Type: "number", Desc: "Page offset."},
+			fieldFilterParam("id,amount,createdAt,comment"),
 		},
 	},
 	{
@@ -58,9 +59,10 @@ var transactionOps = []Operation{
 	},
 	{
 		Name: "getTransfer", Method: "GET", Path: "/transfers/{transferId}",
-		Summary: "Get a transfer by id.",
+		Summary: "Get a transfer by id. Pass `filter` to fetch only the fields you need.",
 		Params: []Param{
 			{Name: "transferId", In: InPath, Type: "string", Required: true, Desc: "Transfer id."},
+			fieldFilterParam("id,amount,createdAt,comment"),
 		},
 	},
 }

--- a/plugins/simulator/mcp-server/internal/tools/workspaces.go
+++ b/plugins/simulator/mcp-server/internal/tools/workspaces.go
@@ -20,6 +20,7 @@ var workspaceOps = []Operation{
 			{Name: "limit", In: InQuery, Type: "number", Desc: "Page size."},
 			{Name: "offset", In: InQuery, Type: "number", Desc: "Page offset."},
 			{Name: "withStats", In: InQuery, Type: "boolean", Desc: "Include totals."},
+			fieldFilterParam("id,name"),
 		},
 	},
 }

--- a/plugins/simulator/skills/simulator-finance/SKILL.md
+++ b/plugins/simulator/skills/simulator-finance/SKILL.md
@@ -435,3 +435,4 @@ Use the `Read` tool to load these files when you need more detail:
 - Use `post-transactions-atom-accId` for accounting entries that must be balanced (double-entry bookkeeping)
 - 2-step transactions are reversible — prefer them for pending/draft operations
 - `get-accounts-children-actorId` aggregates accounts up the actor hierarchy (if `treeCalculation: true`)
+- **Save tokens with `filter`** — read tools (`getAccounts`, `getBalance`, `getTransactions`, `getTransfer`, `getCurrencies`, `getAccountNames`, `filterActors`) accept an optional `filter` field-selection arg (comma-separated fields, e.g. `filter="id,amount,currencyId"`); the server returns only those fields. It is NOT a row filter — that's `q`/`query` or the `POST .../filter` endpoints

--- a/plugins/simulator/skills/simulator-forms/SKILL.md
+++ b/plugins/simulator/skills/simulator-forms/SKILL.md
@@ -482,3 +482,4 @@ Use the `Read` tool to load these files when you need more detail:
 - When a form has `accounts` defined, actors created from it get those accounts automatically
 - Updating a form does NOT retroactively update actors already created from it
 - Use `delete-forms-item_cache-formId-itemId` to refresh `select` field options after updating
+- **Save tokens with `filter`** — `getForm`, `getForms`, `searchForms` accept an optional `filter` field-selection arg (comma-separated fields, e.g. `filter="id,title,sections"`); the server returns only those fields. Form templates can be large, so prefer requesting just what you need

--- a/plugins/simulator/skills/simulator-graph/SKILL.md
+++ b/plugins/simulator/skills/simulator-graph/SKILL.md
@@ -563,6 +563,13 @@ filterActors(formId=<formId>, linkedToActorId="<anchorActorId>",
              accountNameId="<nameId>", currencyId=<id>,
              amountFrom=<min>, amountTo=<max>,        // amountFrom = balance >=, amountTo = balance <=
              orderBy="balance", orderValue="DESC")    // omit linkedToActorId for a form-wide ranking
+
+// Save tokens: every read/traversal tool above (getRelatedActors, getActor,
+// getLayerActors, searchLayerActors, searchActors, filterActors, ...) accepts an
+// optional `filter` field-selection arg — comma-separated fields to return, e.g.
+// filter="id,title,formId" (dotted paths like data.status pick nested data fields).
+// The server returns only those fields. NOT a row filter (that's search / q).
+getRelatedActors(type="children", actorId="<actorId>", filter="id,title,formId")
 ```
 
 ---

--- a/plugins/simulator/skills/simulator/SKILL.md
+++ b/plugins/simulator/skills/simulator/SKILL.md
@@ -59,6 +59,12 @@ server substitutes them into the URL path automatically.
 **Parameter rules:**
 - Path and query parameters → individual named string arguments
 - Request body → `body` argument as a JSON string
+- **`filter` (field selection)** — every read/lookup/list/search tool accepts an
+  optional `filter`: a comma-separated allow-list of fields to return
+  (e.g. `filter="id,title,data.status"`; dotted paths pick nested `data` fields).
+  The server prunes the response to just those fields. Use it actively to save
+  tokens — request only the fields you actually need instead of the whole entity.
+  Don't confuse it with the row filters `q` / `query` (text/data search).
 
 ## Platform Architecture
 
@@ -257,3 +263,4 @@ Use the `Read` tool to load these files when you need deeper detail:
 - When creating accounts, you need both a `currencyId` AND a `nameId` — create them if they don't exist
 - Use `post-actors-mass_links-accId` for creating multiple links at once (much more efficient)
 - Transactions are permanent — use 2-step (authorize → complete/cancel) for reversible operations
+- **Save tokens with `filter`** — on any read/list/search tool, pass `filter` with only the fields you need (e.g. `filter="id,title"`) so the server trims the response instead of returning the full model


### PR DESCRIPTION
## What

Adds an optional **`filter`** query parameter (comma-separated field allow-list) to **every read/lookup/list/search MCP tool**, so a tool call can fetch only the fields it needs instead of the full entity — keeping responses, and token cost, small.

The backend prunes the response to just those fields via `filterActorData` / `filterData`; dotted paths like `data.status` select nested fields inside the free-form `data` object.

```
getActor(actorId="…", filter="id,title,data.status")
getAccounts(actorId="…", filter="id,amount,currencyId,nameId")
searchActors(accId="…", query="…", filter="id,title,formId")
```

## Changes

- **`fieldFilterParam` helper** (`internal/tools/op.go`) — single source of truth for the param (type, description, entity-appropriate example).
- **Wired into all 20 read tools** across forms, actors, accounts, transactions, graph, apps, search, workspaces.
- **Fixed two mislabeled params:** `getAccounts` and `getRelatedActors` previously described `filter` as a *data-filter expression*; the backend has always treated `filter` as field selection (confirmed in `graph.js` / `accountsCRUD.js`). Descriptions corrected — no behavioural change.
- **Refreshed the drift spec** `testdata/papi-openapi.json` via pong-server's `yarn dump-openapi` so it carries the new `filter` params. Drift gate passes.
- **Docs & skills:** README, `docs/ARCHITECTURE.md`, and the `simulator` / `simulator-finance` / `simulator-forms` / `simulator-graph` skills now tell the model to use `filter` actively to save tokens (and not to confuse it with the row filters `q` / `query`).
- **Version:** 1.7.0 → 1.8.0 across all manifests + CHANGELOG.

## Backend dependency

For the 12 routes that didn't already support it, this relies on a **matching pong-server change** that declares `filter` on the route schema and applies `filterActorData` / `filterData` (forms, currencies, account_names, transfers, edge_types, graph_layers nodes, smart_forms, search actor-results, workspaces, actors-by-ref). The refreshed drift spec in this PR was dumped from a pong-server build that includes it. The 8 tools whose backend already supported `filter` work against current `develop`.

## Verification

- `make build`, `make vet`, `go test ./...` — all green (incl. the drift gate: `(method, path, operationId)`).
- `gofmt` clean on changed files; `make discovery` produced no `public/` changes.

## Notes / follow-ups

- The drift gate validates path/method/operationId, **not params** — consider a small `scenario_test.go` case asserting `filter` reaches the query string (happy to add).
- Field selection trims **payload/tokens, not DB cost** (rows are fully fetched, then pruned in memory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)