### PR TITLE
fix(simulator): chat deep-link, reaction attachments, activeActor priority (2.0.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "simulator",
       "source": "./plugins/simulator",
       "description": "Simulator.Company platform assistant. Exposes the Simulator REST API as an MCP server and provides skills for managing actors, forms, graph structures, and financial accounts.",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "author": {
         "name": "Simulator.Company",
         "url": "https://simulator.company"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.0.1]
+
+### Fixed
+- `buildLink` chat deep-links now point at a conversation correctly: `/chats/<acc>/list/chats/<chatActorId>?tab=chat` (the stream segment defaults to the standard `chats` stream and the required `?tab=chat` query is included). `id` is the chat-actor UUID; omit it to open the chat list.
+- AI agent now finds files the user attached to their **triggering message**. The message is a reaction under the root actor, so its files live on the reaction, not the actor — the agent was calling `getActorAttachments` on the root actor and reporting "no attachments". Documented that an actor's own attachments and the triggering message's attachments are **two distinct sets**, both read via `getActorAttachments(<id>)` → `readAttachment` (the actor for "files on this actor", the triggering reaction for "the file I sent"). Added an `activeReaction` field to the UI context (`control-events-context`) so the platform can hand the trigger id directly, with a `getReactions(... orderValue=DESC)` fallback when it's absent. (Populating `activeReaction` requires a matching pong-server change.)
+- UI-context guidance now states that `activeActor` (the actor the user is *viewing*) outranks the *root actor* the agent was triggered on: "this / the current / the open actor" resolves to `activeActor`. Fixes the AI agent answering about the root/console actor instead of the on-screen one. (Paired with a pong-server `buildPrompt` change that asserts the same priority in the agent's prompt.)
+
 ## [2.0.0]
 
 First public release of the Simulator.Company plugin for Claude Code / Codex.

--- a/plugins/simulator/.claude-plugin/plugin.json
+++ b/plugins/simulator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simulator",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Simulator.Company platform assistant. Exposes the Simulator REST API as an MCP server and provides skills for managing actors, forms, graph structures, and financial accounts.",
   "author": {
     "name": "Simulator.Company",

--- a/plugins/simulator/.codex-plugin/plugin.json
+++ b/plugins/simulator/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simulator",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Simulator.Company platform assistant. Exposes the Simulator REST API as an MCP server and provides skills for managing actors, forms, graph structures, and financial accounts.",
   "author": {
     "name": "Simulator.Company",

--- a/plugins/simulator/docs/entities/reactions.md
+++ b/plugins/simulator/docs/entities/reactions.md
@@ -101,14 +101,26 @@ Platform posts a child `ai` reaction and streams the result:
 - **Avoid loops.** Set `extra.mcp` only on genuine (human) requests, not on the agent's
   own output. The platform bounds runaway chains, but it still wastes turns.
 - **UI context.** When the agent runs, the client passes a `control-events-context` object
-  (where the user is in the UI — `activeActor` / `activeLayer` / `activeGraph` / `page` / …),
-  injected into the agent's prompt. See [`ui-context.md`](ui-context.md).
+  (where the user is in the UI — `activeActor` / `activeReaction` / `activeLayer` / `activeGraph` /
+  `page` / …), injected into the agent's prompt. See [`ui-context.md`](ui-context.md).
 - **Reading attachments on a reaction.** A reaction can carry files (it is itself an actor).
-  To read them, list the reaction's attachments with `getActorAttachments` (the reaction's id)
+  To read them, list the reaction's attachments with `getActorAttachments` (**the reaction's id**)
   and call `readAttachment` with each `fileName` — text comes back inline, images as a viewable
   block, PDFs/binary as an embedded resource. `readAttachment` works in actor-scoped mode, so
   the agent can read files attached to the reaction it is handling. See
   [`attachments.md`](attachments.md).
+- **Actor files vs. message files — two distinct sets.** Attachments are a per-actor linked
+  collection, and a reaction is itself an actor, so a file can live in either of two places — each
+  read the same way, `getActorAttachments(<id>)` → `readAttachment(<fileName>)`, just with a different id:
+  - **The root actor's own files** ("files on this actor", the actor's attachments tab) →
+    `getActorAttachments(<root actor id / `activeActor`>)`.
+  - **A file the user attached to *their* message** ("do you see the attachment I sent?") → the
+    triggering message **is a reaction** under the root actor, so its file is on that **reaction**, not on
+    the actor. Use the triggering reaction's id: **preferred** the UI context's **`activeReaction`**;
+    **fallback** (no `activeReaction`) `getReactions(actorId=<activeActor>, view="flat", orderValue="DESC")`
+    and take the most recent human (non-`ai`) reaction — the one carrying `extra.mcp`.
+
+  Pick the set the user means; if it's ambiguous, check **both** the actor and the triggering reaction.
 
 ## Embedding: smart forms, nested actor cards, chips
 

--- a/plugins/simulator/docs/entities/ui-context.md
+++ b/plugins/simulator/docs/entities/ui-context.md
@@ -19,6 +19,7 @@ decoded JSON into the agent's system prompt. **Read it to resolve deictic refere
   "hostOrigin": "https://mw.simulator.company",
   "page": "/actors_graph/a58d969b-4b2f-42ce-add5-0972c4f45421/graph/4c39176b-c3fd-4e24-b63f-c2319e2ceada/layers/21a7c6b6-bba1-4b19-9fcd-7e94f29a9e8a",
   "activeActor": "21a7c6b6-bba1-4b19-9fcd-7e94f29a9e8a",
+  "activeReaction": "5f0c8a91-2b14-4f3e-9d77-1a2b3c4d5e6f",
   "activeLayer": "21a7c6b6-bba1-4b19-9fcd-7e94f29a9e8a",
   "activeGraph": "4c39176b-c3fd-4e24-b63f-c2319e2ceada",
   "graphDiscovery": {
@@ -41,7 +42,8 @@ decoded JSON into the agent's system prompt. **Read it to resolve deictic refere
 | `workspaceId` | The active workspace (full UUID). | The workspace the user is in — use it as `accId` if you need to override the configured one. |
 | `hostOrigin` | The web-app origin, e.g. `https://mw.simulator.company`. | The web base for deep-links (`hostOrigin + page`, or pair with `buildLink`). |
 | `page` | The current route path (everything after the origin). | A ready-made link to *what the user is looking at* — `hostOrigin + page` is the full URL. Also tells you the section (`/actors_graph/…`, `/chats/…`, `/events/…`). |
-| `activeActor` | UUID of the actor currently open/focused. | Resolve "this actor" / "the open card" / "it". Pass to `getActor`, `createReaction`, `buildLink(entity="actor")`, etc. |
+| `activeActor` | UUID of the actor currently open/focused. | Resolve "this actor" / "the open card" / "it". Pass to `getActor`, `createReaction`, `buildLink(entity="actor")`, etc. For the **actor's own files** ("files on this actor"), `getActorAttachments(activeActor)`. |
+| `activeReaction` | UUID of the **reaction that triggered the agent** — i.e. the user's message itself (the `extra.mcp` reaction). May be absent on older platforms. | Resolve "**this message**" / "the file **I sent**". The triggering message is a *reaction* under `activeActor` (a separate actor), so its files are read with `getActorAttachments(activeReaction)` → `readAttachment(...)` — a **different set** from the actor's own attachments. |
 | `activeLayer` | UUID of the graph layer currently open. | Resolve "this layer" / "here" for placement. Pass as the `actorId` of layer tools (`getLayerActors`, `manageLayerActors`, …). |
 | `activeGraph` | UUID of the graph (graph-folder) currently open. | Resolve "this graph/diagram". The `graphFolderId` in graph routes. |
 | `actorRef` | The origin widget/console ref (e.g. `ai_console_system`). | Routing/provenance — where the request came from. Rarely needed for the answer itself. |
@@ -63,6 +65,23 @@ decoded JSON into the agent's system prompt. **Read it to resolve deictic refere
   already have in the context.
 - **Default, don't override.** If the user names a specific actor/layer, that wins; the context
   only fills the gaps.
+- **`activeActor` is "this/current/open actor" — it outranks the actor you were triggered on.**
+  In the AI-agent flow you act on a *root actor* (the one the triggering reaction lives on), but the
+  user may be **viewing a different actor** (e.g. from the AI console). When `activeActor` is present
+  and differs from that root actor, deictic references — "this actor", "the current actor", "what I'm
+  looking at" — mean **`activeActor`**, not the root actor. Resolve them against `activeActor` (e.g.
+  `getActor(activeActor)`) unless the user names another.
+- **Attachments: two distinct sets, same tool.** `getActorAttachments(<id>)` → `readAttachment` reads
+  whichever you point it at — pick the id by what the user means:
+  - **Actor's own files** ("files on this actor", the attachments tab) → `getActorAttachments(activeActor)`.
+  - **A file the user attached to *their message*** ("do you see the file I sent?") → the triggering
+    message is a **reaction** under `activeActor`, so use **`activeReaction`**:
+    `getActorAttachments(activeReaction)`. **Fallback** when `activeReaction` is absent (older platform):
+    `getReactions(actorId=activeActor, view="flat", orderValue="DESC")`, take the most recent human
+    (non-`ai`) reaction (the one with `extra.mcp`), then `getActorAttachments(<that reaction id>)`.
+
+  These are different sets — the message's file is **not** in the actor's own attachments and vice-versa.
+  If it's ambiguous which the user wants, check **both**.
 - **Stay in place.** Prefer operating on the layer/graph the user is viewing rather than creating
   a new one, unless they ask otherwise.
 - **Link to the current view.** `hostOrigin + page` is the exact URL the user is on. The

--- a/plugins/simulator/mcp-server/internal/apiclient/client.go
+++ b/plugins/simulator/mcp-server/internal/apiclient/client.go
@@ -93,11 +93,12 @@ const (
 // tools (e.g. buildLink) can default to the user's current view. All fields are
 // optional; absent ones are "".
 type UIContext struct {
-	HostOrigin  string `json:"hostOrigin"`  // web-app origin, e.g. https://mw.simulator.company
-	WorkspaceID string `json:"workspaceId"` // active workspace (full UUID)
-	ActiveActor string `json:"activeActor"` // UUID of the open/focused actor
-	ActiveLayer string `json:"activeLayer"` // UUID of the open graph layer
-	ActiveGraph string `json:"activeGraph"` // UUID of the open graph (folder)
+	HostOrigin     string `json:"hostOrigin"`     // web-app origin, e.g. https://mw.simulator.company
+	WorkspaceID    string `json:"workspaceId"`    // active workspace (full UUID)
+	ActiveActor    string `json:"activeActor"`    // UUID of the open/focused actor
+	ActiveReaction string `json:"activeReaction"` // UUID of the reaction that triggered the agent (the user's message), when present
+	ActiveLayer    string `json:"activeLayer"`    // UUID of the open graph layer
+	ActiveGraph    string `json:"activeGraph"`    // UUID of the open graph (folder)
 }
 
 // ParseUIContext decodes a `control-events-context` header value into a UIContext.

--- a/plugins/simulator/mcp-server/internal/tools/deeplinks.go
+++ b/plugins/simulator/mcp-server/internal/tools/deeplinks.go
@@ -122,17 +122,21 @@ var linkEntities = []linkEntity{
 	},
 	{
 		name: "chat",
-		help: "Chat conversation. streamId = stream containing the chat (required); id = chat conversation (chat-actor) UUID (optional).",
+		help: "Chat conversation. id = chat conversation (chat-actor / Events-actor) UUID — opens that chat. " +
+			"Optional streamId names the chat stream (defaults to the standard \"chats\" stream). Omit id to open the chat list.",
 		build: func(acc string, p linkParams) (string, error) {
-			stream, err := require(p.streamId, "streamId", "chat")
-			if err != nil {
-				return "", err
+			if p.id == "" {
+				// No specific conversation: open the workspace chat list.
+				return fmt.Sprintf("/chats/%s", acc), nil
 			}
-			path := fmt.Sprintf("/chats/%s/list/%s", acc, stream)
-			if p.id != "" {
-				path += "/" + p.id
+			// Conversation deep-link: /chats/<acc>/list/<stream>/<chatId>?tab=chat.
+			// The stream segment is the literal "chats" for the standard chat
+			// stream unless the caller names a different stream.
+			stream := p.streamId
+			if stream == "" {
+				stream = "chats"
 			}
-			return path, nil
+			return fmt.Sprintf("/chats/%s/list/%s/%s?tab=chat", acc, stream, p.id), nil
 		},
 	},
 	{
@@ -268,8 +272,8 @@ func registerBuildLink(s *server.MCPServer, c *apiclient.Client) {
 		mcp.WithString("entity", mcp.Required(),
 			mcp.Description("Kind of link to build. One of: "+strings.Join(linkEntityNames(), ", ")+".")),
 		mcp.WithString("accId", mcp.Description("Workspace id. Defaults to the active workspace if omitted.")),
-		mcp.WithString("id", mcp.Description("Primary resource id; meaning depends on entity (actor/transaction/transfer/chart/meeting/form UUID, layer id or \"0\", or chat conversation id). See the entity list in the description.")),
-		mcp.WithString("streamId", mcp.Description("Stream UUID — for event and chat links.")),
+		mcp.WithString("id", mcp.Description("Primary resource id; meaning depends on entity (actor/transaction/transfer/chart/meeting/form UUID, layer id or \"0\", or chat conversation (chat-actor) UUID). See the entity list in the description.")),
+		mcp.WithString("streamId", mcp.Description("Stream UUID — for event links, and to override the default \"chats\" stream on chat links.")),
 		mcp.WithString("secondaryId", mcp.Description("Event sub-stream UUID — narrows an event link further.")),
 		mcp.WithString("mode", mcp.Description("Graph display mode for layer/graph links."),
 			mcp.Enum("layers", "actors", "trees")),

--- a/plugins/simulator/mcp-server/internal/tools/deeplinks_test.go
+++ b/plugins/simulator/mcp-server/internal/tools/deeplinks_test.go
@@ -57,8 +57,12 @@ func TestBuildLinkHandler(t *testing.T) {
 			"https://sim.simulator.company/actors_graph/af451011/graph/L1/actors/" + actor},
 		{"event stream", map[string]any{"entity": "event", "streamId": "S1", "secondaryId": "S2"},
 			"https://sim.simulator.company/events/af451011/list/S1/S2"},
-		{"chat", map[string]any{"entity": "chat", "streamId": "S1", "id": "C1"},
-			"https://sim.simulator.company/chats/af451011/list/S1/C1"},
+		{"chat conversation (default stream)", map[string]any{"entity": "chat", "id": "C1"},
+			"https://sim.simulator.company/chats/af451011/list/chats/C1?tab=chat"},
+		{"chat conversation (explicit stream)", map[string]any{"entity": "chat", "streamId": "S1", "id": "C1"},
+			"https://sim.simulator.company/chats/af451011/list/S1/C1?tab=chat"},
+		{"chat list (no id)", map[string]any{"entity": "chat"},
+			"https://sim.simulator.company/chats/af451011"},
 		{"form new", map[string]any{"entity": "form"},
 			"https://sim.simulator.company/form/af451011/edit"},
 		{"explicit acc", map[string]any{"entity": "settings", "accId": "bbbb2222"},
@@ -121,10 +125,10 @@ func TestBuildLinkUsesUIContext(t *testing.T) {
 
 // ParseUIContext decodes the base64-JSON header value pong-server sends.
 func TestParseUIContext(t *testing.T) {
-	raw := `{"hostOrigin":"https://mw.simulator.company","workspaceId":"ws-1","activeActor":"act-1","activeLayer":"lay-1","activeGraph":"gr-1"}`
+	raw := `{"hostOrigin":"https://mw.simulator.company","workspaceId":"ws-1","activeActor":"act-1","activeReaction":"rx-1","activeLayer":"lay-1","activeGraph":"gr-1"}`
 	b64 := base64.StdEncoding.EncodeToString([]byte(raw))
 	ui := apiclient.ParseUIContext(b64)
-	if ui.HostOrigin != "https://mw.simulator.company" || ui.ActiveActor != "act-1" || ui.ActiveLayer != "lay-1" || ui.ActiveGraph != "gr-1" || ui.WorkspaceID != "ws-1" {
+	if ui.HostOrigin != "https://mw.simulator.company" || ui.ActiveActor != "act-1" || ui.ActiveReaction != "rx-1" || ui.ActiveLayer != "lay-1" || ui.ActiveGraph != "gr-1" || ui.WorkspaceID != "ws-1" {
 		t.Errorf("ParseUIContext(base64) = %+v", ui)
 	}
 	if got := apiclient.ParseUIContext(""); got != (apiclient.UIContext{}) {

--- a/plugins/simulator/skills/simulator-reactions/SKILL.md
+++ b/plugins/simulator/skills/simulator-reactions/SKILL.md
@@ -115,10 +115,22 @@ So when reading a discussion (`getReactions`), an `ai` reaction with
 > output wastes turns.
 
 When the agent runs, the client also passes a **UI-context** object (`control-events-context`)
-that says **where the user is** — `activeActor`, `activeLayer`, `activeGraph`, `page`,
-`hostOrigin`, `workspaceId`, `graphDiscovery`. Read it to resolve "here" / "this actor" /
+that says **where the user is** — `activeActor`, `activeReaction`, `activeLayer`, `activeGraph`,
+`page`, `hostOrigin`, `workspaceId`, `graphDiscovery`. Read it to resolve "here" / "this actor" /
 "this layer" and to default ids the user left implicit. See
 `$CLAUDE_PLUGIN_ROOT/docs/entities/ui-context.md`.
+
+> **Attachments: actor vs. message are two different sets.** Attachments are a per-actor linked
+> collection, and a reaction is itself an actor — so there are **two** places a file can live, each
+> read with `getActorAttachments(<id>)` → `readAttachment`:
+> - **The actor's own files** ("files on this actor / the attachments tab") → `getActorAttachments(activeActor)`.
+> - **A file the user attached to *their message*** ("do you see the file I sent?") → the triggering
+>   message **is a reaction** under `activeActor`, so its file lives on **that reaction**, not on the
+>   actor. Use the reaction's id: prefer **`activeReaction`** from the UI context; if absent, find the
+>   trigger via `getReactions(actorId=activeActor, view="flat", orderValue="DESC")` — the newest human
+>   reaction (the one with `extra.mcp`) — and pass **its** id to `getActorAttachments`.
+>
+> Pick the set the user means; if it's ambiguous, check **both** (the actor and the triggering reaction).
 
 ## Embed a smart form, an actor card, or chips
 


### PR DESCRIPTION
## Summary

Three AI-agent / deep-link fixes found while testing the reaction agent, plus a `2.0.0 → 2.0.1` version bump.

### 1. `buildLink` chat deep-link
Was producing `/chats/<acc>/list/<id>` — missing the `chats` stream segment and `?tab=chat`. Now resolves a conversation correctly:
`/chats/<acc>/list/chats/<chatActorId>?tab=chat`. `id` is the chat-actor UUID; omit it to open the chat list. Tests updated.

### 2. Reaction attachments not visible to the agent
The triggering message is a **reaction** under the root actor, so files the user attached live on the **reaction**, not the actor — the agent was calling `getActorAttachments` on the root actor and reporting "no attachments".
- Documented that an actor's own attachments and the triggering message's attachments are **two distinct sets**, both read via `getActorAttachments(<id>)` → `readAttachment`.
- Added an `activeReaction` field to the UI context (`control-events-context`) so the platform can hand the trigger id directly, with a `getReactions(… orderValue=DESC)` fallback when absent.

### 3. `activeActor` priority
"This / the current / the open actor" now resolves to `activeActor` (what the user is viewing), which **outranks** the root actor the agent was triggered on (e.g. the AI console).

## Cross-repo note
Fixes 2 and 3 are paired with a **pong-server** change (already merged to `develop` and cherry-picked to `master`): `orchestrator.js` now populates `activeReaction` intent via `buildPrompt`, asserting `activeActor` priority and the reaction-vs-actor distinction. The plugin side degrades gracefully (fallbacks) until the platform ships it.

## Verification
- `make build`, `make vet`, `go test ./internal/...` — all green.
- `make discovery` — no drift (frontmatter unchanged).
- JSON manifests validated; version bumped to `2.0.1` in all three manifests + `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)