### PR TITLE
fix(graph): cap paginated layer reads at the backend's 50 limit

### DIFF
--- a/plugins/simulator/mcp-server/internal/engines/graph/compact_layout.go
+++ b/plugins/simulator/mcp-server/internal/engines/graph/compact_layout.go
@@ -107,7 +107,7 @@ func handleCompactGraphLayout(ctx context.Context, req mcp.CallToolRequest) (*mc
 	placementsByActor := map[string][]compactPlacement{}
 	titleByActor := map[string]string{}
 	allPlacements := []compactPlacement{}
-	const limit = 100
+	const limit = maxLayerPageLimit
 	offset := 0
 	for {
 		u := fmt.Sprintf("%s/graph_layers/paginated/%s?type=nodes&limit=%d&offset=%d",

--- a/plugins/simulator/mcp-server/internal/engines/graph/limit_test.go
+++ b/plugins/simulator/mcp-server/internal/engines/graph/limit_test.go
@@ -1,0 +1,15 @@
+package graph
+
+import "testing"
+
+// TestMaxLayerPageLimit guards the page size shared by every paginated layer
+// reader (getAllLayerPlacements, compactGraphLayout, pruneLongEdges). The
+// backend rejects /graph_layers/paginated requests with ?limit > 50
+// ("querystring/limit must be <= 50"), so the cap must stay within that bound —
+// regressing it to 100 (the original bug) makes those tools fail on any layer
+// with more than 50 nodes.
+func TestMaxLayerPageLimit(t *testing.T) {
+	if maxLayerPageLimit < 1 || maxLayerPageLimit > 50 {
+		t.Fatalf("maxLayerPageLimit = %d, must be in [1,50] (backend caps ?limit at 50)", maxLayerPageLimit)
+	}
+}

--- a/plugins/simulator/mcp-server/internal/engines/graph/placements.go
+++ b/plugins/simulator/mcp-server/internal/engines/graph/placements.go
@@ -11,6 +11,12 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
+// maxLayerPageLimit is the largest page size the backend accepts on
+// /graph_layers/paginated (?limit). Requests above it fail with
+// "querystring/limit must be <= 50", so every paginated layer reader must cap
+// its page size at this value. (push.go / sync.go already use 50 directly.)
+const maxLayerPageLimit = 50
+
 // getAllLayerPlacements walks the paginated /graph_layers/paginated/{layerId}
 // endpoint and returns every (actorId, laId, formId, title, x, y) row for the
 // layer in a single MCP call. The existing `getLayerActorsByFormId` forces the
@@ -58,7 +64,7 @@ func handleGetAllLayerPlacements(ctx context.Context, req mcp.CallToolRequest) (
 	client := ecore.APIHTTPClient()
 
 	var rows []layerPlacementRow
-	const limit = 100
+	const limit = maxLayerPageLimit
 	offset := 0
 	for {
 		u := fmt.Sprintf("%s/graph_layers/paginated/%s?type=nodes&limit=%d&offset=%d",

--- a/plugins/simulator/mcp-server/internal/engines/graph/prune_edges.go
+++ b/plugins/simulator/mcp-server/internal/engines/graph/prune_edges.go
@@ -100,7 +100,7 @@ func handlePruneLongEdges(ctx context.Context, req mcp.CallToolRequest) (*mcp.Ca
 	}
 	positionOf := map[string]struct{ X, Y int }{}
 	titleOf := map[string]string{}
-	const limit = 100
+	const limit = maxLayerPageLimit
 	offset := 0
 	for {
 		u := fmt.Sprintf("%s/graph_layers/paginated/%s?type=nodes&limit=%d&offset=%d",


### PR DESCRIPTION
## Problem

Three layer readers page `/graph_layers/paginated` with `limit=100`:

- `getAllLayerPlacements` (`placements.go`)
- `compactGraphLayout` (`compact_layout.go`, nodes + edges)
- `pruneLongEdges` (`prune_edges.go`, nodes + edges)

The backend caps that querystring at 50 and rejects anything larger with `400 querystring/limit must be <= 50`. So all three return a 400 on any layer with **more than 50 nodes** — i.e. virtually every real layer. `compactGraphLayout` (auto-layout) and `getAllLayerPlacements` are effectively unusable at scale. (Observed in the field: both → `400 ... limit must be <= 50` on a 94-node layer.)

## Solution

Cap the page size at the backend maximum (50) — exactly what the **working** push/pull paths already do: `push.go` (`fetchLayerActors`/`fetchLayerEdges`) and `sync.go` use `limit, offset := 50, 0`.

Introduce a single shared `maxLayerPageLimit = 50` constant and use it in the three readers, so the value can't drift out of sync again. The pagination loops already break on a short page, so a smaller page size only means a few more requests — no logic change.

## Changes

- `placements.go` — add `maxLayerPageLimit = 50`; use it in `getAllLayerPlacements`.
- `compact_layout.go` — use `maxLayerPageLimit` (node + edge pagination).
- `prune_edges.go` — use `maxLayerPageLimit` (node + edge pagination).
- `limit_test.go` — `TestMaxLayerPageLimit` guards the cap (≤ 50).

## Test plan

- [x] `go build ./...`, `go vet ./internal/engines/graph/`, `gofmt -l` — clean.
- [x] `TestMaxLayerPageLimit` — PASS (fails if the cap regresses above 50).
- [x] `go test ./internal/engines/graph/` — all green.
- [x] Consistency: the new cap equals the value already used by the working `push.go` / `sync.go` paginators.

> Live note: reproducing the original 400 needs a layer with >50 nodes; the fix aligns the three readers with the push/pull paginators that already use 50, so paging is now uniform across the codebase.

## Risk

Low — page size only; pagination already terminates on a short page. No API/contract change.
