### PR TITLE
fix(simulator-init): always prompt for environment, drop mw "default" framing

### DIFF
--- a/plugins/simulator/mcp-server/internal/config/config.go
+++ b/plugins/simulator/mcp-server/internal/config/config.go
@@ -52,8 +52,10 @@ type CloudEnv struct {
 	APIBaseURL string // public API root incl. /papi/1.0 prefix
 }
 
-// CloudEnvironments are the shipped cloud gateways, in presentation order (mw is the
-// default). Users may also enter a custom/local URL instead of picking a preset.
+// CloudEnvironments are the shipped cloud gateways, in presentation order (mw is
+// listed first by convention, not as a default — set-environment has no default and
+// always requires an explicit choice). Users may also enter a custom/local URL
+// instead of picking a preset.
 var CloudEnvironments = []CloudEnv{
 	{Name: "mw", Label: "Simulator Cloud — mw.simulator.company", APIBaseURL: "https://mw.simulator.company/papi/1.0"},
 	{Name: "sim", Label: "Simulator Cloud — sim.simulator.company", APIBaseURL: "https://sim.simulator.company/papi/1.0"},

--- a/plugins/simulator/skills/simulator-init/SKILL.md
+++ b/plugins/simulator/skills/simulator-init/SKILL.md
@@ -14,19 +14,24 @@ You are a specialist in setting up the Simulator.Company working environment usi
 
 ## Step 0 — Choose an environment
 
-Simulator runs on many environments (cloud, on-prem, and local dev). Ask the user which one
-they want, then call **`set-environment`**. Offer the presets the tool advertises in its
-`preset` parameter (don't invent others):
+Simulator runs on many environments (cloud, on-prem, and local dev). **You must always let the
+user choose — there is no default environment. Never call `set-environment` with a preset the
+user did not pick.** Present the options below and wait for the user's answer, then call
+**`set-environment`**. Offer only the presets the tool advertises in its `preset` parameter
+(don't invent others):
 
-- **Simulator Cloud** — `mw` = `mw.simulator.company` (default) or `sim` = `sim.simulator.company`
+- **Simulator Cloud** — `mw` = `mw.simulator.company` or `sim` = `sim.simulator.company`
 - **Custom / on-prem** — they paste a server URL or host (e.g. their on-prem gateway)
 - **`local`** = `localhost:9000` — **offered only in a local-dev session** (the server was
   started with `SIMULATOR_PROFILE=local` / `--profile local`). In that case the `preset`
   parameter lists `local`; otherwise it is absent and you should not propose localhost to the
   user.
 
+`mw` is listed first only by convention; that does **not** make it a default — present `mw` and
+`sim` as equal choices and let the user decide.
+
 ```
-set-environment(preset="mw")                  # cloud (default); or preset="sim"
+set-environment(preset="mw")                  # cloud; or preset="sim"
 set-environment(preset="local")               # ONLY in a local-dev session
 set-environment(url="https://my-onprem.example.com")   # custom / on-prem
 ```


### PR DESCRIPTION
## Problem

`simulator-init` frequently skipped the environment choice and silently picked **`mw`**, instead of letting the user pick.

## Root cause

Not the tool — prompt design in the skill. `set-environment` has **no default** (it requires an explicit `preset`/`url`, otherwise it errors). But `SKILL.md` Step 0 labelled `mw` as **"(default)"** twice while also instructing "ask the user which one they want". The model resolved that contradiction by taking the advertised default and skipping the question.

## Changes

- **`skills/simulator-init/SKILL.md` (Step 0):** add a hard directive — *always let the user choose, there is no default environment, never call `set-environment` with a preset the user did not pick*. Removed "(default)" from the `mw` preset line and the example, and clarified that `mw` is listed first by convention only — `mw` and `sim` are equal choices.
- **`internal/config/config.go`:** reworded the `CloudEnvironments` comment so it no longer claims "mw is the default" (presentation order only), keeping code and skill in sync.

## Verification

`make build && make vet` clean. Skill frontmatter unchanged, so no `make discovery` needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)