### PR TITLE
feat(mcp): per-actor scoped tools on the embeddable server (app/mcpserver)

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ the actor/node items.)
 | Transactions  | `createTransaction` `finalizeTransaction` `atomCreateTransaction` `getTransactions` `getAccountTransactions` `getTransactionByRef` `createTransfer` `createTransferTwoStep` `getTransfer` `getTransferByRef` `filterTransfers` |
 | Graph (links) | `createLink` `massLink` `getEdge` `updateEdge` `deleteEdge` `existLink` `deleteEdgesByNodes` `getEdgeTypes` `getLayerActors` `getRelatedActors` `getLinkedActors` `getActorLinks` `manageLayerActors` `moveActors` `existLayerElement` `cleanGraphLayer` `layerStats` |
 | Reactions     | `createReaction` `updateReaction` `deleteReaction` `getReactions` `getReactionsStats` `markReactionsRead` `getPinnedReactions` `togglePinnedReaction` |
-| Attachments   | `getAttachments` `addAttachments` `updateAttachment` `removeAttachments` `uploadBase64` |
+| Attachments   | `getAttachments` `getActorAttachments` `addAttachments` `updateAttachment` `removeAttachments` `uploadBase64` |
 | Search        | `searchAll` (global text/semantic search across actors & users)                        |
 | Users         | `getUsers` `getUser` `searchUsers` (workspace members — resolve a userId/groupId for sharing) |
 | Setup         | `set-environment` (cloud preset or custom/local URL) `login` `getWorkspaces` `set-workspace` (by accId or name) |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -244,7 +244,7 @@ backend operation, with typed parameters:
 | Transactions  | `createTransaction` `finalizeTransaction` `atomCreateTransaction` `getTransactions` `getAccountTransactions` `getTransactionByRef` `createTransfer` `createTransferTwoStep` `getTransfer` `getTransferByRef` `filterTransfers` |
 | Graph (links) | `createLink` `massLink` `getEdge` `updateEdge` `deleteEdge` `existLink` `deleteEdgesByNodes` `getEdgeTypes` `getLayerActors` `getRelatedActors` `getLinkedActors` `getActorLinks` `manageLayerActors` `moveActors` `existLayerElement` `cleanGraphLayer` `layerStats` |
 | Reactions     | `createReaction` `updateReaction` `deleteReaction` `getReactions` `getReactionsStats` `markReactionsRead` `getPinnedReactions` `togglePinnedReaction` |
-| Attachments   | `getAttachments` `addAttachments` `updateAttachment` `removeAttachments` `uploadBase64` |
+| Attachments   | `getAttachments` `getActorAttachments` `addAttachments` `updateAttachment` `removeAttachments` `uploadBase64` |
 | Search        | `searchAll` (global text/semantic search across actors & users)                        |
 | Users         | `getUsers` `getUser` `searchUsers` (workspace members — resolve a userId/groupId for sharing) |
 | Setup         | `set-environment` (cloud preset or custom/local URL; derives the account URL from the gateway's public config) `login` `getWorkspaces` `set-workspace` (by accId or name) |

--- a/plugins/simulator/mcp-server/app/mcpserver/actor.go
+++ b/plugins/simulator/mcp-server/app/mcpserver/actor.go
@@ -1,0 +1,49 @@
+package mcpserver
+
+import (
+	"errors"
+
+	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/internal/apiclient"
+	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/internal/config"
+	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/internal/engines/ecore"
+	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/internal/tools"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// NewActorServer builds a per-actor MCP server: the curated tools scoped to one
+// actor, with the actor's identity ({actorId}, link source, access-rule object)
+// pre-bound and hidden from the tool schemas — the model cannot target a
+// different actor. It is always stateless: Authorization, workspace id and API
+// base URL arrive per request via ctx (WithAuthorization / WithWorkspaceID /
+// WithBaseURL), and no .env / login helpers are registered. Serve it over any
+// transport; the hosting gateway routes /mcp/actors/{actorId} to one of these.
+func NewActorServer(actorID string, opts Options) (*server.MCPServer, Info, error) {
+	prof, err := config.Resolve(opts.Profile)
+	if err != nil {
+		return nil, Info{}, err
+	}
+	// Stateless: auth/workspace/baseURL come from request ctx. A non-nil authHeader
+	// surfaces misuse if a request arrives without an Authorization on the ctx.
+	authHeader := func() (string, error) {
+		return "", errors.New("stateless mode: Authorization header missing on request")
+	}
+	client := apiclient.New(prof.APIBaseURL, "", authHeader, opts.Insecure)
+
+	name := opts.Name
+	if name == "" {
+		name = defaultName
+	}
+	version := opts.Version
+	if version == "" {
+		version = defaultVersion
+	}
+
+	s := server.NewMCPServer(name, version)
+	ecore.SetStateless(true)
+	tools.BuildActorScoped(s, client, actorID)
+	return s, Info{
+		Profile:    prof.Name,
+		APIBaseURL: prof.APIBaseURL,
+		AccountURL: prof.AccountURL,
+	}, nil
+}

--- a/plugins/simulator/mcp-server/app/mcpserver/actor_test.go
+++ b/plugins/simulator/mcp-server/app/mcpserver/actor_test.go
@@ -1,0 +1,108 @@
+package mcpserver_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	mcpserver "github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/app/mcpserver"
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// End-to-end over the in-process transport: a real MCP client performs the
+// initialize + tools/list handshake against NewActorServer and receives exactly
+// the per-actor specification — actor-scoped tools (read + CRUD), with the actor's
+// identity ({actorId}, link source, access-rule object) hidden from every schema,
+// and no .env/login helpers (stateless). tools/list issues no HTTP.
+func TestNewActorServerServesPerActorSpec(t *testing.T) {
+	srv, info, err := mcpserver.NewActorServer("act-XYZ", mcpserver.Options{})
+	if err != nil {
+		t.Fatalf("NewActorServer: %v", err)
+	}
+	if info.APIBaseURL == "" {
+		t.Error("Info.APIBaseURL should be resolved")
+	}
+
+	cli, err := client.NewInProcessClient(srv)
+	if err != nil {
+		t.Fatalf("new in-process client: %v", err)
+	}
+	defer func() { _ = cli.Close() }()
+
+	ctx := context.Background()
+	if err := cli.Start(ctx); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	var init mcp.InitializeRequest
+	init.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+	init.Params.ClientInfo = mcp.Implementation{Name: "spec-test", Version: "0"}
+	if _, err := cli.Initialize(ctx, init); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+
+	lt, err := cli.ListTools(ctx, mcp.ListToolsRequest{})
+	if err != nil {
+		t.Fatalf("tools/list: %v", err)
+	}
+	byName := make(map[string]mcp.Tool, len(lt.Tools))
+	for _, tool := range lt.Tools {
+		byName[tool.Name] = tool
+	}
+
+	// actor-scoped tools are served — reads, finance/reaction CRUD, graph
+	// relationship tools, link CRUD, attachments (read + manage), access rules.
+	for _, want := range []string{
+		"getActor", "getAccounts", "createAccount", "updateAccount", "deleteAccount",
+		"getReactions", "createReaction", "updateReaction", "deleteReaction",
+		"getRelatedActors", "getLinkedActors", "getActorLinks",
+		"createLink", "existLink", "updateEdge", "deleteEdge",
+		"getActorAttachments", "uploadBase64", "addAttachments", "removeAttachments",
+		"getAccessRules", "saveAccessRules",
+	} {
+		if _, ok := byName[want]; !ok {
+			t.Errorf("per-actor spec is missing tool %q", want)
+		}
+	}
+	// workspace-wide tools and .env/login helpers are not served.
+	for _, notWant := range []string{
+		"getCurrencies", "getWorkspaces", "createForm",
+		"login", "set-workspace", "set-environment",
+	} {
+		if _, ok := byName[notWant]; ok {
+			t.Errorf("per-actor spec must not expose %q", notWant)
+		}
+	}
+
+	// the bound actorId must not appear in any served tool's input schema.
+	for name, tool := range byName {
+		if schemaContains(t, tool, `"actorId"`) {
+			t.Errorf("tool %q leaks the bound actorId in its schema", name)
+		}
+	}
+	// access-rule tools are pinned to the actor: objType/objId are bound + hidden.
+	for _, name := range []string{"getAccessRules", "saveAccessRules"} {
+		for _, hidden := range []string{`"objType"`, `"objId"`} {
+			if schemaContains(t, byName[name], hidden) {
+				t.Errorf("tool %q leaks bound %s in its schema", name, hidden)
+			}
+		}
+	}
+	// link create/check is pinned to the actor as source.
+	for _, name := range []string{"createLink", "existLink"} {
+		if schemaContains(t, byName[name], `"source"`) {
+			t.Errorf("tool %q leaks the bound source in its schema", name)
+		}
+	}
+}
+
+func schemaContains(t *testing.T, tool mcp.Tool, needle string) bool {
+	t.Helper()
+	raw, err := json.Marshal(tool.InputSchema)
+	if err != nil {
+		t.Fatalf("marshal %s schema: %v", tool.Name, err)
+	}
+	return strings.Contains(string(raw), needle)
+}

--- a/plugins/simulator/mcp-server/internal/tools/actor_server.go
+++ b/plugins/simulator/mcp-server/internal/tools/actor_server.go
@@ -1,0 +1,118 @@
+package tools
+
+import (
+	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/internal/apiclient"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// actorScopedOps is the subset of the curated set that operates on a single
+// actor — every operation whose path carries an {actorId} placeholder
+// (getActor, getAccounts, getReactions, createReaction, getRelatedActors, …).
+// These are the tools that make sense on a per-actor MCP endpoint; workspace-wide
+// tools (create form, list all actors) are intentionally excluded.
+func actorScopedOps() []Operation {
+	var ops []Operation
+	for _, op := range allOps() {
+		for _, p := range op.Params {
+			if p.In == InPath && p.Name == "actorId" {
+				ops = append(ops, op)
+				break
+			}
+		}
+	}
+	return ops
+}
+
+// opsNamed returns the curated ops with the given names, in allOps order. Used to
+// pull specific tools into the per-actor server with a tailored binding (their
+// path is not keyed by {actorId}, so actorScopedOps does not select them).
+func opsNamed(names ...string) []Operation {
+	want := make(map[string]bool, len(names))
+	for _, n := range names {
+		want[n] = true
+	}
+	var ops []Operation
+	for _, op := range allOps() {
+		if want[op.Name] {
+			ops = append(ops, op)
+		}
+	}
+	return ops
+}
+
+// injectActorIntoItems sets actorId on every object in the root-array `items`
+// argument. The per-actor link/unlink tools (addAttachments / removeAttachments)
+// use it so a request targets only this actor — the model supplies just attachId.
+func injectActorIntoItems(args map[string]any, actorID string) {
+	items, ok := args["items"].([]any)
+	if !ok {
+		return
+	}
+	for _, it := range items {
+		if m, ok := it.(map[string]any); ok {
+			m["actorId"] = actorID
+		}
+	}
+}
+
+// registerActorItems registers a body-root-array op (addAttachments /
+// removeAttachments) for the per-actor server: actorID is injected into every
+// items[] element at call time, and the items description is rewritten so the
+// model supplies only the file id — never the actor. The shared op is copied, not
+// mutated.
+func registerActorItems(s *server.MCPServer, c *apiclient.Client, op Operation, actorID string) {
+	local := op
+	local.Params = append([]Param(nil), op.Params...)
+	for i := range local.Params {
+		if local.Params[i].In == InBodyRoot {
+			local.Params[i].Desc = "Array (min 1) of {attachId:int (from uploadBase64 / getActorAttachments)}. " +
+				"The file is linked to this actor automatically — do not include actorId."
+		}
+	}
+	rewrite := func(args map[string]any) { injectActorIntoItems(args, actorID) }
+	s.AddTool(mcp.NewTool(local.Name, toolOptions(local, nil)...), makeHandlerRewrite(c, local, nil, rewrite))
+}
+
+// BuildActorScoped registers the per-actor tool set on s: the curated tools scoped
+// to a single actor, all with the actor's identity pre-bound and hidden from the
+// tool schemas, so the model cannot target a different actor. Auth, workspace and
+// API base URL arrive per request via ctx (apiclient.WithAuthorization /
+// WithWorkspaceID / WithBaseURL); no .env / login helpers are registered. The
+// hosting gateway routes /mcp/actors/{actorId} to a server built this way — see
+// app/mcpserver.NewActorServer.
+func BuildActorScoped(s *server.MCPServer, c *apiclient.Client, actorID string) {
+	// (1) Tools whose path is keyed by {actorId}: bind it to this actor.
+	idBound := map[string]any{"actorId": actorID}
+	for _, op := range actorScopedOps() {
+		registerBound(s, c, op, idBound)
+	}
+
+	// (2) Generic access-rule tools, pinned to this actor (objType="actor",
+	// objId=<actor>, both hidden) — manage this actor's access rules.
+	accessBound := map[string]any{"objType": "actor", "objId": actorID}
+	for _, op := range opsNamed("getAccessRules", "saveAccessRules") {
+		registerBound(s, c, op, accessBound)
+	}
+
+	// (3) Link CRUD: create/check outgoing links from this actor (source bound +
+	// hidden); edit/delete the actor's existing edges by id (ids come from
+	// getActorLinks — backend access rules still apply).
+	sourceBound := map[string]any{"source": actorID}
+	for _, op := range opsNamed("createLink", "existLink") {
+		registerBound(s, c, op, sourceBound)
+	}
+	for _, op := range opsNamed("updateEdge", "deleteEdge") {
+		register(s, c, op)
+	}
+
+	// (4) Attachment management for this actor: upload a file to the workspace
+	// (accId from the request context), then link/unlink it to this actor — the
+	// actorId is injected into every items[] entry, so the model passes only attachId.
+	for _, op := range opsNamed("uploadBase64") {
+		register(s, c, op)
+	}
+	for _, op := range opsNamed("addAttachments", "removeAttachments") {
+		registerActorItems(s, c, op, actorID)
+	}
+}

--- a/plugins/simulator/mcp-server/internal/tools/actor_server_test.go
+++ b/plugins/simulator/mcp-server/internal/tools/actor_server_test.go
@@ -1,0 +1,95 @@
+package tools
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// actorScopedOps must contain only operations that carry an {actorId} path
+// placeholder, include the obvious per-actor reads + the actor's attachments, and
+// exclude workspace-wide tools (which take accId, not actorId).
+func TestActorScopedOps(t *testing.T) {
+	ops := actorScopedOps()
+	if len(ops) == 0 {
+		t.Fatal("actorScopedOps() is empty")
+	}
+
+	byName := map[string]Operation{}
+	for _, op := range ops {
+		byName[op.Name] = op
+		ok := false
+		for _, p := range op.Params {
+			if p.In == InPath && p.Name == "actorId" {
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			t.Errorf("%s selected but has no {actorId} path param", op.Name)
+		}
+	}
+
+	for _, want := range []string{
+		"getActor", "getAccounts", "createAccount", "updateAccount", "deleteAccount",
+		"getReactions", "createReaction",
+		"getRelatedActors", "getLinkedActors", "getActorLinks",
+		"getActorAttachments",
+	} {
+		if _, ok := byName[want]; !ok {
+			t.Errorf("expected actor-scoped op %q to be included", want)
+		}
+	}
+	for _, notWant := range []string{"getCurrencies", "getWorkspaces"} {
+		if _, ok := byName[notWant]; ok {
+			t.Errorf("workspace-wide op %q must not be actor-scoped", notWant)
+		}
+	}
+}
+
+// BuildActorScoped registers the per-actor set onto a server without panicking.
+func TestBuildActorScoped(t *testing.T) {
+	c, _ := setup(t)
+	s := server.NewMCPServer("simulator", "test")
+	BuildActorScoped(s, c, "act-1") // must not panic / double-register
+}
+
+// The per-actor link/unlink handler injects the session actor into every items[]
+// element, so the model supplies only attachId and the request targets this actor.
+func TestActorItemsInjectsActorID(t *testing.T) {
+	c, rec := setup(t)
+	op := opByName(t, "addAttachments")
+	h := makeHandlerRewrite(c, op, nil, func(args map[string]any) {
+		injectActorIntoItems(args, "act-7")
+	})
+
+	var req mcp.CallToolRequest
+	req.Params.Name = op.Name
+	req.Params.Arguments = map[string]any{
+		"items": []any{map[string]any{"attachId": float64(5521)}}, // model sends only attachId
+	}
+	res, err := h(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error result: %+v", res.Content)
+	}
+
+	arr, ok := rec.body.([]any)
+	if !ok || len(arr) != 1 {
+		t.Fatalf("request body is not a 1-element array: %#v", rec.body)
+	}
+	item, ok := arr[0].(map[string]any)
+	if !ok {
+		t.Fatalf("item is not an object: %#v", arr[0])
+	}
+	if item["actorId"] != "act-7" {
+		t.Errorf("items[0].actorId = %v, want act-7 (injected)", item["actorId"])
+	}
+	if item["attachId"] != float64(5521) {
+		t.Errorf("items[0].attachId = %v, want 5521 (preserved)", item["attachId"])
+	}
+}

--- a/plugins/simulator/mcp-server/internal/tools/attachments.go
+++ b/plugins/simulator/mcp-server/internal/tools/attachments.go
@@ -21,6 +21,15 @@ var attachmentOps = []Operation{
 		},
 	},
 	{
+		Name: "getActorAttachments", Method: "GET", Path: "/attachments/actor/{actorId}",
+		Summary: "List the files (attachments) linked to a specific actor.",
+		Params: []Param{
+			{Name: "actorId", In: InPath, Type: "string", Required: true, Desc: "Actor whose attachments to list."},
+			{Name: "limit", In: InQuery, Type: "number", Desc: "Page size (1-100, default 100)."},
+			{Name: "offset", In: InQuery, Type: "number", Desc: "Page offset (default 0)."},
+		},
+	},
+	{
 		Name: "addAttachments", Method: "POST", Path: "/attachments/{accId}",
 		Summary: "Link one or more existing uploaded files to actors/reactions in a workspace.",
 		Params: []Param{

--- a/plugins/simulator/mcp-server/internal/tools/op.go
+++ b/plugins/simulator/mcp-server/internal/tools/op.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/url"
 	"strings"
 
@@ -90,11 +91,29 @@ func fieldFilterParam(example string) Param {
 
 // register builds the MCP tool for op and wires its handler to the client.
 func register(s *server.MCPServer, c *apiclient.Client, op Operation) {
+	registerBound(s, c, op, nil)
+}
+
+// registerBound is register with pre-bound argument values. Params named in bound
+// are NOT exposed in the tool's input schema (the model cannot set them) and are
+// injected authoritatively at call time. Used to bind actor-scoped params — e.g.
+// `actorId` taken from the per-actor URL — so a per-actor tool takes only the
+// meaningful arguments.
+func registerBound(s *server.MCPServer, c *apiclient.Client, op Operation, bound map[string]any) {
+	s.AddTool(mcp.NewTool(op.Name, toolOptions(op, bound)...), makeHandlerBound(c, op, bound))
+}
+
+// toolOptions builds the MCP tool options for op, skipping any pre-bound param
+// (hidden from the model).
+func toolOptions(op Operation, bound map[string]any) []mcp.ToolOption {
 	opts := []mcp.ToolOption{mcp.WithDescription(op.Summary)}
 	for _, p := range op.Params {
+		if _, ok := bound[p.Name]; ok {
+			continue
+		}
 		opts = append(opts, paramOption(p))
 	}
-	s.AddTool(mcp.NewTool(op.Name, opts...), makeHandler(c, op))
+	return opts
 }
 
 // paramOption converts a Param into the matching mcp.With* tool option.
@@ -123,8 +142,40 @@ func paramOption(p Param) mcp.ToolOption {
 
 // makeHandler returns the tool handler that assembles and issues the request.
 func makeHandler(c *apiclient.Client, op Operation) server.ToolHandlerFunc {
+	return makeHandlerBound(c, op, nil)
+}
+
+// makeHandlerBound is makeHandler with pre-bound argument values injected
+// (authoritative) before resolution and request assembly.
+func makeHandlerBound(c *apiclient.Client, op Operation, bound map[string]any) server.ToolHandlerFunc {
+	return makeHandlerRewrite(c, op, bound, nil)
+}
+
+// prepareArgs applies the pre-bound values (authoritative) and an optional
+// rewrite hook to the caller's arguments, returning the (possibly newly
+// allocated) map. A no-op when there is nothing to inject.
+func prepareArgs(args, bound map[string]any, rewrite func(map[string]any)) map[string]any {
+	if len(bound) == 0 && rewrite == nil {
+		return args
+	}
+	if args == nil {
+		args = map[string]any{}
+	}
+	maps.Copy(args, bound)
+	if rewrite != nil {
+		rewrite(args)
+	}
+	return args
+}
+
+// makeHandlerRewrite is makeHandlerBound with an extra hook that may mutate the
+// assembled args after pre-bound injection and before Resolve. It exists for the
+// per-actor server, where a bound identity must be injected into each element of
+// a root-array body (e.g. setting actorId on every attachment link item) — which
+// a flat key bind cannot express. rewrite may be nil.
+func makeHandlerRewrite(c *apiclient.Client, op Operation, bound map[string]any, rewrite func(map[string]any)) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		args := req.GetArguments()
+		args := prepareArgs(req.GetArguments(), bound, rewrite)
 		if op.Resolve != nil {
 			if err := op.Resolve(ctx, args, c); err != nil {
 				return mcp.NewToolResultError(fmt.Sprintf("[Error] %s: %v", op.Name, err)), nil

--- a/plugins/simulator/mcp-server/internal/tools/op_bound_test.go
+++ b/plugins/simulator/mcp-server/internal/tools/op_bound_test.go
@@ -1,0 +1,44 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// A pre-bound param is hidden from the tool schema and injected at call time, so
+// the model never sets it and a Required param (actorId) is satisfied by the bind.
+func TestBoundArgHiddenAndInjected(t *testing.T) {
+	op := opByName(t, "getActor") // GET /actors/{actorId}, actorId InPath + Required
+	bound := map[string]any{"actorId": "bound-1"}
+
+	// (1) hidden — the marshaled input schema has no actorId property.
+	tool := mcp.NewTool(op.Name, toolOptions(op, bound)...)
+	raw, err := json.Marshal(tool)
+	if err != nil {
+		t.Fatalf("marshal tool: %v", err)
+	}
+	if strings.Contains(string(raw), `"actorId"`) {
+		t.Errorf("bound actorId must be hidden from the schema; tool = %s", raw)
+	}
+
+	// (2) injected — a call with NO actorId still resolves /actors/bound-1
+	//     (and the Required actorId is satisfied, i.e. no error).
+	c, rec := setup(t)
+	var req mcp.CallToolRequest
+	req.Params.Name = op.Name
+	req.Params.Arguments = map[string]any{} // model sends nothing
+	res, err := makeHandlerBound(c, op, bound)(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error (bound actorId should satisfy Required): %+v", res.Content)
+	}
+	if rec.path != "/actors/bound-1" {
+		t.Errorf("path = %s, want /actors/bound-1 (bound actorId injected)", rec.path)
+	}
+}

--- a/plugins/simulator/mcp-server/internal/tools/op_ctx_test.go
+++ b/plugins/simulator/mcp-server/internal/tools/op_ctx_test.go
@@ -1,0 +1,31 @@
+package tools
+
+import (
+	"context"
+	"testing"
+
+	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/internal/apiclient"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// When accId is omitted, the per-request workspace from the context (hosted) wins
+// over the Client's default workspace. setup()'s client default is "WS".
+func TestAccIdDefaultsFromContextWorkspace(t *testing.T) {
+	c, rec := setup(t)
+	ctx := apiclient.WithWorkspaceID(context.Background(), "CTXWS")
+
+	var req mcp.CallToolRequest
+	req.Params.Name = "getCurrencies"
+	req.Params.Arguments = map[string]any{} // no accId → defaulted
+
+	res, err := makeHandler(c, opByName(t, "getCurrencies"))(ctx, req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error result: %+v", res.Content)
+	}
+	if rec.path != "/currencies/CTXWS" {
+		t.Errorf("path = %s, want /currencies/CTXWS (ctx workspace overrides client default)", rec.path)
+	}
+}

--- a/plugins/simulator/mcp-server/internal/tools/testdata/papi-openapi.json
+++ b/plugins/simulator/mcp-server/internal/tools/testdata/papi-openapi.json
@@ -915,6 +915,48 @@
         }
       }
     },
+    "/papi/1.0/attachments/actor/{actorId}": {
+      "get": {
+        "operationId": "getActorAttachments",
+        "tags": [
+          "Attachments"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "in": "query",
+            "name": "limit",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "in": "query",
+            "name": "offset",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "actorId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      }
+    },
     "/papi/1.0/attachments/{attachId}": {
       "put": {
         "operationId": "updateAttachment",
@@ -3367,9 +3409,6 @@
                           "x",
                           "y"
                         ]
-                      },
-                      "mcp": {
-                        "type": "boolean"
                       }
                     }
                   },
@@ -3605,9 +3644,6 @@
                           "x",
                           "y"
                         ]
-                      },
-                      "mcp": {
-                        "type": "boolean"
                       }
                     }
                   },
@@ -3973,9 +4009,6 @@
                           "x",
                           "y"
                         ]
-                      },
-                      "mcp": {
-                        "type": "boolean"
                       }
                     }
                   },

--- a/plugins/simulator/skills/simulator-attachments/SKILL.md
+++ b/plugins/simulator/skills/simulator-attachments/SKILL.md
@@ -10,9 +10,9 @@ description: >
   comments that carry files use `simulator-reactions`.
 ---
 
-> **Curated tool names (v2 server):** `uploadBase64`, `getAttachments`, `addAttachments`,
-> `updateAttachment`, `removeAttachments`. Plus the engine tools `uploadActorPicture` /
-> `uploadActorPictureBulk` for actor avatars. Call them by these exact names.
+> **Curated tool names (v2 server):** `uploadBase64`, `getAttachments`, `getActorAttachments`,
+> `addAttachments`, `updateAttachment`, `removeAttachments`. Plus the engine tools
+> `uploadActorPicture` / `uploadActorPictureBulk` for actor avatars. Call them by these exact names.
 
 # Simulator.Company Files & Attachments Specialist
 
@@ -67,9 +67,13 @@ removeAttachments(accId="ws_xxx", items=[
 ## List & rename
 
 ```
-getAttachments(accId="ws_xxx", limit=50, orderBy="created_at", orderValue="DESC")
+getAttachments(accId="ws_xxx", limit=50, orderBy="created_at", orderValue="DESC")  # all files in the workspace
+getActorAttachments(actorId="<actor UUID>", limit=100)                             # only files linked to one actor
 updateAttachment(attachId=5521, title="Q3 report.pdf")
 ```
+
+> Use `getActorAttachments` when you want a single actor's files; `getAttachments` lists the
+> whole workspace. `getActorAttachments` is addressed by `actorId` (no `accId`).
 
 ## End-to-end: attach a PDF to an actor
 


### PR DESCRIPTION
Layers the **per-actor MCP** on top of the embeddable stateless server from #21, instead of duplicating its foundation. The hosting gateway (cc-api) routes `/mcp/actors/{actorId}` to one of these servers; the connecting user's credential/workspace/base-URL arrive per request via ctx.

## What

- **`app/mcpserver.NewActorServer(actorID, opts)`** — a stateless server exposing the curated tools **scoped to one actor**. Reuses the package's per-request ctx helpers (`WithAuthorization`/`WithWorkspaceID`/`WithBaseURL`) and stateless build from #21; no `.env`/login helpers.
- **`tools/op.go`**: `register → registerBound`, `makeHandler → makeHandlerRewrite` (keeping the existing `WorkspaceIDForContext` accId default). Pre-bound params are **hidden from the tool schema and injected authoritatively** at call time; a rewrite hook injects a bound identity into each element of a root-array body (`prepareArgs`).
- **`tools.BuildActorScoped`** registers the per-actor set, all with the actor's identity bound + hidden so the model cannot target another actor:
  - `{actorId}`-path reads + CRUD: accounts, reactions, graph traversal/layers
  - access rules pinned to the actor (`objType="actor"`, `objId` bound)
  - link CRUD: `createLink`/`existLink` (`source` bound), `updateEdge`/`deleteEdge` by id
  - attachments: `getActorAttachments` + `uploadBase64` + `add`/`removeAttachments` (`actorId` injected into every `items[]`)
- New curated tool **`getActorAttachments`** (`GET /attachments/actor/{actorId}`; public route added in pong-server) + refreshed drift spec.

41 tools served per actor.

## Tests

- `make build` / `make vet`, full `go test ./...` — green
- drift gate (`TestSpecDrift`) — pass (incl. `getActorAttachments`)
- in-process `initialize`+`tools/list` e2e asserting the served per-actor spec: identity hidden from every schema, no `.env`/login helpers
- bound-arg hide/inject, ctx workspace default, actor-scoped selection, `items[]` injection

## Not in scope (follow-ups)

- Capability-aware tool filtering (serve a tool only if the actor actually has accounts/reactions/…) — v1 serves the full actor-scoped set.
- Engine tools (e.g. `uploadActorPicture`) are intentionally not on the per-actor endpoint.
- cc-api: bump the module dependency and switch the gateway to link `NewActorServer` in-process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)