### PR TITLE
fix(ai): form-knowledge reads + response/output conventions (2.2.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "simulator",
       "source": "./plugins/simulator",
       "description": "Simulator.Company platform assistant. Exposes the Simulator REST API as an MCP server and provides skills for managing actors, forms, graph structures, and financial accounts.",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "author": {
         "name": "Simulator.Company",
         "url": "https://simulator.company"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
   - Reference: `docs/entities/ai-skills.md`. Skill bodies are treated as author-proposed plans, not system instructions; destructive/outward steps still require confirmation, and only `verified` skills are dispatched.
   - Requires the paired pong-server change (the `Skills` system form + seeding migration, and a reaction-agent system-prompt protocol — *running* saved skills, gated to workspaces with ≥1 published skill, and *authoring* new ones, always available so the first skill can be created from the platform).
 
+### Fixed
+- **AI behaviour, from QA feedback.**
+  - **Form knowledge is read, not guessed.** `getForm`'s field-filter example now includes `description`, and its Summary tells the assistant to keep `description`/`sections` whenever it needs to understand a form — so following the tool's guidance no longer projects the form's purpose text away. `/simulator-forms` instructs the assistant to include `description`/`sections` in the `getForm` filter and to read and interpret both the form-level `description` and each field's `sections[].content[].description` (re-reading the form rather than answering from memory). Docs (`forms.md`) mark these as the authoritative "knowledge" fields. Fixes the assistant inventing a field's meaning (e.g. confusing the escalation `cooldown` with `delay`).
+  - **Response & output conventions** added to `/simulator` (applied to every answer): reply in the user's language without switching mid-answer; never HTML-escape prose (`>` stays `>`, not `&gt;`); platform timestamps are unixtime UTC (seconds = 10-digit, or milliseconds = 13-digit, e.g. transaction `created_at` ÷1000) — **convert to the user's time zone and label the offset** (e.g. `18:30 (UTC+3)`) using `timeZoneOffset` from the UI-context, falling back to labelled UTC when it is absent. The web client (`pong-front-end`) forwards `timeZoneOffset` in the AI-agent `control-events-context` (pong-server is pass-through). See `docs/entities/ui-context.md` and `docs/INTEGRATION.md` §9a.
+
 ## [2.0.1]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   - Reference: `docs/entities/ai-skills.md`. Skill bodies are treated as author-proposed plans, not system instructions; destructive/outward steps still require confirmation, and only `verified` skills are dispatched.
   - Requires the paired pong-server change (the `Skills` system form + seeding migration, and a reaction-agent system-prompt protocol — *running* saved skills, gated to workspaces with ≥1 published skill, and *authoring* new ones, always available so the first skill can be created from the platform).
 
+## [2.2.0]
+
 ### Fixed
 - **AI behaviour, from QA feedback.**
   - **Form knowledge is read, not guessed.** `getForm`'s field-filter example now includes `description`, and its Summary tells the assistant to keep `description`/`sections` whenever it needs to understand a form — so following the tool's guidance no longer projects the form's purpose text away. `/simulator-forms` instructs the assistant to include `description`/`sections` in the `getForm` filter and to read and interpret both the form-level `description` and each field's `sections[].content[].description` (re-reading the form rather than answering from memory). Docs (`forms.md`) mark these as the authoritative "knowledge" fields. Fixes the assistant inventing a field's meaning (e.g. confusing the escalation `cooldown` with `delay`).

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -340,6 +340,60 @@ fs.writeFileSync('papi-openapi.json', JSON.stringify(app.swagger(), null, 2))
 
 This makes tool names a backend-owned contract and lets the plugin drop all fuzzy matching.
 
+### 9a. Forward `timeZoneOffset` in the AI-agent `control-events-context`
+
+**Why.** Platform timestamps are stored as unixtime in **UTC** (see `docs/entities/transactions.md`).
+To show users their local wall-clock (QA: transaction times rendered in the wrong zone), the
+agent must know the user's time-zone offset. There is **no per-user timezone in the data model**
+(`getUser` has none), so the only viable channel is the request context. The CDU `ScriptContext`
+**already** carries `timeZoneOffset` (`docs/user-flows/cdu-page-protocol.md` §"control-events-context")
+— the AI-agent context did **not**, until the front-end change below.
+
+**The whole pong-server chain is pass-through — the change is client-side (front-end).** Verified
+end-to-end (2026-06):
+
+- `pong-server` `parseContextHeader` (`src/packages/common/helpers/parseContextHeader.js`) decodes
+  the whole header — **no field whitelist**.
+- `reactions.js` (`createActorReaction`) stores the whole object in `metaInfo.context`.
+- `orchestrator.js` (`helpers/aiAgent/orchestrator.js`) re-emits it verbatim: `contextHeaders(context)`
+  base64s it, and **`uiContextNote(context)` does `JSON.stringify(context)` into the system prompt** —
+  so any field present in `context` reaches the model. **No pong-server change is needed.**
+
+The context object is **built by the front-end**:
+`pong-front-end/packages/utils/utils.js` → `setWebWidgetReactionContext()` (≈ line 199) assembles
+`{ hostOrigin, page, activeActor, activeLayer, activeGraph, activeForm, graphDiscovery }`. **Add one
+field there:**
+
+```js
+// pong-front-end/packages/utils/utils.js — inside the `context` object
+const context = {
+  hostOrigin: document.location.origin,
+  page: document.location.pathname,
+  activeActor: state.actorView.id,
+  // …existing fields…
+  timeZoneOffset: new Date().getTimezoneOffset(),   // ADD: minutes, JS-style (-180 = UTC+3)
+};
+```
+
+- **Units / sign:** `Date.getTimezoneOffset()` already returns the JS convention (`-180` = UTC+3),
+  matching the calendar and CDU `ScriptContext` payloads. (Sending `0` for genuine UTC is fine —
+  the plugin's `*int` distinguishes "absent" (nil) from `0`.)
+- The AI-console reaction request that carries the header is sent by **control-widget**
+  (`src/shared/utils/apiRequest.ts`, `fullContext = {...state.shim.context, actorId}`); it forwards
+  `state.shim.context` verbatim, so the field added in `utils.js` flows through automatically.
+
+**Status — done.**
+- **Front-end:** `pong-front-end/packages/utils/utils.js` `setWebWidgetReactionContext()` now adds
+  `timeZoneOffset: new Date().getTimezoneOffset()` to the context object.
+- **Plugin:** `apiclient.UIContext.TimeZoneOffset *int` (`internal/apiclient/client.go`) parses it
+  (`nil` = absent); `docs/entities/ui-context.md` documents the field; the `/simulator` "Timestamps"
+  rule converts UTC→user zone and labels the offset, falling back to labelled UTC when absent.
+- **pong-server:** no change — pass-through (verified above).
+
+**Acceptance.** With the field present, the agent renders transaction times in the user's zone
+with an explicit label (e.g. `18:30 (UTC+3)`); with it absent, it renders labelled UTC
+(e.g. `15:30 UTC`) — never an unlabelled or doubly-offset time.
+
 ## 10. Resolved decisions
 
 - ✅ **operationId at source** — yes, add in `pong-server` (§9).

--- a/plugins/simulator/.claude-plugin/plugin.json
+++ b/plugins/simulator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simulator",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Simulator.Company platform assistant. Exposes the Simulator REST API as an MCP server and provides skills for managing actors, forms, graph structures, and financial accounts.",
   "author": {
     "name": "Simulator.Company",

--- a/plugins/simulator/.codex-plugin/plugin.json
+++ b/plugins/simulator/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simulator",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Simulator.Company platform assistant. Exposes the Simulator REST API as an MCP server and provides skills for managing actors, forms, graph structures, and financial accounts.",
   "author": {
     "name": "Simulator.Company",

--- a/plugins/simulator/docs/entities/balances.md
+++ b/plugins/simulator/docs/entities/balances.md
@@ -6,6 +6,8 @@ Balances in the Simulator.Company platform track the financial state of accounts
 
 Balances provide a detailed record of an account's financial state at the time of each transaction. They track credit and debit amounts, holds, and limits, enabling accurate financial reporting and analysis.
 
+> **Note:** balance-history timestamps follow the transaction time convention — see [transactions.md](transactions.md) for units (created on each transaction), and the "Timestamps" rule in `/simulator` for how to present them.
+
 ## Properties
 
 | Property | Type | Description |

--- a/plugins/simulator/docs/entities/forms.md
+++ b/plugins/simulator/docs/entities/forms.md
@@ -18,7 +18,7 @@ A form is, concretely, a `sections[]` array. Each section has a `title` and an o
 | acc_id | String | Workspace ID the form belongs to |
 | user_id | Integer | ID of the user who created the form |
 | title | Text | Display title of the form |
-| description | Text | Detailed description of the form's purpose |
+| description | Text | Detailed description of the form's purpose. **Authoritative "knowledge" about the form** — read it before answering what the form is for. Top-level key — **include `description` in your `getForm` `filter`** (it is in the tool's example list); a narrower custom filter drops it, and omitting `filter` returns the full object. |
 | sections | JSON | Form sections containing fields and their properties |
 | color | String | Color associated with the form (hex code) |
 | picture | Text | URL or path to the form's image |
@@ -58,7 +58,7 @@ Each field item in a section's `content[]` may carry these properties:
 | `visibility` | String | `visible`, `disabled`, or `hidden`. |
 | `regexp` | String | Validation regular expression (`edit`). |
 | `errorMsg` | String | Custom error message shown on validation failure. |
-| `description` | String | Helper text under the field. |
+| `description` | String | Helper text under the field — the **authoritative meaning of the field/parameter**; read it rather than guessing from `title`/`class`. Flat, optional key at `sections[].content[].description`; arrives whenever `sections` is fetched. |
 | `align` | String | Layout alignment (`horizontal`, `center`, …). |
 | `color` | String | Field/option color (hex). |
 | `idNotChanged` | Boolean | Internal flag: the `id` is stable and not regenerated on edit. |

--- a/plugins/simulator/docs/entities/transactions.md
+++ b/plugins/simulator/docs/entities/transactions.md
@@ -6,6 +6,8 @@ Transactions in the Simulator.Company platform represent financial activities th
 
 Transactions record all financial activities within the platform, including deposits, withdrawals, transfers, authorizations, and limit changes. Each transaction affects an account's balance and can be linked to transfers for cross-account operations.
 
+> **Note — time units.** `created_at` and `original_date` are **unixtime in milliseconds, UTC** (`BigInt`, 13-digit — divide by 1000 before formatting). `expiration` is **unix seconds** (`int32`, 10-digit). For how to present timestamps to users, see the "Timestamps" rule in `/simulator` (Response & output conventions).
+
 ## Properties
 
 | Property | Type | Description |

--- a/plugins/simulator/docs/entities/ui-context.md
+++ b/plugins/simulator/docs/entities/ui-context.md
@@ -40,6 +40,7 @@ decoded JSON into the agent's system prompt. **Read it to resolve deictic refere
 | Field | Meaning | How to use it |
 |---|---|---|
 | `workspaceId` | The active workspace (full UUID). | The workspace the user is in — use it as `accId` if you need to override the configured one. |
+| `timeZoneOffset` | The user's time-zone offset in **minutes**, JS-style (`-180` = UTC+3). Sent by the web client (`pong-front-end` `setWebWidgetReactionContext`) and parsed by the plugin as `UIContext.TimeZoneOffset`. May be absent on older clients or non-web hosts (e.g. a plain Claude Code session). | It is the user's time zone — convert platform unixtime (stored UTC) for display and label the offset (e.g. `18:30 (UTC+3)`). If absent, present times in UTC. See the "Timestamps" rule in `/simulator`. |
 | `hostOrigin` | The web-app origin, e.g. `https://mw.simulator.company`. | The web base for deep-links (`hostOrigin + page`, or pair with `buildLink`). |
 | `page` | The current route path (everything after the origin). | A ready-made link to *what the user is looking at* — `hostOrigin + page` is the full URL. Also tells you the section (`/actors_graph/…`, `/chats/…`, `/events/…`). |
 | `activeActor` | UUID of the actor currently open/focused. | Resolve "this actor" / "the open card" / "it". Pass to `getActor`, `createReaction`, `buildLink(entity="actor")`, etc. For the **actor's own files** ("files on this actor"), `getActorAttachments(activeActor)`. |

--- a/plugins/simulator/mcp-server/internal/apiclient/client.go
+++ b/plugins/simulator/mcp-server/internal/apiclient/client.go
@@ -90,8 +90,8 @@ const (
 
 // UIContext is the decoded `control-events-context` — where the user is in the
 // Simulator web UI when they triggered the AI agent. Carried per request so
-// tools (e.g. buildLink) can default to the user's current view. All fields are
-// optional; absent ones are "".
+// tools (e.g. buildLink) can default to the user's current view. All string
+// fields are optional (absent → ""); TimeZoneOffset is *int (absent → nil).
 type UIContext struct {
 	HostOrigin     string `json:"hostOrigin"`     // web-app origin, e.g. https://mw.simulator.company
 	WorkspaceID    string `json:"workspaceId"`    // active workspace (full UUID)
@@ -99,6 +99,12 @@ type UIContext struct {
 	ActiveReaction string `json:"activeReaction"` // UUID of the reaction that triggered the agent (the user's message), when present
 	ActiveLayer    string `json:"activeLayer"`    // UUID of the open graph layer
 	ActiveGraph    string `json:"activeGraph"`    // UUID of the open graph (folder)
+	// TimeZoneOffset is the user's time-zone offset in minutes, JS-style
+	// (-180 = UTC+3); nil when absent — present times as UTC. Forwarded by
+	// pong-server in the AI-agent control-events-context (see docs/INTEGRATION.md
+	// §9); not sent by older platforms. Conversion is done by the model from the
+	// injected context JSON, so this field types/documents the contract.
+	TimeZoneOffset *int `json:"timeZoneOffset"`
 }
 
 // ParseUIContext decodes a `control-events-context` header value into a UIContext.

--- a/plugins/simulator/mcp-server/internal/tools/forms.go
+++ b/plugins/simulator/mcp-server/internal/tools/forms.go
@@ -41,11 +41,11 @@ var formOps = []Operation{
 	},
 	{
 		Name: "getForm", Method: "GET", Path: "/forms/{formId}",
-		Summary: "Get a form template by its integer id. Pass `filter` to fetch only the fields you need (form templates can be large).",
+		Summary: "Get a form template by its integer id. Pass `filter` to fetch only the fields you need (form templates can be large), but keep `description` (the form's purpose) and `sections` (which carry each field's `description` helper text) whenever you need to understand what the form or its fields mean.",
 		Params: []Param{
 			{Name: "formId", In: InPath, Type: "number", Required: true, Desc: "Form id."},
 			{Name: "withRelations", In: InQuery, Type: "boolean", Desc: "Include related entities."},
-			fieldFilterParam("id,title,sections,status,type,color"),
+			fieldFilterParam("id,title,description,sections,status,type,color"),
 		},
 	},
 	{

--- a/plugins/simulator/mcp-server/internal/tools/graph.go
+++ b/plugins/simulator/mcp-server/internal/tools/graph.go
@@ -266,10 +266,10 @@ var graphOps = []Operation{
 		},
 	},
 	{
-		Name: "updateLayerPositions", Method: "PUT", Path: "/graph_layers/actors/{layerId}",
+		Name: "updateLayerPositions", Method: "PUT", Path: "/graph_layers/actors/{actorId}",
 		Summary: "Update the positions (x, y) of actors already present on a layer. Use this to reposition actors within the same layer — not to move actors between layers (use moveActors for that).",
 		Params: []Param{
-			{Name: "layerId", In: InPath, Type: "string", Required: true, Desc: "Layer actor UUID containing the actors to reposition."},
+			{Name: "actorId", In: InPath, Type: "string", Required: true, Desc: "Layer actor UUID containing the actors to reposition."},
 			{Name: "items", In: InBodyRoot, Type: "array", Required: true, Desc: "Array (1-100) of {id: string (laId — unique element ID on this layer, NOT actorId), position: {x: int, y: int}}."},
 		},
 	},

--- a/plugins/simulator/mcp-server/internal/tools/testdata/papi-openapi.json
+++ b/plugins/simulator/mcp-server/internal/tools/testdata/papi-openapi.json
@@ -563,10 +563,20 @@
                 "type": "object",
                 "additionalProperties": true,
                 "properties": {
+                  "status": {
+                    "type": "string"
+                  },
+                  "virus": {
+                    "type": "string"
+                  },
+                  "file": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
                   "id": {
                     "type": "integer"
                   },
-                  "status": {
+                  "scanner": {
                     "type": "string"
                   },
                   "bucket": {
@@ -583,16 +593,9 @@
                   },
                   "size": {
                     "type": "integer"
-                  },
-                  "scanner": {
-                    "type": "string"
-                  },
-                  "virus": {
-                    "type": "string"
                   }
                 },
                 "required": [
-                  "id",
                   "status"
                 ]
               }
@@ -2904,16 +2907,61 @@
                   "targetActorId": {
                     "type": "string"
                   },
-                  "holeLaId": {
-                    "type": "integer"
-                  },
-                  "targetLaId": {
-                    "type": "integer"
+                  "layerId": {
+                    "type": "string"
                   }
                 },
                 "required": [
                   "holeActorId",
-                  "targetActorId"
+                  "targetActorId",
+                  "layerId"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "accId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      }
+    },
+    "/papi/1.0/actors/revert_hole/{accId}": {
+      "post": {
+        "tags": [
+          "Graph"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "targetActorId": {
+                    "type": "string"
+                  },
+                  "layerId": {
+                    "type": "string"
+                  },
+                  "holeActorId": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "targetActorId",
+                  "layerId"
                 ]
               }
             }
@@ -3443,6 +3491,16 @@
                             "text": {
                               "type": "string"
                             },
+                            "subtitle": {
+                              "type": "string"
+                            },
+                            "icon": {
+                              "type": "string"
+                            },
+                            "count": {
+                              "type": "integer",
+                              "minimum": 1
+                            },
                             "createdAt": {
                               "type": "number"
                             }
@@ -3680,6 +3738,16 @@
                             },
                             "text": {
                               "type": "string"
+                            },
+                            "subtitle": {
+                              "type": "string"
+                            },
+                            "icon": {
+                              "type": "string"
+                            },
+                            "count": {
+                              "type": "integer",
+                              "minimum": 1
                             },
                             "createdAt": {
                               "type": "number"
@@ -4048,6 +4116,16 @@
                             },
                             "text": {
                               "type": "string"
+                            },
+                            "subtitle": {
+                              "type": "string"
+                            },
+                            "icon": {
+                              "type": "string"
+                            },
+                            "count": {
+                              "type": "integer",
+                              "minimum": 1
                             },
                             "createdAt": {
                               "type": "number"
@@ -12915,6 +12993,7 @@
         }
       },
       "put": {
+        "operationId": "updateLayerPositions",
         "tags": [
           "Graph"
         ],
@@ -14215,6 +14294,9 @@
                   "abbreviation": {
                     "type": "string",
                     "maxLength": 255
+                  },
+                  "transferOnly": {
+                    "type": "boolean"
                   }
                 },
                 "required": [
@@ -16097,6 +16179,78 @@
             "required": false
           }
         ],
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      }
+    },
+    "/papi/1.0/ai": {
+      "post": {
+        "description": "cc-api AI-usage callback: kind=tokens (usage) or kind=cost (request_id+cost)",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "kind": {
+                    "type": "string",
+                    "enum": [
+                      "tokens",
+                      "cost"
+                    ]
+                  },
+                  "session_id": {
+                    "type": "string"
+                  },
+                  "dialog_actor_id": {
+                    "type": "string"
+                  },
+                  "acc_id": {
+                    "type": "string"
+                  },
+                  "user_id": {},
+                  "usage": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "input_tokens": {
+                        "type": "number"
+                      },
+                      "output_tokens": {
+                        "type": "number"
+                      },
+                      "total_tokens": {
+                        "type": "number"
+                      },
+                      "cache_read_input_tokens": {
+                        "type": "number"
+                      },
+                      "cache_creation_input_tokens": {
+                        "type": "number"
+                      }
+                    }
+                  },
+                  "request_id": {
+                    "type": "string"
+                  },
+                  "cost": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "kind",
+                  "dialog_actor_id",
+                  "acc_id"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "200": {
             "description": "Default Response"

--- a/plugins/simulator/skills/simulator-forms/SKILL.md
+++ b/plugins/simulator/skills/simulator-forms/SKILL.md
@@ -47,6 +47,25 @@ fields, and field types of every actor.
 
 ---
 
+## Reading a form's "knowledge"
+
+A form carries human-written documentation that is the **authoritative source** for what
+it and its fields mean. Read and **interpret** it before answering about a form's purpose
+or the meaning of a field/parameter — never guess from a field's `title`/`class`:
+
+- **Form-level `description`** — a top-level key on the form object; explains the form's purpose.
+- **Field-level `description`** — a flat, **optional** key on each field at
+  `sections[].content[].description` (the field's helper text). Present on some fields, absent
+  on others.
+
+Because reads should always pass a `filter`, **include `description` and `sections` in the
+`getForm` `filter`** when you need to understand a form or its fields — a narrower filter drops
+them. If the relevant description isn't already in context — e.g. a follow-up question a few
+turns later — **re-read the form** with `getForm`; do not answer from memory or invent a
+field's meaning.
+
+---
+
 ## Form Concepts
 
 **Forms are templates. Actors are instances.**
@@ -150,8 +169,10 @@ actor data is keyed by field **`id`**, never by the field `title` or its seconda
 | Delete a form | `deleteForm(formId=42)` |
 
 > **Save tokens with `filter`.** `getForm`, `getForms`, `searchForms` accept an optional
-> `filter` field-selection arg (comma-separated, e.g. `filter="id,title,sections"`); the
-> server returns only those fields. Templates can be large — request just what you need.
+> `filter` field-selection arg (comma-separated, e.g. `filter="id,title,description,sections"`); the
+> server returns only those fields. Templates can be large — request just what you need, but keep
+> `description` (form purpose) and `sections` (field definitions, incl. each field's `description`)
+> when you need to understand the form.
 
 ### Create a form
 

--- a/plugins/simulator/skills/simulator/SKILL.md
+++ b/plugins/simulator/skills/simulator/SKILL.md
@@ -80,6 +80,26 @@ To create or edit skills, use **`/simulator-skills`**.
 
 ---
 
+## Response & output conventions
+
+These apply to **every** answer you produce, regardless of which sub-skill is active:
+
+- **Language.** Reply in the language of the user's latest message, and do **not** switch
+  language within a single answer. These instructions and the tool/parameter descriptions
+  are written in English for tooling reasons — they do **not** dictate the answer's language.
+- **No HTML escaping in prose.** Write `>` as `>`, `<` as `<`, `&` as `&` — never emit
+  `&gt;` / `&lt;` / `&amp;` in your reply text. HTML/BBCode escaping belongs only inside
+  values you send to a tool (e.g. an actor's or reaction's `description`), not in the chat reply.
+- **Timestamps.** Platform time fields are **unixtime in UTC**, either **seconds** (10-digit)
+  or **milliseconds** (13-digit; e.g. transaction `created_at` — divide by 1000) — tell them
+  apart by digit count. **Convert to the user's time zone and label the offset**
+  (e.g. `18:30 (UTC+3)`): read `timeZoneOffset` from the UI-context / `control-events-context`
+  (minutes, JS-style — `-180` = UTC+3; see [`ui-context.md`]($CLAUDE_PLUGIN_ROOT/docs/entities/ui-context.md)).
+  If no `timeZoneOffset` is available (e.g. a plain Claude Code session), present the value in
+  **UTC and label it** (`15:30 UTC`). Never show an unlabelled or un-converted wall-clock time.
+
+---
+
 ## MCP Tool Usage
 
 Each API operation is a dedicated MCP tool. The tool name is the swagger


### PR DESCRIPTION
## Summary

AI-assistant behaviour fixes from QA feedback (A2–A5; A1 was an invalid report — only needed a more precise request). Bumps the plugin to **2.2.0**.

- **Form knowledge is read, not guessed.** `getForm`'s default field-filter example now includes `description` and its Summary tells the assistant to keep `description`/`sections` when it needs to understand a form. `/simulator-forms` instructs reading & interpreting the form-level `description` and each field's `sections[].content[].description` (re-reading the form rather than answering from memory). Fixes the assistant inventing a field's meaning (e.g. confusing the escalation `cooldown` with `delay`).
- **Response & output conventions** added to `/simulator` (every answer): reply in the user's language without switching mid-answer; never HTML-escape prose (`>` stays `>`, not `&gt;`); timestamps are unixtime UTC (seconds = 10-digit / milliseconds = 13-digit, e.g. tx `created_at` ÷1000) — convert to the user's time zone via UI-context `timeZoneOffset` and label it (`18:30 (UTC+3)`), falling back to labelled UTC.
- `apiclient.UIContext.TimeZoneOffset *int` parses the offset (`nil` = absent → UTC).
- Docs: `forms.md` / `transactions.md` / `balances.md` / `ui-context.md`; `docs/INTEGRATION.md` §9a documents the end-to-end timezone context flow (front-end builds it, pong-server passes through).

## Paired change (separate repo)

`pong-front-end` — `setWebWidgetReactionContext` now adds `timeZoneOffset` (`new Date().getTimezoneOffset()`) to the `control-events-context` (branch `feat/ai-console-timezone-offset`, not yet pushed — corp GitLab). **pong-server needs no change** (verified pass-through). Until the front-end change ships, the agent falls back to labelled UTC.

## Test plan

- [x] `make build` / `make vet` clean; `Form` / `Eval` / `UIContext` tests pass.
- [ ] Note: `TestSpecDrift` fails on `updateLayerPositions` — **pre-existing and unrelated** (stale `testdata/papi-openapi.json` vs graph ops; refresh via `yarn dump-openapi` from pong-server).
- [ ] Manual: cooldown/delay answered from the form's `description`; reply language stays in the user's language; `>` not rendered as `&gt;`; transaction time shown with an explicit zone label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
