### PR TITLE
feat(mcp): Add embeddable mcpserver package with stateless ctx mode

### DIFF
--- a/plugins/simulator/mcp-server/app/mcpserver/graph.go
+++ b/plugins/simulator/mcp-server/app/mcpserver/graph.go
@@ -1,0 +1,26 @@
+package mcpserver
+
+import (
+	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/internal/engines/graph"
+)
+
+// Graph types and the PushGraphFile function are re-exported here so external
+// consumers (e.g. claude-code-api's /v1/layers/push endpoint) can build and
+// sync a graph without depending on the internal/ package layout.
+
+// GraphFile, GraphActor, GraphEdge mirror the YAML data model used by the
+// pushGraphFile MCP tool.
+type (
+	GraphFile  = graph.GraphFile
+	GraphActor = graph.GraphActor
+	GraphEdge  = graph.GraphEdge
+)
+
+// PushGraphResult holds the outcome of PushGraphFile.
+type PushGraphResult = graph.PushGraphResult
+
+// PushGraphFile syncs a parsed graph to the simulator API without touching the
+// filesystem or environment variables. See graph.PushGraphFile for details.
+func PushGraphFile(g GraphFile, workspaceID, layerID, authorization, baseURL string) (PushGraphResult, error) {
+	return graph.PushGraphFile(g, workspaceID, layerID, authorization, baseURL)
+}

--- a/plugins/simulator/mcp-server/app/mcpserver/mcpserver.go
+++ b/plugins/simulator/mcp-server/app/mcpserver/mcpserver.go
@@ -1,0 +1,170 @@
+// Package mcpserver is the public embedding API for the simulator MCP server.
+//
+// It assembles the curated tool set plus engine tools on top of a configured
+// *server.MCPServer and returns the server to the caller, who is free to
+// serve it over any transport (stdio, SSE, Streamable HTTP, etc.).
+//
+// cmd/server uses this package to expose the server over stdio. External
+// consumers (e.g. claude-code-api) use it to embed the same server inside
+// their own process and pick a network transport.
+package mcpserver
+
+import (
+	"context"
+	"errors"
+	"os"
+
+	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/app/auth"
+	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/internal/apiclient"
+	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/internal/config"
+	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/internal/engines"
+	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/internal/engines/ecore"
+	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/internal/tools"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+const (
+	defaultName    = "simulator"
+	defaultVersion = "2.1.0"
+)
+
+// Options configures the embedded MCP server.
+type Options struct {
+	// Profile selects the environment profile (e.g. "prod", "local").
+	// Empty falls back to SIMULATOR_PROFILE env var, then "prod".
+	Profile string
+
+	// Insecure disables TLS verification for on-prem gateways with self-signed certs.
+	Insecure bool
+
+	// Name overrides the MCP server name (default "simulator").
+	Name string
+
+	// Version overrides the MCP server version.
+	Version string
+
+	// AuthHeader returns the Authorization header value for each API call.
+	// Nil falls back to reading credentials via app/auth.Load() from .env in cwd.
+	// Ignored when Stateless=true (auth must arrive via request ctx instead).
+	AuthHeader func() (string, error)
+
+	// WorkspaceID overrides the workspace ID. Empty falls back to WORKSPACE_ID env var.
+	// Ignored when Stateless=true (workspace arrives via request ctx instead).
+	WorkspaceID string
+
+	// Stateless switches the server into per-request mode: no .env reads or writes,
+	// no process-global auth cache, and the .env-mutating helper tools
+	// (login / set-workspace / set-environment) are NOT registered. Authorization,
+	// workspace id and API base URL must arrive on every request via ctx using
+	// apiclient.WithAuthorization / WithWorkspaceID / WithBaseURL — typically wired
+	// from HTTP headers by the SSE transport's WithSSEContextFunc.
+	Stateless bool
+}
+
+// Info reports the resolved environment for logging / diagnostics.
+type Info struct {
+	Profile    string // profile name (e.g. "prod", "local")
+	APIBaseURL string // public API root (incl. /papi/1.0)
+	AccountURL string // OAuth2 / SA base URL
+}
+
+// New builds and returns an MCP server with every simulator tool and engine
+// registered. The returned server is ready to be served over any transport.
+// Info carries the resolved profile/URLs for the caller to log.
+func New(opts Options) (*server.MCPServer, Info, error) {
+	prof, err := config.Resolve(opts.Profile)
+	if err != nil {
+		return nil, Info{}, err
+	}
+
+	var (
+		authHeader  func() (string, error)
+		workspaceID string
+	)
+	if opts.Stateless {
+		// In stateless mode, the default Client values are never used: auth and
+		// workspace are read from request ctx on every call (set by
+		// apiclient.WithAuthorization / WithWorkspaceID). We still need a non-nil
+		// authHeader so Client.Do doesn't skip the header path when no ctx auth
+		// is attached — return a sentinel error in that case to surface misuse.
+		authHeader = func() (string, error) {
+			return "", errors.New("stateless mode: Authorization header missing on request")
+		}
+	} else {
+		authHeader = opts.AuthHeader
+		if authHeader == nil {
+			authHeader = defaultAuthHeader
+		}
+		workspaceID = opts.WorkspaceID
+		if workspaceID == "" {
+			workspaceID = os.Getenv("WORKSPACE_ID")
+		}
+	}
+
+	client := apiclient.New(prof.APIBaseURL, workspaceID, authHeader, opts.Insecure)
+
+	name := opts.Name
+	if name == "" {
+		name = defaultName
+	}
+	version := opts.Version
+	if version == "" {
+		version = defaultVersion
+	}
+
+	s := server.NewMCPServer(name, version)
+	ecore.SetStateless(opts.Stateless)
+	if opts.Stateless {
+		tools.BuildAllStateless(s, client)
+	} else {
+		tools.BuildAll(s, client, prof, opts.Insecure)
+	}
+	engines.Configure(prof.APIBaseURL, opts.Insecure)
+	engines.RegisterTools(s)
+	return s, Info{
+		Profile:    prof.Name,
+		APIBaseURL: prof.APIBaseURL,
+		AccountURL: prof.AccountURL,
+	}, nil
+}
+
+// ToolCount reports how many curated API tools are registered (auth helpers excluded).
+func ToolCount() int { return tools.Count() }
+
+// IsInsecureCredentialTransport reports whether the given API base URL would
+// send credentials over plaintext HTTP to a non-loopback host. Callers can use
+// this to emit a startup warning.
+func IsInsecureCredentialTransport(baseURL string) bool {
+	return apiclient.IsInsecureCredentialTransport(baseURL)
+}
+
+// Per-request context helpers, re-exported from the internal apiclient package.
+// External transports (e.g. claude-code-api's SSE wrapper) use these to attach
+// the caller's Authorization header / workspace id / API base URL to ctx, so
+// tool handlers running in stateless mode see the per-request values.
+
+// WithAuthorization stores the full Authorization header value on ctx.
+func WithAuthorization(ctx context.Context, value string) context.Context {
+	return apiclient.WithAuthorization(ctx, value)
+}
+
+// WithWorkspaceID stores a per-request workspace id (accId) on ctx.
+func WithWorkspaceID(ctx context.Context, value string) context.Context {
+	return apiclient.WithWorkspaceID(ctx, value)
+}
+
+// WithBaseURL stores a per-request API base URL override on ctx.
+func WithBaseURL(ctx context.Context, value string) context.Context {
+	return apiclient.WithBaseURL(ctx, value)
+}
+
+func defaultAuthHeader() (string, error) {
+	creds, err := auth.Load()
+	if err != nil {
+		return "", err
+	}
+	if creds == nil {
+		return "", errors.New("not authenticated — run the `login` tool first")
+	}
+	return creds.AuthorizationHeader(), nil
+}

--- a/plugins/simulator/mcp-server/cmd/server/main.go
+++ b/plugins/simulator/mcp-server/cmd/server/main.go
@@ -6,18 +6,13 @@
 package main
 
 import (
-	"errors"
 	"flag"
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/app/auth"
-	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/internal/apiclient"
-	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/internal/config"
-	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/internal/engines"
-	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/internal/tools"
+	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/app/mcpserver"
 	"github.com/mark3labs/mcp-go/server"
 )
 
@@ -34,46 +29,22 @@ func main() {
 		loadDotEnv(".env")
 	}
 
-	prof, err := config.Resolve(*profileFlag)
+	s, info, err := mcpserver.New(mcpserver.Options{
+		Profile:  *profileFlag,
+		Insecure: *insecure,
+		Version:  version,
+	})
 	if err != nil {
 		log.Fatalf("config: %v", err)
 	}
-	log.Printf("simulator MCP server %s — profile=%s api=%s account=%s", version, prof.Name, prof.APIBaseURL, prof.AccountURL)
-	warnIfInsecureCredentialTransport(prof.APIBaseURL)
-
-	// AuthHeader provider reads the current credentials each call so a fresh
-	// login takes effect without a restart.
-	authHeader := func() (string, error) {
-		creds, err := auth.Load()
-		if err != nil {
-			return "", err
-		}
-		if creds == nil {
-			return "", errors.New("not authenticated — run the `login` tool first")
-		}
-		return creds.AuthorizationHeader(), nil
+	log.Printf("simulator MCP server %s — profile=%s api=%s account=%s", version, info.Profile, info.APIBaseURL, info.AccountURL)
+	if mcpserver.IsInsecureCredentialTransport(info.APIBaseURL) {
+		log.Printf("WARNING: API base URL %q uses plaintext HTTP to a non-local host — the auth token will be sent unencrypted. Use HTTPS.", info.APIBaseURL)
 	}
-
-	client := apiclient.New(prof.APIBaseURL, os.Getenv("WORKSPACE_ID"), authHeader, *insecure)
-
-	s := server.NewMCPServer("simulator", version)
-	tools.BuildAll(s, client, prof, *insecure)
-	engines.Configure(prof.APIBaseURL, *insecure)
-	engines.RegisterTools(s)
-	log.Printf("registered %d curated API tools + auth helpers + engine tools", tools.Count())
+	log.Printf("registered %d curated API tools + auth helpers + engine tools", mcpserver.ToolCount())
 
 	if err := server.ServeStdio(s); err != nil {
 		log.Fatalf("server error: %v", err)
-	}
-}
-
-// warnIfInsecureCredentialTransport logs a warning when the resolved API base
-// URL would send the bearer token over plaintext HTTP to a non-loopback host.
-// The token is attached to every request, so a remote http:// endpoint (e.g.
-// set via SIMULATOR_API_BASE_URL or profiles.json) would expose it on the wire.
-func warnIfInsecureCredentialTransport(baseURL string) {
-	if apiclient.IsInsecureCredentialTransport(baseURL) {
-		log.Printf("WARNING: API base URL %q uses plaintext HTTP to a non-local host — the auth token will be sent unencrypted. Use HTTPS.", baseURL)
 	}
 }
 

--- a/plugins/simulator/mcp-server/internal/apiclient/client.go
+++ b/plugins/simulator/mcp-server/internal/apiclient/client.go
@@ -75,6 +75,75 @@ func (c *Client) SetWorkspaceID(id string) {
 	c.workspaceID = id
 }
 
+// ctxKey is the unexported type for per-request context override keys.
+// Use the WithXxx / XxxFromContext helpers below — callers never touch this directly.
+type ctxKey int
+
+const (
+	authCtxKey ctxKey = iota
+	baseURLCtxKey
+	workspaceCtxKey
+)
+
+// WithAuthorization stores the full Authorization header value on ctx so that
+// Client.Do uses it instead of calling the Client's AuthHeader callback.
+// Empty value is ignored.
+func WithAuthorization(ctx context.Context, value string) context.Context {
+	if value == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, authCtxKey, value)
+}
+
+// WithBaseURL stores a per-request API base URL override on ctx so that
+// Client.Do routes against it instead of the Client's stored base URL.
+// Empty value is ignored.
+func WithBaseURL(ctx context.Context, value string) context.Context {
+	if value == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, baseURLCtxKey, strings.TrimRight(value, "/"))
+}
+
+// WithWorkspaceID stores a per-request workspace id override on ctx so that
+// Client.WorkspaceIDForContext returns it instead of the stored default.
+// Empty value is ignored.
+func WithWorkspaceID(ctx context.Context, value string) context.Context {
+	if value == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, workspaceCtxKey, value)
+}
+
+// AuthorizationFromContext returns the per-request Authorization header value,
+// or "" if none was attached.
+func AuthorizationFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(authCtxKey).(string)
+	return v
+}
+
+// BaseURLFromContext returns the per-request API base URL override, or "".
+func BaseURLFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(baseURLCtxKey).(string)
+	return v
+}
+
+// WorkspaceIDFromContext returns the per-request workspace id override, or "".
+func WorkspaceIDFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(workspaceCtxKey).(string)
+	return v
+}
+
+// WorkspaceIDForContext returns the per-request workspace id (from ctx) if set,
+// otherwise the Client's stored default. Tool handlers that read the workspace
+// should call this so stateless/SSE deployments can override per request.
+func (c *Client) WorkspaceIDForContext(ctx context.Context) string {
+	if id := WorkspaceIDFromContext(ctx); id != "" {
+		return id
+	}
+	return c.WorkspaceID()
+}
+
 // IsInsecureCredentialTransport reports whether baseURL would send the bearer
 // token over plaintext HTTP to a non-loopback host. The token is attached to every
 // request, so a remote http:// endpoint would expose it on the wire.
@@ -104,7 +173,11 @@ func (e *APIError) Error() string {
 // be nil; body may be nil, or any JSON-serialisable value. On a 2xx it returns the
 // raw response body; on a non-2xx it returns an *APIError.
 func (c *Client) Do(ctx context.Context, method, path string, query url.Values, body any) ([]byte, error) {
-	full := c.BaseURL() + path
+	base := BaseURLFromContext(ctx)
+	if base == "" {
+		base = c.BaseURL()
+	}
+	full := base + path
 	if len(query) > 0 {
 		full += "?" + query.Encode()
 	}
@@ -125,7 +198,9 @@ func (c *Client) Do(ctx context.Context, method, path string, query url.Values, 
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	if c.AuthHeader != nil {
+	if ctxAuth := AuthorizationFromContext(ctx); ctxAuth != "" {
+		req.Header.Set("Authorization", ctxAuth)
+	} else if c.AuthHeader != nil {
 		auth, err := c.AuthHeader()
 		if err != nil {
 			return nil, err

--- a/plugins/simulator/mcp-server/internal/engines/ecore/helpers.go
+++ b/plugins/simulator/mcp-server/internal/engines/ecore/helpers.go
@@ -2,6 +2,7 @@ package ecore
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -59,12 +60,13 @@ func RequireUUID(name, v string) *mcp.CallToolResult {
 func Seg(s string) string { return url.PathEscape(s) }
 
 // PapiGET sends an authenticated GET and returns the response body.
-func PapiGET(apiURL string) ([]byte, error) {
-	req, err := http.NewRequest("GET", apiURL, nil)
+// The ctx supplies the per-request Authorization in stateless mode.
+func PapiGET(ctx context.Context, apiURL string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", apiURL, nil)
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Authorization", AuthHeader())
+	req.Header.Set("Authorization", AuthHeaderForContext(ctx))
 	resp, err := APIHTTPClient().Do(req)
 	if err != nil {
 		return nil, err
@@ -84,12 +86,12 @@ func PapiGET(apiURL string) ([]byte, error) {
 }
 
 // PapiPOST sends an authenticated POST with a JSON body and returns the response body.
-func PapiPOST(apiURL string, body []byte) ([]byte, error) {
-	req, err := http.NewRequest("POST", apiURL, bytes.NewReader(body))
+func PapiPOST(ctx context.Context, apiURL string, body []byte) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, "POST", apiURL, bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Authorization", AuthHeader())
+	req.Header.Set("Authorization", AuthHeaderForContext(ctx))
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := APIHTTPClient().Do(req)
 	if err != nil {
@@ -107,12 +109,12 @@ func PapiPOST(apiURL string, body []byte) ([]byte, error) {
 }
 
 // PapiPUT sends an authenticated PUT with a JSON body and returns the response body.
-func PapiPUT(apiURL string, body []byte) ([]byte, error) {
-	req, err := http.NewRequest("PUT", apiURL, bytes.NewReader(body))
+func PapiPUT(ctx context.Context, apiURL string, body []byte) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, "PUT", apiURL, bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Authorization", AuthHeader())
+	req.Header.Set("Authorization", AuthHeaderForContext(ctx))
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := APIHTTPClient().Do(req)
 	if err != nil {

--- a/plugins/simulator/mcp-server/internal/engines/ecore/runtime.go
+++ b/plugins/simulator/mcp-server/internal/engines/ecore/runtime.go
@@ -5,10 +5,12 @@ package ecore
 
 import (
 	"context"
+	"os"
 	"strings"
 	"sync"
 
 	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/app/auth"
+	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/internal/apiclient"
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
@@ -44,6 +46,48 @@ func Configure(baseURL string, insecure bool) {
 	Cfg.Insecure = insecure
 }
 
+// statelessMu guards the stateless flag, which switches EnsureAuth / AuthHeader
+// / BuildBaseURL to read exclusively from request ctx (set by apiclient.WithXxx
+// helpers) instead of falling back to process-global state or auth.Load().
+//
+// Stateless mode is meant for embedded SSE deployments where every request
+// carries its own credentials in HTTP headers and the .env-based stateful
+// path (login / set-workspace / set-environment) is not used.
+var (
+	statelessMu sync.RWMutex
+	stateless   bool
+)
+
+// SetStateless toggles the engine into stateless mode. In stateless mode the
+// engine never touches .env (no auth.Load, no global token cache) — auth and
+// base URL come from request ctx via apiclient.AuthorizationFromContext /
+// BaseURLFromContext.
+func SetStateless(on bool) {
+	statelessMu.Lock()
+	defer statelessMu.Unlock()
+	stateless = on
+}
+
+// IsStateless reports whether the engine is in stateless (per-request ctx) mode.
+func IsStateless() bool {
+	statelessMu.RLock()
+	defer statelessMu.RUnlock()
+	return stateless
+}
+
+// WorkspaceIDForContext returns the per-request workspace id (from ctx) if set,
+// otherwise the WORKSPACE_ID env var. In stateless mode the env fallback is
+// suppressed so callers cannot accidentally leak process-wide state.
+func WorkspaceIDForContext(ctx context.Context) string {
+	if id := apiclient.WorkspaceIDFromContext(ctx); id != "" {
+		return id
+	}
+	if IsStateless() {
+		return ""
+	}
+	return os.Getenv("WORKSPACE_ID")
+}
+
 // SetBaseURL updates the engine API base URL at runtime (used by set-environment),
 // mirroring apiclient.Client.SetBaseURL so a mid-session environment switch takes
 // effect for engine tools too.
@@ -62,10 +106,26 @@ func ResetAuth() {
 }
 
 // AuthHeader returns the cached Authorization value, safe for concurrent reads.
+//
+// Prefer AuthHeaderForContext(ctx) when a ctx is available — it honours the
+// per-request override stored by apiclient.WithAuthorization in stateless mode.
 func AuthHeader() string {
 	cfgMu.RLock()
 	defer cfgMu.RUnlock()
 	return Cfg.Authorization
+}
+
+// AuthHeaderForContext returns the per-request Authorization value if present,
+// otherwise the process-global cached value. Engine code that has a ctx in
+// scope should call this so stateless / SSE deployments work correctly.
+func AuthHeaderForContext(ctx context.Context) string {
+	if v := apiclient.AuthorizationFromContext(ctx); v != "" {
+		return v
+	}
+	if IsStateless() {
+		return ""
+	}
+	return AuthHeader()
 }
 
 // baseURL returns the configured API base URL, safe for concurrent reads.
@@ -76,6 +136,9 @@ func baseURL() string {
 }
 
 // BuildBaseURL returns the same base URL used by all other MCP tools.
+//
+// Prefer BuildBaseURLForContext(ctx) when a ctx is available so stateless
+// deployments can override the base URL per request.
 func BuildBaseURL() string {
 	if Cfg.Url != "" {
 		return strings.TrimSuffix(Cfg.Url, "/")
@@ -86,9 +149,28 @@ func BuildBaseURL() string {
 	return "https://api.simulator.company/v/1.0"
 }
 
+// BuildBaseURLForContext returns the per-request API base URL override if set,
+// otherwise falls back to the explicit Cfg.Url, the configured Cfg.BaseUrl, or
+// the public default — in that order.
+func BuildBaseURLForContext(ctx context.Context) string {
+	if b := apiclient.BaseURLFromContext(ctx); b != "" {
+		return strings.TrimSuffix(b, "/")
+	}
+	return BuildBaseURL()
+}
+
 // EnsureAuth refreshes the cached authorization from saved credentials and
 // returns a friendly error result if the user is not authenticated yet.
+//
+// In stateless mode it never touches .env — auth must arrive via ctx
+// (apiclient.WithAuthorization) and is not cached process-globally.
 func EnsureAuth(ctx context.Context) *mcp.CallToolResult {
+	if IsStateless() {
+		if apiclient.AuthorizationFromContext(ctx) == "" {
+			return mcp.NewToolResultError("[Error] missing Authorization header")
+		}
+		return nil
+	}
 	if creds, _ := auth.Load(); creds != nil && !auth.IsExpired(creds) {
 		cfgMu.Lock()
 		Cfg.Authorization = creds.AuthorizationHeader()

--- a/plugins/simulator/mcp-server/internal/engines/graph/chart.go
+++ b/plugins/simulator/mcp-server/internal/engines/graph/chart.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"sync"
 
 	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/internal/engines/ecore"
@@ -610,7 +609,7 @@ func handleCreateChart(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallT
 		Accounts:      accounts,
 	}
 
-	result, err := CreateChart(ctx, cfg, os.Getenv("WORKSPACE_ID"), ecore.AuthHeader(), ecore.BuildBaseURL())
+	result, err := CreateChart(ctx, cfg, ecore.WorkspaceIDForContext(ctx), ecore.AuthHeaderForContext(ctx), ecore.BuildBaseURLForContext(ctx))
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("[Error] createChart: %v", err)), nil
 	}

--- a/plugins/simulator/mcp-server/internal/engines/graph/compact_layout.go
+++ b/plugins/simulator/mcp-server/internal/engines/graph/compact_layout.go
@@ -90,7 +90,7 @@ func handleCompactGraphLayout(ctx context.Context, req mcp.CallToolRequest) (*mc
 	client := ecore.APIHTTPClient()
 	apiGet := func(url string) ([]byte, error) {
 		hr, _ := http.NewRequestWithContext(ctx, "GET", url, nil)
-		hr.Header.Set("Authorization", ecore.AuthHeader())
+		hr.Header.Set("Authorization", ecore.AuthHeaderForContext(ctx))
 		resp, err := client.Do(hr)
 		if err != nil {
 			return nil, err
@@ -111,7 +111,7 @@ func handleCompactGraphLayout(ctx context.Context, req mcp.CallToolRequest) (*mc
 	offset := 0
 	for {
 		u := fmt.Sprintf("%s/graph_layers/paginated/%s?type=nodes&limit=%d&offset=%d",
-			ecore.BuildBaseURL(), layerID, limit, offset)
+			ecore.BuildBaseURLForContext(ctx), layerID, limit, offset)
 		body, err := apiGet(u)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("[Error] fetch placements: %v", err)), nil
@@ -143,7 +143,7 @@ func handleCompactGraphLayout(ctx context.Context, req mcp.CallToolRequest) (*mc
 	offset = 0
 	for {
 		u := fmt.Sprintf("%s/graph_layers/paginated/%s?type=edges&limit=%d&offset=%d",
-			ecore.BuildBaseURL(), layerID, limit, offset)
+			ecore.BuildBaseURLForContext(ctx), layerID, limit, offset)
 		body, err := apiGet(u)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("[Error] fetch edges: %v", err)), nil
@@ -332,7 +332,7 @@ func handleCompactGraphLayout(ctx context.Context, req mcp.CallToolRequest) (*mc
 	apiPut := func(url string, body interface{}) error {
 		bodyBytes, _ := json.Marshal(body)
 		hr, _ := http.NewRequestWithContext(ctx, "PUT", url, strings.NewReader(string(bodyBytes)))
-		hr.Header.Set("Authorization", ecore.AuthHeader())
+		hr.Header.Set("Authorization", ecore.AuthHeaderForContext(ctx))
 		hr.Header.Set("Content-Type", "application/json")
 		resp, err := client.Do(hr)
 		if err != nil {
@@ -352,7 +352,7 @@ func handleCompactGraphLayout(ctx context.Context, req mcp.CallToolRequest) (*mc
 			end = len(items)
 		}
 		batch := items[i:end]
-		u := fmt.Sprintf("%s/graph_layers/actors/%s", ecore.BuildBaseURL(), layerID)
+		u := fmt.Sprintf("%s/graph_layers/actors/%s", ecore.BuildBaseURLForContext(ctx), layerID)
 		if err := apiPut(u, map[string]interface{}{"items": batch}); err != nil {
 			return mcp.NewToolResultError(
 				fmt.Sprintf("[Error] applyPositions batch %d: %v", i/batchSize, err)), nil

--- a/plugins/simulator/mcp-server/internal/engines/graph/placements.go
+++ b/plugins/simulator/mcp-server/internal/engines/graph/placements.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 
 	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/internal/engines/ecore"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -63,12 +62,12 @@ func handleGetAllLayerPlacements(ctx context.Context, req mcp.CallToolRequest) (
 	offset := 0
 	for {
 		u := fmt.Sprintf("%s/graph_layers/paginated/%s?type=nodes&limit=%d&offset=%d",
-			ecore.BuildBaseURL(), layerID, limit, offset)
+			ecore.BuildBaseURLForContext(ctx), layerID, limit, offset)
 		httpReq, err := http.NewRequestWithContext(ctx, "GET", u, nil)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("[Error] new request: %v", err)), nil
 		}
-		httpReq.Header.Set("Authorization", ecore.AuthHeader())
+		httpReq.Header.Set("Authorization", ecore.AuthHeaderForContext(ctx))
 		resp, err := client.Do(httpReq)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("[Error] http: %v", err)), nil
@@ -107,7 +106,7 @@ func handleGetAllLayerPlacements(ctx context.Context, req mcp.CallToolRequest) (
 	// endpoints — not required for downstream layerActorsPosition / manageLayer.
 	out := map[string]interface{}{
 		"layerId":     layerID,
-		"workspaceId": os.Getenv("WORKSPACE_ID"),
+		"workspaceId": ecore.WorkspaceIDForContext(ctx),
 		"total":       len(rows),
 		"placements":  rows,
 	}

--- a/plugins/simulator/mcp-server/internal/engines/graph/prune_edges.go
+++ b/plugins/simulator/mcp-server/internal/engines/graph/prune_edges.go
@@ -62,7 +62,7 @@ func handlePruneLongEdges(ctx context.Context, req mcp.CallToolRequest) (*mcp.Ca
 	client := ecore.APIHTTPClient()
 	apiGet := func(url string) ([]byte, error) {
 		hr, _ := http.NewRequestWithContext(ctx, "GET", url, nil)
-		hr.Header.Set("Authorization", ecore.AuthHeader())
+		hr.Header.Set("Authorization", ecore.AuthHeaderForContext(ctx))
 		resp, err := client.Do(hr)
 		if err != nil {
 			return nil, err
@@ -76,7 +76,7 @@ func handlePruneLongEdges(ctx context.Context, req mcp.CallToolRequest) (*mcp.Ca
 	}
 	apiDelete := func(url string) error {
 		hr, _ := http.NewRequestWithContext(ctx, "DELETE", url, nil)
-		hr.Header.Set("Authorization", ecore.AuthHeader())
+		hr.Header.Set("Authorization", ecore.AuthHeaderForContext(ctx))
 		resp, err := client.Do(hr)
 		if err != nil {
 			return err
@@ -104,7 +104,7 @@ func handlePruneLongEdges(ctx context.Context, req mcp.CallToolRequest) (*mcp.Ca
 	offset := 0
 	for {
 		u := fmt.Sprintf("%s/graph_layers/paginated/%s?type=nodes&limit=%d&offset=%d",
-			ecore.BuildBaseURL(), layerID, limit, offset)
+			ecore.BuildBaseURLForContext(ctx), layerID, limit, offset)
 		body, err := apiGet(u)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("[Error] fetch placements: %v", err)), nil
@@ -135,7 +135,7 @@ func handlePruneLongEdges(ctx context.Context, req mcp.CallToolRequest) (*mcp.Ca
 	offset = 0
 	for {
 		u := fmt.Sprintf("%s/graph_layers/paginated/%s?type=edges&limit=%d&offset=%d",
-			ecore.BuildBaseURL(), layerID, limit, offset)
+			ecore.BuildBaseURLForContext(ctx), layerID, limit, offset)
 		body, err := apiGet(u)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("[Error] fetch edges: %v", err)), nil
@@ -191,7 +191,7 @@ func handlePruneLongEdges(ctx context.Context, req mcp.CallToolRequest) (*mcp.Ca
 		}
 		// Delete it.
 		if !dryRun {
-			u := fmt.Sprintf("%s/actors/link/%s", ecore.BuildBaseURL(), e.ID)
+			u := fmt.Sprintf("%s/actors/link/%s", ecore.BuildBaseURLForContext(ctx), e.ID)
 			if err := apiDelete(u); err != nil {
 				stats.Errors = append(stats.Errors,
 					fmt.Sprintf("%s→%s: %v", titleOf[e.Source], titleOf[e.Target], err))

--- a/plugins/simulator/mcp-server/internal/engines/graph/sync.go
+++ b/plugins/simulator/mcp-server/internal/engines/graph/sync.go
@@ -90,13 +90,13 @@ type layerEdge struct {
 
 // ---- Layer fetch helpers ----
 
-func fetchLayerActors(layerID string) ([]layerActor, error) {
-	base := ecore.BuildBaseURL()
+func fetchLayerActors(ctx context.Context, layerID string) ([]layerActor, error) {
+	base := ecore.BuildBaseURLForContext(ctx)
 	var all []layerActor
 	limit, offset := 50, 0
 	for {
 		u := fmt.Sprintf("%s/graph_layers/paginated/%s?type=nodes&limit=%d&offset=%d", base, ecore.Seg(layerID), limit, offset)
-		body, err := ecore.PapiGET(u)
+		body, err := ecore.PapiGET(ctx, u)
 		if err != nil {
 			return nil, err
 		}
@@ -115,13 +115,13 @@ func fetchLayerActors(layerID string) ([]layerActor, error) {
 	return all, nil
 }
 
-func fetchLayerEdges(layerID string) ([]layerEdge, error) {
-	base := ecore.BuildBaseURL()
+func fetchLayerEdges(ctx context.Context, layerID string) ([]layerEdge, error) {
+	base := ecore.BuildBaseURLForContext(ctx)
 	var all []layerEdge
 	limit, offset := 50, 0
 	for {
 		u := fmt.Sprintf("%s/graph_layers/paginated/%s?type=edges&limit=%d&offset=%d", base, ecore.Seg(layerID), limit, offset)
-		body, err := ecore.PapiGET(u)
+		body, err := ecore.PapiGET(ctx, u)
 		if err != nil {
 			return nil, err
 		}
@@ -183,7 +183,7 @@ func handlePushGraphFile(ctx context.Context, req mcp.CallToolRequest) (*mcp.Cal
 		return mcp.NewToolResultError(fmt.Sprintf("[Error] cannot parse YAML %s: %v", filePath, parseErr)), nil
 	}
 
-	result, syncErr := PushGraphFile(graph, os.Getenv("WORKSPACE_ID"), layerID, ecore.AuthHeader(), ecore.BuildBaseURL())
+	result, syncErr := PushGraphFile(graph, ecore.WorkspaceIDForContext(ctx), layerID, ecore.AuthHeaderForContext(ctx), ecore.BuildBaseURLForContext(ctx))
 	if syncErr != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("[Error] %v", syncErr)), nil
 	}
@@ -233,13 +233,13 @@ func handlePullGraphFile(ctx context.Context, req mcp.CallToolRequest) (*mcp.Cal
 	filePath := ecore.ResolvePath(layerID + ".yaml")
 
 	// Fetch actors
-	serverActors, err := fetchLayerActors(layerID)
+	serverActors, err := fetchLayerActors(ctx, layerID)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("[Error] fetch layer actors: %v", err)), nil
 	}
 
 	// Fetch edges
-	serverEdges, err := fetchLayerEdges(layerID)
+	serverEdges, err := fetchLayerEdges(ctx, layerID)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("[Error] fetch layer edges: %v", err)), nil
 	}

--- a/plugins/simulator/mcp-server/internal/engines/graph/upload.go
+++ b/plugins/simulator/mcp-server/internal/engines/graph/upload.go
@@ -105,12 +105,12 @@ func uploadFile(ctx context.Context, accID string, filename string, contentType 
 	// POST request — `ttl=0` mirrors the UI request and the Postman collection
 	// (`Simulator_public_API.postman_collection.json`).  Without `ttl=0` the
 	// file is sometimes uploaded with a TTL that hides it from the graph UI.
-	apiURL := fmt.Sprintf("%s/upload/%s?ttl=0", ecore.BuildBaseURL(), accID)
+	apiURL := fmt.Sprintf("%s/upload/%s?ttl=0", ecore.BuildBaseURLForContext(ctx), accID)
 	req, err := http.NewRequestWithContext(ctx, "POST", apiURL, &buf)
 	if err != nil {
 		return "", fmt.Errorf("new request: %w", err)
 	}
-	req.Header.Set("Authorization", ecore.AuthHeader())
+	req.Header.Set("Authorization", ecore.AuthHeaderForContext(ctx))
 	req.Header.Set("Content-Type", mw.FormDataContentType())
 
 	client := ecore.APIHTTPClient()
@@ -145,12 +145,12 @@ func setActorPicture(ctx context.Context, formID int, actorID, picture string) e
 	bodyBytes, _ := json.Marshal(body)
 
 	apiURL := fmt.Sprintf("%s/actors/actor/%d/%s?replaceEmpty=false",
-		ecore.BuildBaseURL(), formID, actorID)
+		ecore.BuildBaseURLForContext(ctx), formID, actorID)
 	req, err := http.NewRequestWithContext(ctx, "PUT", apiURL, bytes.NewReader(bodyBytes))
 	if err != nil {
 		return fmt.Errorf("new request: %w", err)
 	}
-	req.Header.Set("Authorization", ecore.AuthHeader())
+	req.Header.Set("Authorization", ecore.AuthHeaderForContext(ctx))
 	req.Header.Set("Content-Type", "application/json")
 
 	client := ecore.APIHTTPClient()
@@ -256,7 +256,7 @@ func handleUploadActorPicture(ctx context.Context, req mcp.CallToolRequest) (*mc
 		return mcp.NewToolResultError("[Error] formId is required"), nil
 	}
 
-	accID := os.Getenv("WORKSPACE_ID")
+	accID := ecore.WorkspaceIDForContext(ctx)
 	if accID == "" {
 		return mcp.NewToolResultError("[Error] WORKSPACE_ID is not set"), nil
 	}
@@ -367,7 +367,7 @@ func handleUploadActorPictureBulk(ctx context.Context, req mcp.CallToolRequest) 
 		return mcp.NewToolResultError("[Error] items[] capped at 500 per call"), nil
 	}
 
-	accID := os.Getenv("WORKSPACE_ID")
+	accID := ecore.WorkspaceIDForContext(ctx)
 	if accID == "" {
 		return mcp.NewToolResultError("[Error] WORKSPACE_ID is not set"), nil
 	}

--- a/plugins/simulator/mcp-server/internal/engines/smartform/create.go
+++ b/plugins/simulator/mcp-server/internal/engines/smartform/create.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/internal/engines/ecore"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -29,7 +28,7 @@ func handleCreateSmartForm(ctx context.Context, req mcp.CallToolRequest) (*mcp.C
 		return mcp.NewToolResultError("[Error] ref is required"), nil
 	}
 
-	accID := os.Getenv("WORKSPACE_ID")
+	accID := ecore.WorkspaceIDForContext(ctx)
 	if accID == "" {
 		return mcp.NewToolResultError("[Error] WORKSPACE_ID not set — run set-workspace first"), nil
 	}
@@ -81,8 +80,8 @@ func handleCreateSmartForm(ctx context.Context, req mcp.CallToolRequest) (*mcp.C
 		return mcp.NewToolResultError(fmt.Sprintf("[Error] marshal: %v", err)), nil
 	}
 
-	apiURL := fmt.Sprintf("%s/applications/%s", ecore.BuildBaseURL(), ecore.Seg(accID))
-	respBytes, err := ecore.PapiPOST(apiURL, bodyBytes)
+	apiURL := fmt.Sprintf("%s/applications/%s", ecore.BuildBaseURLForContext(ctx), ecore.Seg(accID))
+	respBytes, err := ecore.PapiPOST(ctx, apiURL, bodyBytes)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("[Error] create application: %v", err)), nil
 	}

--- a/plugins/simulator/mcp-server/internal/engines/smartform/file_history.go
+++ b/plugins/simulator/mcp-server/internal/engines/smartform/file_history.go
@@ -32,7 +32,7 @@ func handleGetFileHistory(ctx context.Context, req mcp.CallToolRequest) (*mcp.Ca
 	}
 	fileID := int(fileIDFloat)
 
-	apiURL := fmt.Sprintf("%s/file_history/%s/%d", ecore.BuildBaseURL(), ecore.Seg(actorID), fileID)
+	apiURL := fmt.Sprintf("%s/file_history/%s/%d", ecore.BuildBaseURLForContext(ctx), ecore.Seg(actorID), fileID)
 
 	sep := "?"
 	if limit, ok := args["limit"].(float64); ok && limit > 0 {
@@ -43,7 +43,7 @@ func handleGetFileHistory(ctx context.Context, req mcp.CallToolRequest) (*mcp.Ca
 		apiURL += fmt.Sprintf("%soffset=%d", sep, int(offset))
 	}
 
-	respBytes, err := ecore.PapiGET(apiURL)
+	respBytes, err := ecore.PapiGET(ctx, apiURL)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("[Error] get file history: %v", err)), nil
 	}
@@ -77,8 +77,8 @@ func handleGetFileVersion(ctx context.Context, req mcp.CallToolRequest) (*mcp.Ca
 		return mcp.NewToolResultError("[Error] versionId is required"), nil
 	}
 
-	apiURL := fmt.Sprintf("%s/file_history/%s/%d/%s", ecore.BuildBaseURL(), ecore.Seg(actorID), fileID, ecore.Seg(versionID))
-	respBytes, err := ecore.PapiGET(apiURL)
+	apiURL := fmt.Sprintf("%s/file_history/%s/%d/%s", ecore.BuildBaseURLForContext(ctx), ecore.Seg(actorID), fileID, ecore.Seg(versionID))
+	respBytes, err := ecore.PapiGET(ctx, apiURL)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("[Error] get file version: %v", err)), nil
 	}
@@ -113,8 +113,8 @@ func handleRollbackFile(ctx context.Context, req mcp.CallToolRequest) (*mcp.Call
 	}
 
 	body, _ := json.Marshal(map[string]string{"versionId": versionID})
-	apiURL := fmt.Sprintf("%s/file_history/%s/%d/rollback", ecore.BuildBaseURL(), ecore.Seg(actorID), fileID)
-	respBytes, err := ecore.PapiPOST(apiURL, body)
+	apiURL := fmt.Sprintf("%s/file_history/%s/%d/rollback", ecore.BuildBaseURLForContext(ctx), ecore.Seg(actorID), fileID)
+	respBytes, err := ecore.PapiPOST(ctx, apiURL, body)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("[Error] rollback file: %v", err)), nil
 	}
@@ -142,13 +142,13 @@ func handleListTrash(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToo
 	if envName == "" {
 		envName = "develop"
 	}
-	envID, err := resolveEnvID(actorID, envName)
+	envID, err := resolveEnvID(ctx, actorID, envName)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("[Error] resolve env: %v", err)), nil
 	}
 
-	apiURL := fmt.Sprintf("%s/file_history/trash/%s/%d", ecore.BuildBaseURL(), ecore.Seg(actorID), envID)
-	respBytes, err := ecore.PapiGET(apiURL)
+	apiURL := fmt.Sprintf("%s/file_history/trash/%s/%d", ecore.BuildBaseURLForContext(ctx), ecore.Seg(actorID), envID)
+	respBytes, err := ecore.PapiGET(ctx, apiURL)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("[Error] list trash: %v", err)), nil
 	}
@@ -177,8 +177,8 @@ func handleRestoreFromTrash(ctx context.Context, req mcp.CallToolRequest) (*mcp.
 	}
 
 	body, _ := json.Marshal(map[string]string{"id": objectID})
-	apiURL := fmt.Sprintf("%s/file_history/trash/%s/restore", ecore.BuildBaseURL(), ecore.Seg(actorID))
-	respBytes, err := ecore.PapiPOST(apiURL, body)
+	apiURL := fmt.Sprintf("%s/file_history/trash/%s/restore", ecore.BuildBaseURLForContext(ctx), ecore.Seg(actorID))
+	respBytes, err := ecore.PapiPOST(ctx, apiURL, body)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("[Error] restore from trash: %v", err)), nil
 	}

--- a/plugins/simulator/mcp-server/internal/engines/smartform/pull.go
+++ b/plugins/simulator/mcp-server/internal/engines/smartform/pull.go
@@ -61,8 +61,8 @@ func hashSource(s string) string {
 
 // ---- Fetch helpers ----
 
-func fetchAppEnvs(actorID string) ([]appEnvItem, error) {
-	body, err := ecore.PapiGET(fmt.Sprintf("%s/applications/envs/%s", ecore.BuildBaseURL(), ecore.Seg(actorID)))
+func fetchAppEnvs(ctx context.Context, actorID string) ([]appEnvItem, error) {
+	body, err := ecore.PapiGET(ctx, fmt.Sprintf("%s/applications/envs/%s", ecore.BuildBaseURLForContext(ctx), ecore.Seg(actorID)))
 	if err != nil {
 		return nil, err
 	}
@@ -75,8 +75,8 @@ func fetchAppEnvs(actorID string) ([]appEnvItem, error) {
 	return resp.Data, nil
 }
 
-func fetchEnvStruct(actorID string, envID int) (*appTreeNode, error) {
-	body, err := ecore.PapiGET(fmt.Sprintf("%s/app_content/struct/%s/%d", ecore.BuildBaseURL(), ecore.Seg(actorID), envID))
+func fetchEnvStruct(ctx context.Context, actorID string, envID int) (*appTreeNode, error) {
+	body, err := ecore.PapiGET(ctx, fmt.Sprintf("%s/app_content/struct/%s/%d", ecore.BuildBaseURLForContext(ctx), ecore.Seg(actorID), envID))
 	if err != nil {
 		return nil, err
 	}
@@ -158,7 +158,7 @@ func handlePullSmartForm(ctx context.Context, req mcp.CallToolRequest) (*mcp.Cal
 		return r, nil
 	}
 
-	envs, err := fetchAppEnvs(actorID)
+	envs, err := fetchAppEnvs(ctx, actorID)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("[Error] fetch envs: %v", err)), nil
 	}
@@ -175,7 +175,7 @@ func handlePullSmartForm(ctx context.Context, req mcp.CallToolRequest) (*mcp.Cal
 
 	baseDir := ecore.ResolvePath(actorID)
 	for _, env := range envs {
-		tree, err := fetchEnvStruct(actorID, env.ID)
+		tree, err := fetchEnvStruct(ctx, actorID, env.ID)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("[Error] fetch struct for env %q (id=%d): %v", env.Title, env.ID, err)), nil
 		}

--- a/plugins/simulator/mcp-server/internal/engines/smartform/push.go
+++ b/plugins/simulator/mcp-server/internal/engines/smartform/push.go
@@ -93,7 +93,7 @@ func handlePushSmartForm(ctx context.Context, req mcp.CallToolRequest) (*mcp.Cal
 	// map and the env root folder id. Re-fetch the env tree to backfill them
 	// so creates can resolve parent ids — no force-repull required.
 	if manifest.EnvRootFolderID == 0 || len(manifest.Folders) == 0 {
-		if err := backfillManifestFromServer(actorID, &manifest); err != nil {
+		if err := backfillManifestFromServer(ctx, actorID, &manifest); err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("[Error] backfill manifest: %v", err)), nil
 		}
 	}
@@ -178,7 +178,7 @@ func handlePushSmartForm(ctx context.Context, req mcp.CallToolRequest) (*mcp.Cal
 		return mcp.NewToolResultText(string(out)), nil
 	}
 
-	apiURL := fmt.Sprintf("%s/app_content/%s", ecore.BuildBaseURL(), ecore.Seg(actorID))
+	apiURL := fmt.Sprintf("%s/app_content/%s", ecore.BuildBaseURLForContext(ctx), ecore.Seg(actorID))
 
 	// Phase 1 — create missing folders, parents first, one POST per folder so
 	// we can pair the returned id back to its path deterministically.
@@ -194,7 +194,7 @@ func handlePushSmartForm(ctx context.Context, req mcp.CallToolRequest) (*mcp.Cal
 			Title:    filepath.Base(relPath),
 		}}
 		body, _ := json.Marshal(batch)
-		respBytes, err := ecore.PapiPOST(apiURL, body)
+		respBytes, err := ecore.PapiPOST(ctx, apiURL, body)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("[Error] create folder %q: %v", relPath, err)), nil
 		}
@@ -224,7 +224,7 @@ func handlePushSmartForm(ctx context.Context, req mcp.CallToolRequest) (*mcp.Cal
 			})
 		}
 		body, _ := json.Marshal(batch)
-		respBytes, err := ecore.PapiPOST(apiURL, body)
+		respBytes, err := ecore.PapiPOST(ctx, apiURL, body)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("[Error] create files: %v", err)), nil
 		}
@@ -277,7 +277,7 @@ func handlePushSmartForm(ctx context.Context, req mcp.CallToolRequest) (*mcp.Cal
 			})
 		}
 		body, _ := json.Marshal(batch)
-		if _, err := ecore.PapiPUT(apiURL, body); err != nil {
+		if _, err := ecore.PapiPUT(ctx, apiURL, body); err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("[Error] update files: %v", err)), nil
 		}
 		for _, relPath := range modifiedFilePaths {
@@ -416,11 +416,11 @@ func defaultMimeType(relPath string) string {
 // backfillManifestFromServer fetches the env struct and rebuilds the folder
 // map + env root folder id on a manifest pulled before folder tracking was
 // added. Files already in the manifest are left untouched.
-func backfillManifestFromServer(actorID string, manifest *smartFormManifest) error {
+func backfillManifestFromServer(ctx context.Context, actorID string, manifest *smartFormManifest) error {
 	if manifest.EnvID == 0 {
 		return fmt.Errorf("manifest has no envId — run pullSmartForm to refresh")
 	}
-	tree, err := fetchEnvStruct(actorID, manifest.EnvID)
+	tree, err := fetchEnvStruct(ctx, actorID, manifest.EnvID)
 	if err != nil {
 		return err
 	}

--- a/plugins/simulator/mcp-server/internal/engines/smartform/releases.go
+++ b/plugins/simulator/mcp-server/internal/engines/smartform/releases.go
@@ -10,8 +10,8 @@ import (
 )
 
 // resolveEnvID finds an env by title (case-insensitive) and returns its numeric ID.
-func resolveEnvID(actorID, envTitle string) (int, error) {
-	envs, err := fetchAppEnvs(actorID)
+func resolveEnvID(ctx context.Context, actorID, envTitle string) (int, error) {
+	envs, err := fetchAppEnvs(ctx, actorID)
 	if err != nil {
 		return 0, err
 	}
@@ -52,11 +52,11 @@ func handleDeploySmartForm(ctx context.Context, req mcp.CallToolRequest) (*mcp.C
 		targetEnv = "production"
 	}
 
-	sourceID, err := resolveEnvID(actorID, sourceEnv)
+	sourceID, err := resolveEnvID(ctx, actorID, sourceEnv)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("[Error] resolve source env: %v", err)), nil
 	}
-	targetID, err := resolveEnvID(actorID, targetEnv)
+	targetID, err := resolveEnvID(ctx, actorID, targetEnv)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("[Error] resolve target env: %v", err)), nil
 	}
@@ -65,8 +65,8 @@ func handleDeploySmartForm(ctx context.Context, req mcp.CallToolRequest) (*mcp.C
 		"sourceEnvId": sourceID,
 		"targetEnvId": targetID,
 	})
-	apiURL := fmt.Sprintf("%s/applications/deploy/%s", ecore.BuildBaseURL(), ecore.Seg(actorID))
-	respBytes, err := ecore.PapiPOST(apiURL, body)
+	apiURL := fmt.Sprintf("%s/applications/deploy/%s", ecore.BuildBaseURLForContext(ctx), ecore.Seg(actorID))
+	respBytes, err := ecore.PapiPOST(ctx, apiURL, body)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("[Error] deploy: %v", err)), nil
 	}
@@ -114,13 +114,13 @@ func handleListReleases(ctx context.Context, req mcp.CallToolRequest) (*mcp.Call
 	if envName == "" {
 		envName = "production"
 	}
-	envID, err := resolveEnvID(actorID, envName)
+	envID, err := resolveEnvID(ctx, actorID, envName)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("[Error] resolve env: %v", err)), nil
 	}
 
-	apiURL := fmt.Sprintf("%s/releases/%s?envId=%d", ecore.BuildBaseURL(), ecore.Seg(actorID), envID)
-	respBytes, err := ecore.PapiGET(apiURL)
+	apiURL := fmt.Sprintf("%s/releases/%s?envId=%d", ecore.BuildBaseURLForContext(ctx), ecore.Seg(actorID), envID)
+	respBytes, err := ecore.PapiGET(ctx, apiURL)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("[Error] list releases: %v", err)), nil
 	}
@@ -167,8 +167,8 @@ func handleDiffReleases(ctx context.Context, req mcp.CallToolRequest) (*mcp.Call
 	}
 
 	apiURL := fmt.Sprintf("%s/releases/%s/%s/diff?vs=%s",
-		ecore.BuildBaseURL(), ecore.Seg(actorID), ecore.Seg(releaseID), ecore.Seg(vsReleaseID))
-	respBytes, err := ecore.PapiGET(apiURL)
+		ecore.BuildBaseURLForContext(ctx), ecore.Seg(actorID), ecore.Seg(releaseID), ecore.Seg(vsReleaseID))
+	respBytes, err := ecore.PapiGET(ctx, apiURL)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("[Error] diff releases: %v", err)), nil
 	}
@@ -197,8 +197,8 @@ func handleRollbackRelease(ctx context.Context, req mcp.CallToolRequest) (*mcp.C
 		return mcp.NewToolResultError("[Error] releaseId is required"), nil
 	}
 
-	apiURL := fmt.Sprintf("%s/releases/%s/%s/rollback", ecore.BuildBaseURL(), ecore.Seg(actorID), ecore.Seg(releaseID))
-	respBytes, err := ecore.PapiPOST(apiURL, []byte("{}"))
+	apiURL := fmt.Sprintf("%s/releases/%s/%s/rollback", ecore.BuildBaseURLForContext(ctx), ecore.Seg(actorID), ecore.Seg(releaseID))
+	respBytes, err := ecore.PapiPOST(ctx, apiURL, []byte("{}"))
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("[Error] rollback: %v", err)), nil
 	}

--- a/plugins/simulator/mcp-server/internal/tools/actors.go
+++ b/plugins/simulator/mcp-server/internal/tools/actors.go
@@ -19,7 +19,7 @@ func resolveActorFormID(ctx context.Context, args map[string]any, c *apiclient.C
 	if name == "" {
 		return nil // neither given — the path check reports the missing formId
 	}
-	accID := c.WorkspaceID()
+	accID := c.WorkspaceIDForContext(ctx)
 	if accID == "" {
 		return fmt.Errorf("resolving formName needs a workspace — run set-workspace or pass formId")
 	}

--- a/plugins/simulator/mcp-server/internal/tools/build.go
+++ b/plugins/simulator/mcp-server/internal/tools/build.go
@@ -47,6 +47,15 @@ func BuildAll(s *server.MCPServer, c *apiclient.Client, prof config.Profile, ins
 	registerAuth(s, c, prof, insecure)
 }
 
+// BuildAllStateless registers only the curated API tools (no login / set-workspace
+// / set-environment helpers). Use for embedded SSE deployments where credentials
+// arrive per request via ctx and the server must not read or write .env.
+func BuildAllStateless(s *server.MCPServer, c *apiclient.Client) {
+	for _, op := range allOps() {
+		register(s, c, op)
+	}
+}
+
 // Count reports how many curated API tools are registered (auth helpers excluded).
 func Count() int { return len(allOps()) }
 

--- a/plugins/simulator/mcp-server/internal/tools/graph.go
+++ b/plugins/simulator/mcp-server/internal/tools/graph.go
@@ -16,7 +16,7 @@ func resolveHierarchyEdgeType(ctx context.Context, args map[string]any, c *apicl
 	if _, ok := args["edgeTypeId"]; ok {
 		return nil // explicit edgeTypeId wins
 	}
-	accID := c.WorkspaceID()
+	accID := c.WorkspaceIDForContext(ctx)
 	if accID == "" {
 		return fmt.Errorf("resolving the hierarchy edge type needs a workspace — run set-workspace or pass edgeTypeId")
 	}

--- a/plugins/simulator/mcp-server/internal/tools/op.go
+++ b/plugins/simulator/mcp-server/internal/tools/op.go
@@ -139,7 +139,7 @@ func makeHandler(c *apiclient.Client, op Operation) server.ToolHandlerFunc {
 			val, present := args[p.Name]
 			// accId defaults to the configured workspace when the caller omits it.
 			if !present && p.Name == "accId" {
-				if ws := c.WorkspaceID(); ws != "" {
+				if ws := c.WorkspaceIDForContext(ctx); ws != "" {
 					val, present = ws, true
 				}
 			}


### PR DESCRIPTION
## Summary

- Extract MCP server assembly from `cmd/server/main.go` into a new `app/mcpserver` package so external processes (e.g. claude-code-api's SSE transport) can embed the same server in their own binary and pick any transport — not just stdio. `cmd/server/main.go` shrinks to env/flag parsing + `mcpserver.New()`.
- Add a **stateless mode** where `Authorization`, workspace id and API base URL arrive per request via `context.Context`. New helpers: `apiclient.WithAuthorization` / `WithWorkspaceID` / `WithBaseURL` (and the matching `*FromContext` accessors), `apiclient.Client.WorkspaceIDForContext`, `ecore.SetStateless` / `AuthHeaderForContext` / `BuildBaseURLForContext` / `WorkspaceIDForContext`, and `tools.BuildAllStateless`.
- In stateless mode the `.env`-mutating helpers (`login`, `set-workspace`, `set-environment`) are not registered, `auth.Load()` and `WORKSPACE_ID` env fallbacks are suppressed, and `ecore.PapiGET/POST/PUT` now thread ctx so every engine call carries the per-request token. The stdio path (`cmd/server`) keeps the existing stateful behaviour by default.

## Test plan

- [x] `make build` clean
- [x] `make vet` clean
- [ ] `make lint` (advisory)
- [ ] Manual: stdio path still authenticates via `.env` and honours `WORKSPACE_ID` (`make run-local`, run a curated tool, run an engine tool).
- [ ] Manual: embed via `mcpserver.New(Options{Stateless: true})` from an SSE host, attach `apiclient.WithAuthorization` / `WithWorkspaceID` to ctx and verify a tool call routes with the per-request token; confirm `login` / `set-workspace` are absent.