### PR TITLE
feat(simulator): expose updateLayerPositions as public MCP tool

### DIFF
--- a/plugins/simulator/mcp-server/internal/tools/graph.go
+++ b/plugins/simulator/mcp-server/internal/tools/graph.go
@@ -266,6 +266,14 @@ var graphOps = []Operation{
 		},
 	},
 	{
+		Name: "updateLayerPositions", Method: "PUT", Path: "/graph_layers/actors/{layerId}",
+		Summary: "Update the positions (x, y) of actors already present on a layer. Use this to reposition actors within the same layer — not to move actors between layers (use moveActors for that).",
+		Params: []Param{
+			{Name: "layerId", In: InPath, Type: "string", Required: true, Desc: "Layer actor UUID containing the actors to reposition."},
+			{Name: "items", In: InBodyRoot, Type: "array", Required: true, Desc: "Array (1-100) of {id: string (laId — unique element ID on this layer, NOT actorId), position: {x: int, y: int}}."},
+		},
+	},
+	{
 		Name: "cleanGraphLayer", Method: "DELETE", Path: "/graph_layers/clean/{actorId}",
 		Summary: "Remove ALL actors and links from a layer (the layer actor itself stays). Irreversible — confirm first.",
 		Params: []Param{


### PR DESCRIPTION
## Problem

`PUT /graph_layers/actors/{layerId}` — the endpoint that repositions actors already placed on a layer — was only used internally inside `pushGraphFile` (via the private `updatePositions()` method in `push.go`). It was visible in `list_opers` as a raw HTTP call, but had no MCP tool descriptor: no name, no summary, no parameter schema.

As a result, when a user asked the agent to move an actor to specific coordinates on a layer, the agent had no reliable way to call this endpoint directly. It had to go through the full `pullGraphFile → edit YAML → pushGraphFile` cycle even for a simple coordinate change, and could confuse this operation with `moveActors` (which transfers actors between layers, not repositions them within one).

## Solution

Added `updateLayerPositions` as a public `Operation` in `internal/tools/graph.go`, following the same pattern as `moveActors`. The descriptor:

- Names the endpoint and its purpose unambiguously
- Explicitly distinguishes it from `moveActors` in the Summary
- Documents that `id` in the request body is `laId` (layer-placement ID), not the global `actorId` — a common source of confusion
- States the 100-item batch limit

No new business logic: the HTTP call already worked. This is purely a public description for MCP.

## Changes

- `plugins/simulator/mcp-server/internal/tools/graph.go` — added `updateLayerPositions` Operation between `moveActors` and `cleanGraphLayer`

`build.go` picks up the new Operation automatically — no manual registration needed.

## Test plan

- [ ] `list_opers` returns `updateLayerPositions`
- [ ] `get_oper` returns correct schema with `layerId` path param and `items` body param (with `laId` note)
- [ ] Agent can call `updateLayerPositions` directly to reposition actors without going through `pushGraphFile`
- [ ] `make build && make vet` pass (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)