### PR TITLE
docs(graph): document edge lineStyle in manageLayerActors

### DIFF
--- a/plugins/simulator/mcp-server/internal/tools/graph.go
+++ b/plugins/simulator/mcp-server/internal/tools/graph.go
@@ -186,10 +186,12 @@ var graphOps = []Operation{
 	},
 	{
 		Name: "manageLayerActors", Method: "POST", Path: "/graph_layers/actors/{actorId}",
-		Summary: "Place or remove nodes/edges on a layer. Pass an array of {action: create|delete, data: {id, type: node|edge, position?}} items.",
+		Summary: "Place or remove nodes/edges on a layer. Pass an array of {action: create|delete, data: {id, type: node|edge, position?}} items. An edge placement may also carry a line style — see `items`.",
 		Params: []Param{
 			{Name: "actorId", In: InPath, Type: "string", Required: true, Desc: "Layer actor UUID."},
-			{Name: "items", In: InBodyRoot, Type: "array", Required: true, Desc: "Array of {action, data:{id, type, position?, laIdSource?, laIdTarget?}} actions."},
+			{Name: "items", In: InBodyRoot, Type: "array", Required: true, Desc: "Array of {action, data:{id, type, position?, laIdSource?, laIdTarget?}} actions. " +
+				"For an EDGE (type:\"edge\"), data also accepts `layerSettings:{lineStyle:\"solid\"|\"dashed\"|\"dotted\"}` to style the line (omit → solid). " +
+				"To CHANGE an existing edge's style, delete its placement and create it again with the new lineStyle — re-creating without deleting first adds a duplicate edge placement."},
 			{Name: "withNum", In: InQuery, Type: "boolean", Desc: "Return counts in the response."},
 		},
 	},

--- a/plugins/simulator/skills/simulator-graph/SKILL.md
+++ b/plugins/simulator/skills/simulator-graph/SKILL.md
@@ -539,6 +539,13 @@ massLink(links=[{"source":"<a>","target":"<b>"}, ...])
 // place it with manageLayerActors (actorId = the layer-actor UUID):
 manageLayerActors(actorId="<layerActorId>", items=[{"action":"create","data":{"id":"<edgeId>","type":"edge","laIdSource":<laA>,"laIdTarget":<laB>}}])
 
+// Edge LINE STYLE — put it in the placed edge's data.layerSettings.lineStyle
+// (solid | dashed | dotted; omit → solid). Use distinct styles for distinct
+// edge meanings (e.g. dashed = dependency, dotted = hint, solid = hierarchy):
+manageLayerActors(actorId="<layerActorId>", items=[{"action":"create","data":{"id":"<edgeId>","type":"edge","laIdSource":<laA>,"laIdTarget":<laB>,"layerSettings":{"lineStyle":"dashed"}}}])
+// To CHANGE an edge's style, DELETE its placement then create it again — re-creating
+// without deleting first adds a DUPLICATE placement (the line is drawn twice).
+
 // existLink REQUIRES edgeTypeId (unlike createLink) — pass it explicitly to find/dedupe an edge by its endpoints:
 existLink(source="<a>", target="<b>", edgeTypeId=<id>)  → edge id if it exists
 getEdge(edgeId="<edgeId>")


### PR DESCRIPTION
## Problem

`manageLayerActors` places nodes and edges on a layer by passing each item's `data` through to the backend. The backend renders an edge's **line style** from `data.layerSettings.lineStyle` (`solid` | `dashed` | `dotted`), but the tool descriptor never documented this — so the agent had no way to know styled edges (dashed dependency links, dotted hints, …) are achievable natively. It would leave every edge solid, or fall back to a raw `PUT graph_layers/edge_settings/...` call.

A second, non-obvious trap: re-running `create` for an already-placed edge does **not** update it — it adds a *second* placement (a duplicate line). Changing a style therefore requires delete + re-create.

## Solution

Document both facts where the agent actually reads them — the `manageLayerActors` Summary and the `items` parameter description:

- an edge's `data` accepts `layerSettings:{lineStyle:"solid"|"dashed"|"dotted"}` (omit → solid);
- to change an existing edge's style, delete its placement and create it again (re-creating without deleting first adds a duplicate placement).

No behavior change — the passthrough already works; this is descriptor text only (same spirit as #39).

## Changes

- `plugins/simulator/mcp-server/internal/tools/graph.go` — extend the `manageLayerActors` Summary and the `items` Desc.

## Test plan

**Static**
- [x] `go build ./...`, `go vet ./internal/tools/`, `gofmt -l` — clean.
- [x] `TestToolInputSchemasAreValid` — PASS (the descriptor still generates a valid input schema).
- [x] `go test ./internal/tools/` — only the pre-existing `TestSpecDrift` fails (unrelated, see #39); this change touches no method/path/operationId.

**Live (real graph) — the behavior this doc describes, verified by hand**
- [x] `manageLayerActors` create edge with `data.layerSettings.lineStyle:"dashed"` → renders dashed.
- [x] `…"dotted"` → renders dotted; no `lineStyle` → solid.
- [x] re-creating a placed edge adds a duplicate (edge count +1); delete + create restores a single styled edge.

## Risk

None functional — documentation-only descriptor change.
