### PR TITLE
feat(actors): expose hole flag on createActor/updateActor

### DIFF
--- a/plugins/simulator/mcp-server/internal/tools/actors.go
+++ b/plugins/simulator/mcp-server/internal/tools/actors.go
@@ -59,6 +59,13 @@ const actorDataDesc = "Field values keyed by each form field's `id` (\"item_<dig
 	"Display-only classes (label, button, image) take NO data entry; omit hidden/disabled fields you do not set. " +
 	"MULTIFORM actors instantiate several forms at once: fields of the actor's own (root) formId use the plain item id, while fields belonging to ANOTHER form are keyed \"__form__<thatFormId>:<itemId>\" (e.g. \"__form__16951:position\"). Use the plain id for this form's own fields."
 
+// holeDesc documents the `hole` flag, exposed on createActor/updateActor. The
+// backend declares `hole` (boolean) on the actor create/update body; a hole is
+// an empty placeholder node that becomes a normal actor once it is filled.
+const holeDesc = "Mark this actor as a HOLE — an empty placeholder slot on the graph (rendered as a " +
+	"hollow node). A hole stands for a not-yet-filled position in the structure and becomes a normal " +
+	"actor once it is filled with data. Default false."
+
 // actorOps — actor (graph node) CRUD. Actors are instances of a form; their
 // fields live in the free-form `data` object keyed by the form's field schema.
 var actorOps = []Operation{
@@ -78,6 +85,7 @@ var actorOps = []Operation{
 			{Name: "ref", In: InBody, Type: "string", Desc: "Optional external reference (1-255 chars), unique per form."},
 			{Name: "appId", In: InBody, Type: "string", Desc: appIdDesc},
 			{Name: "appSettings", In: InBody, Type: "object", Desc: appSettingsDesc},
+			{Name: "hole", In: InBody, Type: "boolean", Desc: holeDesc},
 			{Name: "contextLayerId", In: InQuery, Type: "string", Desc: "Optional layer to place the new actor on."},
 		},
 	},
@@ -116,6 +124,7 @@ var actorOps = []Operation{
 			{Name: "status", In: InBody, Type: "string", Desc: "New status value."},
 			{Name: "appId", In: InBody, Type: "string", Desc: appIdDesc},
 			{Name: "appSettings", In: InBody, Type: "object", Desc: appSettingsDesc},
+			{Name: "hole", In: InBody, Type: "boolean", Desc: holeDesc},
 		},
 	},
 	{

--- a/plugins/simulator/mcp-server/internal/tools/actors_test.go
+++ b/plugins/simulator/mcp-server/internal/tools/actors_test.go
@@ -1,0 +1,40 @@
+package tools
+
+import "testing"
+
+// TestActorHoleParam guards the `hole` flag exposed on createActor and
+// updateActor. The backend declares `hole` (boolean) on the actor
+// create/update request body; these tools must surface it so a model can create
+// or clear a hole (an empty placeholder node) without falling back to a raw API
+// call. See actors.go (holeDesc).
+func TestActorHoleParam(t *testing.T) {
+	byName := map[string]Operation{}
+	for _, op := range allOps() {
+		byName[op.Name] = op
+	}
+
+	for _, name := range []string{"createActor", "updateActor"} {
+		op, ok := byName[name]
+		if !ok {
+			t.Fatalf("operation %q not found in allOps()", name)
+		}
+
+		var hole *Param
+		for i := range op.Params {
+			if op.Params[i].Name == "hole" {
+				hole = &op.Params[i]
+				break
+			}
+		}
+		if hole == nil {
+			t.Errorf("%s: missing `hole` param (backend accepts `hole` on the body)", name)
+			continue
+		}
+		if hole.In != InBody {
+			t.Errorf("%s: hole param In = %v, want InBody (it is a body field)", name, hole.In)
+		}
+		if hole.Type != "boolean" {
+			t.Errorf("%s: hole param Type = %q, want %q", name, hole.Type, "boolean")
+		}
+	}
+}

--- a/plugins/simulator/skills/simulator-actors/SKILL.md
+++ b/plugins/simulator/skills/simulator-actors/SKILL.md
@@ -208,6 +208,24 @@ form; `appSettings` `{autorun, expired, users, groups, fullWidth}` tunes it. See
 `[md]…[/md]` for markdown. Fetch the environment's exact tag set with **`getBbcodeTags`**.
 **BBCode is processed only OUTSIDE `[md]` blocks.** The reverse matters too: a `description` is rendered as **BBCode by default, not markdown**, so any markdown you write (`##`, `-`, `**bold**`, tables) MUST be wrapped in `[md]…[/md]` or it shows as literal text — applies to every `createActor`/`updateActor` `description`, Events actors (chats/meetings/tasks) included (e.g. `description="[md]## Agenda\n- item[/md]"`). See `docs/entities/reactions.md` → "Embedding".
 
+## Holes — empty placeholder nodes
+
+A **hole** is an empty placeholder slot on a graph, rendered as a hollow node: it marks a
+position in the structure that is **not yet filled**. A hole becomes a normal actor once it is
+filled with data — ideal for laying out a template / "company DNA" graph up front and turning
+each slot into a real actor as the data arrives.
+
+```
+createActor(formId=3279, title="Budget", hole=true)        # create a hole
+updateActor(formId=3279, actorId="<UUID>", hole=true)      # turn an existing actor into a hole
+updateActor(formId=3279, actorId="<UUID>", hole=false)     # fill it — hole → normal actor
+```
+
+- `hole` is a top-level **boolean** on `createActor` / `updateActor`; omit it → default `false`.
+- It is independent of `status` and `data` (a hole can still carry a `title`). `hole=false`
+  alone flips a hole back to a normal node.
+- Place a hole on a layer like any node (e.g. `manageLayerActors` — see `simulator-graph`).
+
 ## Status & delete
 
 ```


### PR DESCRIPTION
## Problem

A **hole** is an empty placeholder node on a graph (rendered hollow) — a not-yet-filled slot in the structure that becomes a normal actor once it is filled with data. It is the natural primitive for laying out a template / "company DNA" graph up front and turning each slot into a real actor as data arrives.

The backend already supports it: `hole` (boolean) is a declared body field on **both** actor write endpoints — `POST /papi/1.0/actors/actor/{formId}` (createActor) and `PUT /papi/1.0/actors/actor/{formId}/{actorId}` (updateActor); see `internal/tools/testdata/papi-openapi.json`.

But the MCP `createActor` / `updateActor` tools did **not** expose `hole`, so the agent had no way to create or clear a hole without a raw HTTP call. The obvious alternatives do not work:

- `status="hole"` is rejected — `status` is a fixed enum, and `hole` is a separate top-level field;
- `manageLayerActors` placement cannot set the actor-level flag (it carries placement data only).

## Solution

Expose `hole` as a body param on `createActor` and `updateActor`, following the existing declarative `Param` pattern. The framework already serializes `In: InBody` params into the JSON body, so there is **no business-logic change** — this is a typed surface for a field the backend already accepts.

- `hole=true` on create → creates a hole;
- `hole=true` on update → turns an existing actor into a hole;
- `hole=false` on update → fills it (hole → normal actor);
- omitting `hole` sends nothing → backend default `false` is preserved.

## Changes

- `plugins/simulator/mcp-server/internal/tools/actors.go` — add `holeDesc` and the `hole` param to `createActor` and `updateActor`.
- `plugins/simulator/mcp-server/internal/tools/actors_test.go` — `TestActorHoleParam` (asserts both ops expose `hole` as an `InBody` boolean).
- `plugins/simulator/skills/simulator-actors/SKILL.md` — a "Holes — empty placeholder nodes" section so the feature is usable.

`build.go` picks up the param automatically — no manual registration.

## Test plan

**Contract**
- [x] `hole` is a declared boolean body property on both endpoints in `testdata/papi-openapi.json`.

**Static / unit**
- [x] `go build ./...`, `go vet ./internal/tools/`, `gofmt -l` — all clean.
- [x] `TestActorHoleParam` — PASS.
- [x] `go test ./internal/tools/` — the only failure is the **pre-existing** `TestSpecDrift` (unrelated: the committed `papi-openapi.json` predates `updateLayerPositions` / #39); this change touches no method/path, so drift is unaffected.

**Live (real graph; dev build loaded via `run.sh` local-binary)**
- [x] `createActor(formId=3279, hole=true)` → response `hole: true`.
- [x] `updateActor(formId=3279, actorId=…, hole=false)` → `hole: false` (hole → actor).
- [x] `updateActor(formId=3279, actorId=…, hole=true)` → `hole: true` (actor → hole).
- [x] Verified visually: the node renders as a hollow placeholder on the layer.

## Risk

Minimal. Declarative param addition for a field already in the backend contract; no method/path change (drift-safe); default behavior unchanged when `hole` is omitted.
