### PR TITLE
feat: add simulator-feedback skill and improve CDU Corezoid backend guidance

### DIFF
--- a/plugins/simulator/skills/simulator-feedback/SKILL.md
+++ b/plugins/simulator/skills/simulator-feedback/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: simulator-feedback
+description: >
+  Collects and submits bug reports, improvement requests, and quality signals
+  about the Simulator.Company plugin to the team. Activate in two cases:
+
+  1. The user signals dissatisfaction, reports a bug, or requests an improvement —
+  phrases like "this is not what I asked", "it did the wrong thing", "that's broken",
+  "можна було б краще", "хотілось би щоб", "було б здорово якби", "спрацювало не так",
+  "це не те", "воно зламало мій актор", "не те що я хотів", "можно было бы лучше",
+  "хотелось бы чтобы", "было бы здорово если", "это не то", or explicitly asks to
+  report a bug or send feedback to the Simulator team.
+
+  2. The user message reveals a plugin-level mistake — wrong tool used, wrong API
+  operation, wrong entity type, missing required field, wrong access rule approach —
+  even without explicit phrases. In this case add one offer line to whatever response
+  you are giving; do not open a separate flow unless the user agrees.
+
+  Do NOT activate for business-logic iterations: changing actor data, adding fields
+  to a form, adjusting graph links, renaming things. These are normal user-driven
+  changes, not plugin issues.
+---
+
+# Simulator Feedback Skill
+
+You help users report bugs, suggest improvements, and flag unexpected behavior
+in the Simulator.Company plugin to the team.
+
+## When to offer and how to phrase it
+
+**Case 1 — bug or broken behavior.** The user reports something that stopped
+working, produced wrong output, or broke their actor/form/process. Offer once,
+adapting to the language of the conversation:
+
+> "Хочете повідомити про баг команді Simulator.Company?"
+> "Хотите сообщить о баге команде Simulator.Company?"
+> "Would you like to report this bug to the Simulator.Company team?"
+
+**Case 2 — improvement request.** The user hints that something could work
+better ("хотілось би", "було б здорово", "можна покращити", "хотелось бы"):
+
+> "Хочете надіслати побажання команді Simulator.Company?"
+> "Хотите отправить пожелание команде Simulator.Company?"
+> "Would you like to send this suggestion to the Simulator.Company team?"
+
+**Case 3 — plugin-level mistake.** The message reveals that the plugin chose
+the wrong tool, wrong entity, or wrong structure. Add one line to the normal
+response without interrupting it:
+
+> "Хочете повідомити про це команді Simulator.Company?"
+> "Хотите сообщить об этом команде Simulator.Company?"
+> "Would you like to report this to the Simulator.Company team?"
+
+In all cases: offer once per problem context, do not repeat if the user declines.
+Do not offer when the user is iterating on business logic or data.
+
+## What to collect
+
+If the user agrees, **derive as much as possible from context** and ask only for what is missing:
+
+| Field | Meaning |
+|-------|---------|
+| `problem` *(required)* | What went wrong, in the user's words |
+| `expected` | What the user expected to happen |
+| `proposed_solution` | How the user thinks it should work |
+| `tool` | Which tool or skill was involved (derive from context) |
+| `transcript_excerpt` | Short relevant excerpt of the dialog |
+| `contact` | Optional email or handle for follow-up |
+
+## Mandatory confirmation step
+
+**Before calling `send-feedback`, always show the user exactly what will be sent** (adapt language to conversation):
+
+```
+Планую надіслати таке:
+• Проблема: <problem text>
+• Очікувалось: <expected text>
+• Пропозиція: <proposed_solution text>
+• Інструмент: <tool>
+• Уривок з діалогу: <transcript_excerpt>
+• Контакт: <contact or "не вказано">
+```
+
+Explicitly note that any tokens, API keys, and secrets have been masked. Ask the user to confirm, edit, or cancel before proceeding.
+
+**Never call `send-feedback` without an explicit "yes" / "да" / "так" / "відправляй" / "отправляй" from the user.**
+
+## Calling the tool
+
+After confirmation, call the MCP tool `send-feedback` from the Corezoid plugin:
+
+```
+send-feedback(
+  problem: "<user's description>",
+  expected: "<optional>",
+  proposed_solution: "<optional>",
+  tool: "<optional — prefix with 'simulator:' to distinguish from corezoid tools>",
+  transcript_excerpt: "<optional, keep short>",
+  contact: "<optional>"
+)
+```
+
+The tool performs its own secret redaction automatically. Pass the raw user text — do not pre-redact in your message to the tool.
+
+**If the Corezoid plugin is not installed** (the `send-feedback` tool is not available in the tool registry), fall back to:
+
+> "Відправте баг-репорт на support@simulator.company з описом проблеми."
+> "Отправьте баг-репорт на support@simulator.company с описанием проблемы."
+> "Please send your report to support@simulator.company with a description of the issue."
+
+## After the tool responds
+
+On success the tool returns a ticket id, for example:
+`Feedback submitted. Ticket id: 6a3b8b6ab677ac777074794f`
+
+Tell the user (in their language):
+> "Дякуємо! Заявку відправлено, номер: `6a3b8b6ab677ac777074794f`. На нього можна посилатись при подальшому обговоренні з командою Simulator.Company."
+> "Спасибо! Заявка отправлена, номер: `6a3b8b6ab677ac777074794f`. По нему можно ссылаться при дальнейшем обсуждении с командой Simulator.Company."
+> "Thank you! Ticket submitted: `6a3b8b6ab677ac777074794f`. Reference this ID in future discussions with the Simulator.Company team."
+
+On error, respond gently (in their language):
+> "Не вдалось надіслати фідбек прямо зараз. Спробуйте пізніше або напишіть на support@simulator.company."
+> "Не удалось отправить фидбек прямо сейчас. Попробуйте позже или напишите на support@simulator.company."
+> "Could not send the feedback right now. Try again later or email support@simulator.company."
+
+Do not show the technical endpoint URL or error details to the user.

--- a/plugins/simulator/skills/simulator-smart-forms/SKILL.md
+++ b/plugins/simulator/skills/simulator-smart-forms/SKILL.md
@@ -11,6 +11,25 @@ description: >
   "edit page layout", "add component to CDU", "rollback release".
 ---
 
+## Dynamic behavior → Always pair with Corezoid backend
+
+**If the Smart Form needs to do ANY of the following, it requires a Corezoid backend process:**
+- Display data loaded from actors, accounts, or other platform entities
+- React to button clicks or field changes with server-side logic
+- Save data back to actors or accounts on submit
+- Drive page-to-page transitions based on business rules
+- Send notifications or trigger other processes
+
+**In these cases, ALWAYS proactively activate the `simulator-smart-forms-logic` skill** — do not wait for the user to ask. After laying out the form structure (pages, widgets, locale), immediately say:
+
+> "This form needs dynamic data / submit handling. I'll now set up the Corezoid backend process that powers it — switching to `/simulator-smart-forms-logic`."
+
+Then hand off to `simulator-smart-forms-logic`, which will author the Corezoid process, provision an API key, and bind it to the form's env.
+
+**Static-only forms** (pure information display, no input, no dynamic data) do NOT need a backend — proceed with layout only.
+
+---
+
 # Simulator.Company Smart Form Author
 
 You are a specialist in creating and editing **Smart Forms** (also called CDU,

--- a/public/.well-known/skills/index.json
+++ b/public/.well-known/skills/index.json
@@ -51,6 +51,13 @@
       "name": "simulator-finance"
     },
     {
+      "description": "Collects and submits bug reports, improvement requests, and quality signals about the Simulator.Company plugin to the team. Activate when the user signals dissatisfaction, reports a bug, requests an improvement, or when a plugin-level mistake is detected. Activate on: \"report a bug\", \"send feedback\", \"this is broken\", \"it did the wrong thing\", \"suggest an improvement\", \"повідомити про баг\", \"надіслати фідбек\", \"це не працює\", \"зламалось\", \"запропонувати покращення\", \"сообщить о баге\", \"отправить фидбек\", \"это не работает\", \"сломалось\", \"предложить улучшение\".",
+      "files": [
+        "https://raw.githubusercontent.com/corezoid/simulator-ai-plugin/main/plugins/simulator/skills/simulator-feedback/SKILL.md"
+      ],
+      "name": "simulator-feedback"
+    },
+    {
       "description": "Simulator.Company form designer specialist. Use when the user wants to create or modify form templates (a.k.a. Account Templates / «Шаблон рахунків»), define custom field structures, set up account definitions, explore system forms, work with Smart Forms (CDU / Scripts), manage form status, or understand how forms define actor structure. Activate when the user says \"create a form\", \"design a template\", \"add fields to form\", \"Account Template\", \"Шаблон рахунків\", \"define actor schema\", or \"what system forms are available\".",
       "files": [
         "https://raw.githubusercontent.com/corezoid/simulator-ai-plugin/main/plugins/simulator/skills/simulator-forms/SKILL.md"


### PR DESCRIPTION
## Summary

- **Add `simulator-feedback` skill** — mirrors the `corezoid-feedback` skill from the Corezoid plugin. Users can now report bugs, request improvements, and flag unexpected plugin behavior directly via Claude Code. The skill appears in the plugin's skill discovery index so users can find it.
- **Fix CDU logic auto-guidance** — `simulator-smart-forms` SKILL.md now has a prominent rule instructing Claude to automatically invoke `simulator-smart-forms-logic` whenever the Smart Form needs dynamic data, submit handling, or backend logic — without the user having to explain this manually each time.

## Problem

1. `/send-feedback` was not visible in the Simulator plugin's skill list (`public/.well-known/skills/index.json`) — users had no way to report issues with the Simulator plugin.
2. When building CDUs (Smart Forms), Claude didn't automatically suggest setting up the Corezoid backend process, forcing users to explicitly explain the architecture every time.

## How to test

**Feedback skill:**
1. Install the plugin
2. Open Claude Code and type `/simulator-feedback` or "I found a bug in the simulator plugin"
3. Verify the skill activates, collects details, shows confirmation, and submits

**CDU guidance:**
1. Ask Claude to "create a CDU that shows an actor's data"
2. Verify Claude proactively mentions that a Corezoid backend is needed and switches to `/simulator-smart-forms-logic` automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)