### PR TITLE
fix(graph): accept fractional layer positions on read

### DIFF
--- a/plugins/simulator/mcp-server/internal/engines/graph/jsonint.go
+++ b/plugins/simulator/mcp-server/internal/engines/graph/jsonint.go
@@ -1,0 +1,24 @@
+package graph
+
+import (
+	"encoding/json"
+	"math"
+)
+
+// jsonInt unmarshals a JSON number that may be an integer OR fractional into an
+// int, rounding to nearest. Some backend layer positions are stored as floats
+// (e.g. -1543.58); a plain `int` struct field makes json.Unmarshal fail with
+// "cannot unmarshal number ... into int", which previously broke pullGraphFile /
+// pushGraphFile / getAllLayerPlacements / pruneLongEdges whenever a layer held a
+// single fractional coordinate. Rounding is safe here — these are pixel
+// positions, and the write side already uses integer coordinates.
+type jsonInt int
+
+func (n *jsonInt) UnmarshalJSON(b []byte) error {
+	var f float64
+	if err := json.Unmarshal(b, &f); err != nil {
+		return err
+	}
+	*n = jsonInt(math.Round(f))
+	return nil
+}

--- a/plugins/simulator/mcp-server/internal/engines/graph/jsonint_test.go
+++ b/plugins/simulator/mcp-server/internal/engines/graph/jsonint_test.go
@@ -1,0 +1,49 @@
+package graph
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestJSONIntUnmarshal verifies jsonInt accepts both integer and fractional JSON
+// numbers, rounding fractions to nearest (half away from zero, per math.Round).
+func TestJSONIntUnmarshal(t *testing.T) {
+	cases := []struct {
+		in   string
+		want jsonInt
+	}{
+		{"0", 0},
+		{"42", 42},
+		{"-7", -7},
+		{"-1543.58", -1544},
+		{"1543.49", 1543},
+		{"2.5", 3},
+		{"-2.5", -3},
+	}
+	for _, c := range cases {
+		var got jsonInt
+		if err := json.Unmarshal([]byte(c.in), &got); err != nil {
+			t.Fatalf("Unmarshal(%q) error: %v", c.in, err)
+		}
+		if got != c.want {
+			t.Errorf("Unmarshal(%q) = %d, want %d", c.in, int(got), int(c.want))
+		}
+	}
+}
+
+// TestPositionFractionalParses is the regression guard: a position object with a
+// fractional coordinate must now parse. With plain `int` fields this failed with
+// "json: cannot unmarshal number -1543.58 into Go ... of type int", which broke
+// pull/push and the paginated readers for the whole layer.
+func TestPositionFractionalParses(t *testing.T) {
+	var p struct {
+		X jsonInt `json:"x"`
+		Y jsonInt `json:"y"`
+	}
+	if err := json.Unmarshal([]byte(`{"x":-1543.58,"y":42}`), &p); err != nil {
+		t.Fatalf("fractional position should parse, got error: %v", err)
+	}
+	if p.X != -1544 || p.Y != 42 {
+		t.Errorf("got (%d,%d), want (-1544,42)", int(p.X), int(p.Y))
+	}
+}

--- a/plugins/simulator/mcp-server/internal/engines/graph/placements.go
+++ b/plugins/simulator/mcp-server/internal/engines/graph/placements.go
@@ -35,8 +35,8 @@ type paginatedLayerActor struct {
 	FormID   int    `json:"formId"`
 	Title    string `json:"title"`
 	Position struct {
-		X int `json:"x"`
-		Y int `json:"y"`
+		X jsonInt `json:"x"`
+		Y jsonInt `json:"y"`
 	} `json:"position"`
 	// formId can also live under nested form objects on some endpoints; the
 	// paginated route exposes it at the top level, so this struct is enough.
@@ -92,8 +92,8 @@ func handleGetAllLayerPlacements(ctx context.Context, req mcp.CallToolRequest) (
 				FormID:  p.FormID,
 				Title:   p.Title,
 			}
-			row.Position.X = p.Position.X
-			row.Position.Y = p.Position.Y
+			row.Position.X = int(p.Position.X)
+			row.Position.Y = int(p.Position.Y)
 			rows = append(rows, row)
 		}
 		if len(page.Data) < limit {

--- a/plugins/simulator/mcp-server/internal/engines/graph/prune_edges.go
+++ b/plugins/simulator/mcp-server/internal/engines/graph/prune_edges.go
@@ -94,8 +94,8 @@ func handlePruneLongEdges(ctx context.Context, req mcp.CallToolRequest) (*mcp.Ca
 		ID       string `json:"id"`
 		Title    string `json:"title"`
 		Position struct {
-			X int `json:"x"`
-			Y int `json:"y"`
+			X jsonInt `json:"x"`
+			Y jsonInt `json:"y"`
 		} `json:"position"`
 	}
 	positionOf := map[string]struct{ X, Y int }{}
@@ -116,7 +116,7 @@ func handlePruneLongEdges(ctx context.Context, req mcp.CallToolRequest) (*mcp.Ca
 			return mcp.NewToolResultError(fmt.Sprintf("[Error] parse placements: %v", err)), nil
 		}
 		for _, p := range page.Data {
-			positionOf[p.ID] = struct{ X, Y int }{X: p.Position.X, Y: p.Position.Y}
+			positionOf[p.ID] = struct{ X, Y int }{X: int(p.Position.X), Y: int(p.Position.Y)}
 			titleOf[p.ID] = p.Title
 		}
 		if len(page.Data) < limit {

--- a/plugins/simulator/mcp-server/internal/engines/graph/push.go
+++ b/plugins/simulator/mcp-server/internal/engines/graph/push.go
@@ -997,7 +997,7 @@ func (s *GraphSyncer) pushGraph(ctx context.Context, graph GraphFile, layerID st
 					} else {
 						result.ActorsUnchanged++
 					}
-					if sa.Position.X != a.Position.X || sa.Position.Y != a.Position.Y {
+					if int(sa.Position.X) != a.Position.X || int(sa.Position.Y) != a.Position.Y {
 						posUpdates = append(posUpdates, map[string]interface{}{
 							"id":       sa.LaID,
 							"position": map[string]int{"x": a.Position.X, "y": a.Position.Y},

--- a/plugins/simulator/mcp-server/internal/engines/graph/sync.go
+++ b/plugins/simulator/mcp-server/internal/engines/graph/sync.go
@@ -58,8 +58,8 @@ type layerActor struct {
 	LaID        int                    `json:"laId"`
 	Data        map[string]interface{} `json:"data"`
 	Position    struct {
-		X int `json:"x"`
-		Y int `json:"y"`
+		X jsonInt `json:"x"`
+		Y jsonInt `json:"y"`
 	} `json:"position"`
 }
 
@@ -269,8 +269,8 @@ func handlePullGraphFile(ctx context.Context, req mcp.CallToolRequest) (*mcp.Cal
 		if name := resolveFormIDToName(ga.FormID); name != "" {
 			ga.FormName = name
 		}
-		ga.Position.X = sa.Position.X
-		ga.Position.Y = sa.Position.Y
+		ga.Position.X = int(sa.Position.X)
+		ga.Position.Y = int(sa.Position.Y)
 		graph.Actors = append(graph.Actors, ga)
 	}
 


### PR DESCRIPTION
## Problem

The backend sometimes **returns** a layer position as a fractional number, not an integer. The structs that read positions back declared `x`/`y` as `int`:

- `pullGraphFile` / `pushGraphFile` (`sync.go` — `layerActor`)
- `getAllLayerPlacements` (`placements.go` — `paginatedLayerActor`)
- `pruneLongEdges` (`prune_edges.go`)

So `json.Unmarshal` failed with:

```
json: cannot unmarshal number -1543.58 into Go struct field ... of type int
```

A page is decoded in one `Unmarshal`, so a **single** fractional coordinate anywhere on the layer broke the read for the **entire** layer — `pullGraphFile` / `pushGraphFile` and the paginated readers all errored out, returning nothing.

**Concrete repro (observed in the field):** a 90+ node layer had one pre-existing node whose stored `x` was `-1543.58` (a sub-pixel coordinate left over from a drag/layout op). Every `pullGraphFile` / `pushGraphFile` on that layer failed with the error above until that single node was deleted by hand. Note the value `-1543.58` came **from the server response** — the backend does emit fractional positions on read, even though the write side only ever sends integers.

## Solution

Add a small `jsonInt` type whose `UnmarshalJSON` accepts an integer **or** fractional JSON number and rounds to nearest, then use it for the position `x`/`y` fields in the three read structs. Everything downstream stays `int` exactly as before — the few consumers convert the rounded value with `int(...)`. The write paths are untouched and keep sending integer coordinates (positions are pixels and the update endpoints take ints), so this is purely a *tolerant read*: a stray fractional coordinate no longer crashes the whole layer read; it is normalized to the nearest integer.

## Changes

- `jsonint.go` — `jsonInt` type + `UnmarshalJSON` (round to nearest).
- `sync.go`, `placements.go`, `prune_edges.go` — position `x`/`y` use `jsonInt`; consumers convert with `int(...)`.
- `push.go` — one position comparison converts `jsonInt` → `int`.
- `jsonint_test.go` — rounding cases + the fractional-position regression.

## Test plan

- [x] `go build ./...`, `go vet ./internal/engines/graph/`, `gofmt -l` — clean.
- [x] `TestJSONIntUnmarshal` (int, negative, fractional, `.5` rounding) — PASS.
- [x] `TestPositionFractionalParses` (`{"x":-1543.58,"y":42}` → `(-1544,42)`) — PASS; this exact payload failed to unmarshal before the change.
- [x] `go test ./internal/engines/graph/` — all green (existing push/pull sync tests unaffected).

## Risk

Low — only the read path changes (int → rounded int); write coordinates stay integer. Rounding is at most a sub-pixel shift, and only when the backend returns a non-integer in the first place.

## Alternative considered

If fractional positions should never exist server-side, the root cause is better fixed on the backend (round/reject on write). This client-side guard is still worth having: one stray fractional coordinate otherwise takes down the entire `pullGraphFile`/`pushGraphFile` round-trip for that layer.
