### PR TITLE
docs(repo): add LICENSE + community health files, bump to 1.7.1

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "simulator",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "source": {
         "source": "local",
         "path": "./plugins/simulator"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "simulator",
       "source": "./plugins/simulator",
       "description": "Simulator.Company platform assistant. Exposes the Simulator REST API as an MCP server and provides skills for managing actors, forms, graph structures, and financial accounts.",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "author": {
         "name": "Simulator.Company",
         "url": "https://simulator.company"

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,62 @@
+name: Bug report
+description: Report a problem with the MCP server, a tool, or a skill
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report. For security-sensitive issues, do **not** file here —
+        follow [SECURITY.md](../blob/main/SECURITY.md) instead.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug and what you expected instead.
+      placeholder: When I call `pullGraphFile` with …, the server returns … but I expected …
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: The MCP call sequence, prompt, or graph file that triggers it.
+      placeholder: |
+        1. /simulator-init and log in to mw.simulator.company
+        2. Ask Claude to "…"
+        3. See error
+    validations:
+      required: true
+  - type: input
+    id: plugin-version
+    attributes:
+      label: Plugin version
+      placeholder: "1.7.0"
+    validations:
+      required: true
+  - type: dropdown
+    id: client
+    attributes:
+      label: Client
+      options:
+        - Claude Code
+        - Codex
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS + version, `go version`, and the gateway URL (cloud preset / custom / local).
+      placeholder: |
+        macOS 14.4 arm64
+        go version go1.25.5 darwin/arm64
+        gateway: mw.simulator.company
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Paste any error output. **Redact tokens and `.env` contents.**
+      render: text

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Simulator.Company documentation
+    url: https://doc.simulator.company
+    about: Platform and API documentation.
+  - name: Security vulnerability
+    url: https://github.com/corezoid/simulator-ai-plugin/security/advisories/new
+    about: Report security issues privately — do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature request
+description: Suggest a new tool, skill, or capability
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: The workflow or scenario that the plugin doesn't support today.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: New MCP tool, skill behaviour, or doc. If it maps to a backend operation, name the operationId / route.
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - MCP server / tools
+        - Skill behaviour
+        - Graph / layers
+        - Forms
+        - Finance (accounts / transactions)
+        - Docs
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!-- See CONTRIBUTING.md before opening a PR. -->
+
+## What & why
+
+<!-- What does this change do, and what problem does it solve? -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New MCP tool / capability
+- [ ] Skill behaviour
+- [ ] Docs
+- [ ] Chore / refactor
+
+## Checklist
+
+- [ ] `make build && make vet && make test` pass locally
+- [ ] If I added/renamed a tool: updated the MCP-tools table in `README.md` and §4 of `docs/ARCHITECTURE.md`, and it validates against the drift gate
+- [ ] If I changed skill frontmatter: regenerated `public/` with `make discovery` (no hand-edits)
+- [ ] Reference docs that skills load at runtime stay under `plugins/simulator/docs/`
+- [ ] No tokens or `.env` committed; TLS verification left on by default
+- [ ] Version bumped in all manifests + `CHANGELOG.md` entry added (if this is a release-worthy change)
+
+## Notes for reviewers
+
+<!-- Anything that needs extra attention — e.g. graph-sync logic, which has no unit tests yet. -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /plugins/simulator/mcp-server
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - dependencies
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore(ci)"
+    labels:
+      - dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.7.1]
+
+### Added
+- **Open-source community files.** Added a top-level `LICENSE` (MIT — previously only declared in the plugin manifest), `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, and a `.github/` directory with issue templates (bug / feature + config), a pull-request template, and a `dependabot.yml` (gomod + github-actions, weekly). Added status badges and a "Contributing & support" section to the README. Bumped all manifests to 1.7.1.
+
 ## [Unreleased]
 
 ### Removed

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,54 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a
+harassment-free experience for everyone, regardless of age, body size, visible or invisible
+disability, ethnicity, sex characteristics, gender identity and expression, level of
+experience, education, socio-economic status, nationality, personal appearance, race, religion,
+or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse,
+inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes
+- Focusing on what is best for the overall community
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards and will take
+appropriate and fair corrective action in response to any behavior they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual
+is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the
+community leaders responsible for enforcement at **conduct@corezoid.com**. All complaints will
+be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1,
+available at <https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,80 @@
+# Contributing to the Simulator.Company Plugin
+
+Thanks for your interest in improving the plugin. This document covers how the repo is laid
+out, how to build and verify changes, and the conventions we expect in a pull request.
+
+## Repository layout
+
+| Path                                  | What lives there                                                  |
+|---------------------------------------|-------------------------------------------------------------------|
+| `plugins/simulator/mcp-server/`       | Go MCP server (`cmd/server` + `internal/{config,apiclient,tools,engines}`) |
+| `plugins/simulator/skills/`           | The shipped skills (`simulator`, `simulator-graph`, …)            |
+| `plugins/simulator/docs/`             | Reference docs loaded by skills at runtime (`$CLAUDE_PLUGIN_ROOT/docs/…`) |
+| `docs/`                               | Contributor docs (`ARCHITECTURE.md`, `INTEGRATION.md`)            |
+| `public/`                             | **Generated** discovery artifacts — do not hand-edit              |
+| `.claude-plugin/`, `.agents/`         | Plugin + marketplace manifests                                    |
+
+The canonical, tool-agnostic guide is [`AGENTS.md`](AGENTS.md) — read it first. Architecture
+is in [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
+
+## Prerequisites
+
+- [Go 1.25+](https://go.dev/dl/) in `PATH` (the module declares `go 1.25`; the MCP server runs via `go run`)
+- `make`
+- Optionally [`golangci-lint`](https://golangci-lint.run/) v2 for `make lint`
+
+## Build & verify
+
+All commands run from the repo root.
+
+```bash
+make build    # compile the MCP server
+make vet      # go vet
+make test     # unit tests (config, apiclient, tools, drift gate, eval)
+make lint     # golangci-lint v2 (advisory; gosec must stay clean)
+```
+
+Before opening a PR, run at minimum:
+
+```bash
+make build && make vet && make test
+```
+
+## Conventions
+
+- **Curated tools live in Go**, declared as typed `Operation`s under
+  `internal/tools/<domain>.go` — they are *not* generated from a spec. New or renamed tools
+  must validate against the drift gate (`internal/tools/testdata/papi-openapi.json`). Refresh
+  that spec from pong-server with `yarn dump-openapi`; never write it by hand.
+- **Generated files** (`public/*`) are produced by `make discovery`. If you change a skill's
+  frontmatter, regenerate them — don't hand-edit.
+- **Skills.** Edit the skill's `SKILL.md` to change behaviour. Reference docs that skills load
+  at runtime must stay under `plugins/simulator/docs/` (only the plugin dir ships on install).
+- **When you add or rename a tool**, update the MCP-tools table in [`README.md`](README.md) and
+  §4 of [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
+- **Security.** Keep TLS verification on by default. Never log or commit tokens or `.env`.
+- **Versioning.** Bump the plugin version in *all* manifests (`.claude-plugin/`, `.agents/`)
+  and add a `CHANGELOG.md` entry together, in the same change.
+
+## Commit messages
+
+Follow the existing conventional-commit style used in the history, e.g.:
+
+```
+feat(mcp-server): add filterActors tool
+fix(engines): reject non-UUID layerId before filesystem access
+docs: document set-environment in README
+chore(skills): regenerate discovery artifacts
+```
+
+## Pull requests
+
+1. Branch off `main`.
+2. Keep the change focused; update docs and the changelog alongside code.
+3. Ensure `make build && make vet && make test` pass.
+4. Fill in the PR template.
+
+## Reporting issues
+
+Use the issue templates. For anything security-sensitive, follow
+[`SECURITY.md`](SECURITY.md) instead of opening a public issue.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Simulator.Company (Corezoid)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Simulator.Company — Claude Code & Codex Plugin
 
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Go 1.25+](https://img.shields.io/badge/Go-1.25%2B-00ADD8?logo=go&logoColor=white)](https://go.dev/dl/)
+[![MCP](https://img.shields.io/badge/MCP-2025--03--26-555)](https://modelcontextprotocol.io)
+[![Release](https://img.shields.io/github/v/release/corezoid/simulator-ai-plugin?sort=semver)](https://github.com/corezoid/simulator-ai-plugin/releases)
+[![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-D97757)](https://claude.ai/code)
+
 > **Status:** stable — released, actively maintained. Supported clients: Claude Code ≥ 1.x, Codex. Go 1.24+ required. macOS and Linux tested.
 
 A plugin for [Claude Code](https://claude.ai/code) and [Codex](https://codex.openai.com) that connects the [Simulator.Company](https://simulator.company) platform to Claude via MCP (Model Context Protocol). Claude gets direct access to the Simulator REST API and domain knowledge to manage actors, graphs, forms, and financial accounts through natural conversation.
@@ -445,6 +451,13 @@ go test ./...
 - [Claude Code](https://claude.ai/code)
 - [MCP Protocol](https://modelcontextprotocol.io)
 
+## Contributing & support
+
+- [Contributing guide](CONTRIBUTING.md) — layout, build/verify, conventions
+- [Code of Conduct](CODE_OF_CONDUCT.md)
+- [Security policy](SECURITY.md) — report vulnerabilities privately
+- [Open an issue](https://github.com/corezoid/simulator-ai-plugin/issues)
+
 ## License
 
-MIT
+[MIT](LICENSE) © Simulator.Company (Corezoid)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+## Supported versions
+
+The plugin is released as a single line; the latest published version on the marketplace
+receives security fixes. Please reproduce any issue against the current `main` before reporting.
+
+## Reporting a vulnerability
+
+**Do not open a public GitHub issue for security problems.**
+
+Report privately using GitHub's
+[private vulnerability reporting](https://github.com/corezoid/simulator-ai-plugin/security/advisories/new),
+or email **security@corezoid.com** with:
+
+- a description of the issue and its impact,
+- steps to reproduce (a minimal MCP call sequence or graph file is ideal),
+- the plugin version and your environment (OS, Go version, gateway URL).
+
+We aim to acknowledge reports within 3 business days and to provide a remediation timeline
+after triage. Please give us a reasonable window to release a fix before any public disclosure.
+
+## Scope
+
+In scope:
+
+- the Go MCP server (`plugins/simulator/mcp-server/`) — auth handling, the API client, and the
+  engine tools that touch the filesystem (`pullGraphFile`/`pushGraphFile`,
+  `uploadActorPicture(Bulk)`),
+- handling of credentials, tokens, and `.env` material.
+
+Out of scope:
+
+- vulnerabilities in the upstream Simulator.Company backend / `pong-server` (report to the
+  platform team),
+- issues that require a malicious local `.env` the user wrote themselves.
+
+## Handling of secrets
+
+- TLS verification is on by default; the server warns when it would send a token over plaintext
+  HTTP to a non-local host.
+- Tokens and `.env` are never logged or committed. If you find a path where they leak, that is
+  in scope — please report it.

--- a/plugins/simulator/.claude-plugin/plugin.json
+++ b/plugins/simulator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simulator",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Simulator.Company platform assistant. Exposes the Simulator REST API as an MCP server and provides skills for managing actors, forms, graph structures, and financial accounts.",
   "author": {
     "name": "Simulator.Company",


### PR DESCRIPTION
## What & why

Fills the standard open-source "shell" the repo was missing. The plugin manifest already declared MIT and the README/internal docs were strong, but the repo had no `LICENSE` file (GitHub showed no license), no `.github/`, and an empty About box.

## Changes

- **`LICENSE`** — MIT (was only declared in the plugin manifest; now backed by a file so GitHub detects it).
- **`CONTRIBUTING.md`** — layout, build/verify (`make build && make vet && make test`), and the repo's real conventions (curated tools in Go, drift gate, `make discovery`, version-bump-all-manifests rule).
- **`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1.
- **`SECURITY.md`** — private reporting via GitHub advisories, scope, secret-handling notes.
- **`.github/`** — issue templates (bug / feature + `config.yml` routing security to advisories), PR template (mirrors the contributing checklist), and `dependabot.yml` (gomod + github-actions, weekly).
- **README** — status badges + a "Contributing & support" section; License line now links to `LICENSE`.
- **Manifests** — bumped to **1.7.1** (`.claude-plugin/marketplace.json`, `.agents/plugins/marketplace.json`, `plugins/simulator/.claude-plugin/plugin.json`) + `CHANGELOG.md` entry.

Applied separately on the GitHub repo (outside this diff): About **description**, **homepage** (https://simulator.company), and **topics**.

## Not included

CI workflow (`.github/workflows/ci.yml`) was intentionally left out per scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)