### PR TITLE
build(mcp): add `make inspect` target for the MCP Inspector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 MCP := plugins/simulator/mcp-server
 
-.PHONY: help discovery build vet lint test run-local run-prod eval eval-skills eval-live
+# Backend profile for `make inspect` (local | prod). Override on the command
+# line, e.g. `make inspect PROFILE=prod`.
+PROFILE ?= local
+
+.PHONY: help discovery build vet lint test run-local run-prod inspect eval eval-skills eval-live
 
 help:
 	@echo "Targets:"
@@ -9,6 +13,7 @@ help:
 	@echo "  discovery       Regenerate public/.well-known/skills/index.json and public/llms.txt."
 	@echo "  run-local       Run the MCP server against a local pong-server (:9000)."
 	@echo "  run-prod        Run the MCP server against the public gateway."
+	@echo "  inspect         Launch the MCP Inspector web UI wrapping the server (PROFILE=local|prod, default local)."
 	@echo "  eval            Behavioural eval, dry — canned fixtures, no backend (needs ANTHROPIC_API_KEY; skips otherwise)."
 	@echo "  eval-skills     Behavioural eval, dry, with the SKILL.md files injected as the system prompt."
 	@echo "  eval-live       Behavioural eval executing tools against the backend (throwaway workspace)."
@@ -36,6 +41,14 @@ run-local:
 
 run-prod:
 	cd $(MCP) && go run ./cmd/server --profile prod
+
+# Launch the MCP Inspector (https://github.com/modelcontextprotocol/inspector) — a
+# browser UI to list/call tools and read resources — wrapping the stdio server. Needs
+# Node.js (npx). The server reads .env from $(MCP)/. Pick the backend with PROFILE:
+#   make inspect              # local pong-server (:9000)
+#   make inspect PROFILE=prod # public gateway
+inspect:
+	cd $(MCP) && npx @modelcontextprotocol/inspector go run ./cmd/server --profile $(PROFILE)
 
 # Behavioural eval: drive a model through eval-scenarios.json and check it calls
 # the expected tools (and, via argChecks, with the expected argument shapes).

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ simulator-ai-plugin/
 ├── .agents/
 │   └── plugins/
 │       └── marketplace.json     # Codex marketplace listing (points to plugins/simulator)
-├── Makefile                     # build / vet / test / discovery / run-local / run-prod
+├── Makefile                     # build / vet / test / discovery / run-local / run-prod / inspect
 ├── CHANGELOG.md
 ├── CLAUDE.md                    # Repo guide for Claude Code (points to AGENTS.md)
 ├── AGENTS.md                    # Repo guide for coding agents (canonical)
@@ -458,11 +458,20 @@ and `.env`. Check `/mcp` again if a server shows as failed (see its **Errors** t
 ```bash
 make run-local      # go run ./cmd/server --profile local
 make run-prod       # against the public gateway
+make inspect        # MCP Inspector web UI wrapping the server (PROFILE=local|prod)
 make test           # unit + scenario + drift + eval tests
 make lint           # golangci-lint v2 (gosec clean; style backlog)
 make eval           # behavioural eval, dry (needs ANTHROPIC_API_KEY)
 make eval-live      # behavioural eval executing tools against the backend
 ```
+
+`make inspect` launches the [MCP Inspector](https://github.com/modelcontextprotocol/inspector)
+(needs Node.js / `npx`) — a browser UI to list and call the server's tools and read its
+resources by hand. It prints a `localhost:6274` URL with a session token; open it, hit
+**Connect**, then browse **Tools** / **Resources**. Authenticate first (the `login` tool or
+a valid `.env`) since calls hit the real backend. See the
+[MCP server README](plugins/simulator/mcp-server/README.md#inspecting--debugging-with-the-mcp-inspector)
+for the headless `--cli` mode.
 
 ## Debugging
 

--- a/plugins/simulator/mcp-server/README.md
+++ b/plugins/simulator/mcp-server/README.md
@@ -39,6 +39,34 @@ Profiles are overridable per-field via `SIMULATOR_API_BASE_URL`, `SIMULATOR_ACCO
 profile also makes the `set-environment` tool offer a `local` preset (`localhost:9000`);
 `prod` hides it.
 
+## Inspecting / debugging with the MCP Inspector
+
+The [MCP Inspector](https://github.com/modelcontextprotocol/inspector) is the official
+browser UI for poking at an MCP server by hand — list and call tools, inspect their JSON
+schemas, and read resources (e.g. `simulator://actor/{id}`) — without wiring the server
+into Claude. Requires Node.js (`npx`); no global install needed.
+
+From the **repository root**:
+
+```bash
+make inspect              # wrap the server on the local profile (pong-server :9000)
+make inspect PROFILE=prod # wrap the server on the public gateway
+```
+
+This runs `npx @modelcontextprotocol/inspector go run ./cmd/server --profile $(PROFILE)`
+in this module dir, so the server picks up `.env` from here exactly as the `run-*` targets
+do. The command prints a `http://localhost:6274` URL with a session token — open it, then
+**Connect** → **Tools** / **Resources**. Tool calls hit the real backend, so authenticate
+first (run the `login` tool, or have a valid `ACCESS_TOKEN`/`WORKSPACE_ID` in `.env`).
+
+For scripted/CI use, the Inspector also has a headless CLI mode — handy for diffing the
+tool surface without the UI:
+
+```bash
+cd plugins/simulator/mcp-server
+npx @modelcontextprotocol/inspector --cli go run ./cmd/server --profile local --method tools/list
+```
+
 ## Layout
 
 ```
@@ -67,6 +95,7 @@ make test          # go test ./...   — config, apiclient, tools (scenarios, -r
 make discovery     # regenerate public/llms.txt + public/.well-known/skills/index.json
 make run-local     # go run ./cmd/server --profile local
 make run-prod      # go run ./cmd/server --profile prod
+make inspect       # launch the MCP Inspector web UI wrapping the server (PROFILE=local|prod)
 make eval          # behavioural eval, dry — stubbed tool results (needs ANTHROPIC_API_KEY)
 make eval-live     # behavioural eval executing tools against the backend (throwaway workspace)
 ```


### PR DESCRIPTION
## What

Adds a `make inspect` target that launches the [MCP Inspector](https://github.com/modelcontextprotocol/inspector) — the official browser UI for listing/calling an MCP server's tools and reading its resources by hand — wrapping the stdio server.

```bash
make inspect              # local profile (pong-server :9000)
make inspect PROFILE=prod # public gateway
```

It runs `npx @modelcontextprotocol/inspector go run ./cmd/server --profile $(PROFILE)` in the `mcp-server/` dir, so it picks up `.env` exactly as the `run-*` targets do — auth/workspace carry over. Needs Node.js (`npx`); no global install.

## Why

Gives a no-wiring way to poke at the tool surface and resources (e.g. `simulator://actor/{id}`) without registering the server into a host. The headless `--cli` mode is also handy for diffing the tool list in CI.

## Docs

- New "Inspecting / debugging with the MCP Inspector" section in the MCP server README (web UI + `--cli` mode).
- Added `make inspect` to the root README dev section and the Makefile-targets help.

## Verification

Smoke-tested the full chain via the Inspector's headless CLI — it launched the stdio server and returned the complete `tools/list`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)