### PR TITLE
feat(simulator): transfer-only account-name tool + docs

### DIFF
--- a/plugins/simulator/docs/entities/accounts.md
+++ b/plugins/simulator/docs/entities/accounts.md
@@ -21,6 +21,7 @@ Account names define the categories or types of accounts available in a workspac
 | user_id | Integer | ID of the user who created the account name |
 | name | Text | Name of the account |
 | is_system | Boolean | Whether this is a system account name |
+| transfer_only | Boolean | When true, accounts using this account name reject plain transactions (single, atomic, standalone 2-step) and can only be moved via a transfer. Default false. Set via `updateAccountName(transferOnly=...)` |
 | abbreviation | String | Short abbreviation for the account name |
 | status | Enum | Status of the account name (active, removed) |
 | created_at | Integer | Unix timestamp of creation time |

--- a/plugins/simulator/mcp-server/internal/tools/accounts.go
+++ b/plugins/simulator/mcp-server/internal/tools/accounts.go
@@ -132,11 +132,12 @@ var accountOps = []Operation{
 	},
 	{
 		Name: "updateAccountName", Method: "PUT", Path: "/account_names/{nameId}",
-		Summary: "Rename an account-name category (and/or its abbreviation).",
+		Summary: "Rename an account-name category (and/or its abbreviation), and/or flag it transfer-only.",
 		Params: []Param{
 			{Name: "nameId", In: InPath, Type: "string", Required: true, Desc: "Account name id."},
 			{Name: "name", In: InBody, Type: "string", Required: true, Desc: "New account name."},
 			{Name: "abbreviation", In: InBody, Type: "string", Desc: "New short label."},
+			{Name: "transferOnly", In: InBody, Type: "boolean", Desc: "When true, accounts using this account-name reject plain transactions (single, atomic, and standalone 2-step) and can only be moved via a transfer — useful for clearing/settlement categories that must always balance against a counterparty. Defaults false. Omit to leave the current value unchanged. Returned on every account-name read."},
 		},
 	},
 	{

--- a/plugins/simulator/skills/simulator-finance/SKILL.md
+++ b/plugins/simulator/skills/simulator-finance/SKILL.md
@@ -161,12 +161,29 @@ searchAccountNames(accId="ws_xxx", query="maint")
 
 createAccountName(accId="ws_xxx", name="Maintenance", abbreviation="MNT")
 updateAccountName(nameId="<account-name id>", name="Maintenance costs")
+
+# Make a category transfer-only: every account using this name then rejects plain
+# transactions and can only be moved via a transfer (see "Transfer-only categories" below).
+updateAccountName(nameId="<account-name id>", name="Settlement", transferOnly=true)
+updateAccountName(nameId="<account-name id>", name="Settlement", transferOnly=false)  # lift it
 ```
 
 > Same rule as currencies: **prefer `createAccountPair`** when you are creating an account name
 > that will be used on an account — it creates the name (and currency) if missing AND grants
 > pair access. Reserve bare `createAccountName` for rare workspace-level housekeeping that does
 > not lead to an account.
+
+### Transfer-only categories
+
+An account name can be flagged **`transferOnly`** (boolean, default `false`). When it is `true`,
+every account that uses that account name **rejects plain balance changes** — single
+transactions, atomic multi-account transactions, and standalone 2-step authorize/complete all
+fail with `HTTP 400` ("…is transfer-only; use a transfer instead of a plain transaction"). Only
+a **transfer** (`createTransfer`) moves such balances, because each transfer leg is tied to a
+transfer record. Internal limit changes and the cancel/reverse of an existing transfer are not
+affected. Use it for clearing/settlement categories that must always balance against a
+counterparty. Set/clear it with `updateAccountName(..., transferOnly=...)`; omit the field to
+leave it unchanged. The flag is returned on every account-name read.
 
 ---
 
@@ -449,6 +466,10 @@ getTransactionByRef(accountId="<account id>", ref="service-jan-2024")           
 
 `finalizeTransaction` `type` ∈ `completed` | `canceled` (also `declined`/`reversed`); identify the
 hold by its `ref` (or `parentRef`), not a transaction id.
+
+> If a `createTransaction`/`atomCreateTransaction` here returns `HTTP 400` "…is transfer-only",
+> the account's account-name is flagged `transferOnly` — use `createTransfer` instead (see
+> "Transfer-only categories" under Account names).
 
 ---
 


### PR DESCRIPTION
## Summary

- `updateAccountName` gains a `transferOnly` boolean param.
- Documents the transfer-only behavior (plain transactions rejected, only transfers allowed) in the finance skill and the accounts entity doc.
- Mirrors pong-server CE-15565.

## Changes

- `plugins/simulator/mcp-server/internal/tools/accounts.go` — add `transferOnly` param to `updateAccountName`.
- `plugins/simulator/skills/simulator-finance/SKILL.md` — document transfer-only behavior.
- `plugins/simulator/docs/entities/accounts.md` — document transfer-only behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)