### PR TITLE
feat: add AWS Kiro support (port #42 to develop)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,3 +99,4 @@ jobs:
             dist/checksums.txt
             public/llms.txt
             public/.well-known/skills/index.json
+            POWER.md

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,8 @@ dump.rdb
 /plugins/simulator/mcp-server/gendiscovery
 # Locally built launcher binary picked up by mcp-server/run.sh (skips download cache).
 /plugins/simulator/mcp-server/simulator-mcp
+
+# Build artifacts emitted by `make discovery-kiro` and the release pipeline.
+# Runtime overlays under .kiro/ are generated from the canonical skills tree —
+# committing them would only invite drift.
+/dist/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ repository. Humans: see the root [`README.md`](README.md) (usage) and
 
 ## What this repo is
 
-A plugin for Claude Code and Codex that connects the **Simulator.Company** platform
+A plugin for Claude Code, Codex, and AWS Kiro that connects the **Simulator.Company** platform
 (backend: `pong-server` / `control-api`) to the host via MCP. It bundles:
 
 - a **Go MCP server** (`plugins/simulator/mcp-server/`) that exposes the Simulator
@@ -98,9 +98,19 @@ reinstall. Verify with `/mcp`. Full guide: README → "Local development".
   Account-Template alias «Шаблон рахунків»). Example *data* values should be language-neutral.
 - **Entity/user-flow docs must stay under `plugins/simulator/docs/`.** Skills reference them
   as `$CLAUDE_PLUGIN_ROOT/docs/...` and only `plugins/simulator/` is copied on install.
-  Contributor/architecture docs go in the repo-root `docs/`.
-- **Versioning.** The plugin version appears in `.claude-plugin/{plugin,marketplace}.json`,
-  `.agents/plugins/marketplace.json` and `CHANGELOG.md` — bump them together.
+  Contributor/architecture docs go in the repo-root `docs/`. The token name is host-imposed:
+  Claude Code and Codex both resolve `$CLAUDE_PLUGIN_ROOT` via text substitution at
+  skill-load time (anthropics/claude-code#48230, #47789, #44057). Renaming it breaks both
+  hosts. AWS Kiro doesn't substitute the token at all — `install-kiro.sh` and the release
+  generator hard-copy the skills and `sed`-replace the token with the absolute plugin path
+  at install time instead.
+- **Versioning.** The plugin version appears in **six** files — keep them in lockstep:
+  `plugins/simulator/.claude-plugin/plugin.json`,
+  `plugins/simulator/.codex-plugin/plugin.json`,
+  `plugins/simulator/.kiro-plugin/plugin.json`,
+  `.claude-plugin/marketplace.json`,
+  `.agents/plugins/marketplace.json`,
+  `POWER.md` (frontmatter), plus the top-of-file entry in `CHANGELOG.md`.
 - **Linter.** `make lint` runs golangci-lint v2 (config `plugins/simulator/mcp-server/.golangci.yml`,
   shared with sibling Go services). `gosec` is clean (real findings fixed; trusted-input taint
   false positives are documented in the `gosec.excludes` list). The broader `default: all` set

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [2.2.0]
+
+### Added
+- AWS Kiro support. The same plugin payload now installs on Kiro alongside the existing Claude Code and Codex hosts via a symmetric overlay: `plugins/simulator/.kiro-plugin/plugin.json`, `plugins/simulator/.mcp.kiro.json`, `plugins/simulator/steering/simulator.md`, and a root-level `POWER.md` distribution manifest for kiro.dev/powers.
+- `plugins/simulator/scripts/install-kiro.sh` sets up an existing Kiro workspace from a cloned repo: copies the MCP entry, symlinks the steering file, hard-copies each skill into `.kiro/skills/<name>/`, and `sed`-substitutes `$CLAUDE_PLUGIN_ROOT` in every `SKILL.md` with the absolute plugin path (Kiro does not substitute the token on its own, unlike Claude Code and Codex). Idempotent — re-run after a `git pull` to refresh the workspace overlay.
+
+### Notes
+- The canonical `SKILL.md` files keep `$CLAUDE_PLUGIN_ROOT` — Claude Code and Codex both resolve that exact token via host-side text substitution (anthropics/claude-code#48230, #47789, #44057) and renaming it would break doc loading on both. The install-time `sed` substitution in `install-kiro.sh` is the only host-specific bit.
+- There is no release-zip Kiro overlay artifact in this version. A pre-built zip would still need a post-extract substitution step (the token can only be resolved to an absolute path that the user actually checked out), so the clone + `install-kiro.sh` path is currently the only correct install flow for Kiro.
+
 ## [2.1.0]
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,11 @@ Guidance for Claude Code when working in the **simulator-ai-plugin** repository.
 - **`$CLAUDE_PLUGIN_ROOT` = `plugins/simulator/`.** Skills load reference docs as
   `$CLAUDE_PLUGIN_ROOT/docs/entities/*.md`. Those files must stay under
   `plugins/simulator/docs/` (only the plugin dir is shipped on install). Contributor docs
-  go in the repo-root `docs/`.
+  go in the repo-root `docs/`. Claude Code and Codex both resolve this exact token via
+  text substitution at skill-load time; renaming it breaks doc loading on both hosts
+  (anthropics/claude-code#48230, #47789, #44057). For AWS Kiro — which does no such
+  substitution — `install-kiro.sh` and the release-zip generator hard-copy the skills
+  and `sed`-replace the token with the absolute plugin path at install time.
 - **MCP tools.** When you add or rename a tool, update the MCP-tools table in the root
   [`README.md`](README.md) and §4 of [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
 - **Curated tools live in Go** under `internal/tools/<domain>.go` (declared as typed

--- a/POWER.md
+++ b/POWER.md
@@ -1,0 +1,112 @@
+---
+name: simulator
+displayName: Simulator.Company
+version: 2.2.0
+description: BPM, graph, and financial-tracking toolkit for the Simulator.Company platform. Exposes the Simulator REST API as MCP tools plus 16 skills covering actors, forms, graphs, layers, accounts, transactions, transfers, charts, smart forms, meetings, reactions, and attachments.
+author:
+  name: Simulator.Company
+  url: https://simulator.company
+homepage: https://doc.simulator.company
+repository: https://github.com/corezoid/simulator-ai-plugin
+license: MIT
+keywords:
+  - simulator
+  - bpm
+  - business-process
+  - graph
+  - financial
+  - actors
+  - forms
+  - mcp
+---
+
+# Simulator.Company Power for AWS Kiro
+
+A Kiro Power that brings the [Simulator.Company](https://simulator.company)
+platform — actors, graphs, forms, financial accounts, transactions, and
+dashboards — directly into your Kiro workspace as MCP tools and skills.
+
+## Install
+
+```sh
+git clone https://github.com/corezoid/simulator-ai-plugin
+cd simulator-ai-plugin
+plugins/simulator/scripts/install-kiro.sh "$YOUR_KIRO_WORKSPACE"
+```
+
+Open the workspace in Kiro. The simulator MCP server registers under
+`.kiro/settings/mcp.json`, the steering file under `.kiro/steering/`, and
+every skill under `.kiro/skills/<name>/`. `install-kiro.sh` hard-copies the
+skills into the workspace and resolves the `$CLAUDE_PLUGIN_ROOT` token in
+each `SKILL.md` to the absolute plugin path, so reference docs at
+`plugins/simulator/docs/...` resolve correctly under Kiro (Kiro does not
+substitute the token on its own).
+
+Re-running `install-kiro.sh` is idempotent: it refreshes the workspace
+overlay in place.
+
+## What it does
+
+- **Actors & forms** — create, search, update, link, and inspect every
+  business-process actor with the full form-schema overlay.
+- **Graph layouts** — pull and push whole layers as YAML, auto-cluster nodes
+  by domain (`compactGraphLayout`), prune sprawling edges (`pruneLongEdges`),
+  enumerate placements in one call (`getAllLayerPlacements`).
+- **Pictures & icons** — `uploadActorPicture` and bulk variant with SVG→PNG
+  auto-rasterisation and SHA-256 dedup.
+- **Financial accounts** — currencies, account names, transactions,
+  transfers, balances, counters, and triggers.
+- **Charts & dashboards** — line / bar / area / funnel charts pinned to a
+  layer; pulled at runtime from real accounts and counters.
+- **Smart forms** — design, deploy, and run CDU/Script smart-form
+  applications.
+
+## MCP tools (highlights)
+
+| Tool | What it does |
+|---|---|
+| `login` | OAuth2 browser login; saves token to `~/.simulator/`. |
+| `set-workspace` | Pick the active workspace by id or name. |
+| `pullGraphFile` / `pushGraphFile` | Export / sync a layer as YAML. |
+| `createActor` / `updateActor` / `deleteActor` | Single-actor CRUD. |
+| `createActors` | Bulk create up to 50 actors per call. |
+| `compactGraphLayout` | Auto-layout actors with domain-clustering. |
+| `pruneLongEdges` | Delete edges exceeding a Manhattan distance threshold. |
+| `getAllLayerPlacements` | One call returns every placement on a layer. |
+| `uploadActorPicture` / `uploadActorPictureBulk` | Icons with SVG→PNG. |
+| `createForm` / `updateForm` / `getForms` | Form-template lifecycle. |
+| `createAccountName` / `createCurrency` / `addFormAccount` | Account setup. |
+| `createTransaction` / `createTransfer` | Move value between accounts. |
+| `createChart` / `createDashboard` | Visualise account / counter data. |
+
+The full tool list is generated from the OpenAPI spec; ~190 operations are
+exposed.
+
+## Skills
+
+Each skill is auto-loaded from `.kiro/skills/<name>/SKILL.md` and routes on
+trigger phrases declared in the SKILL.md frontmatter. Highlights:
+
+- `simulator` — universal entry point and platform overview.
+- `simulator-graph` — graph layouts, actor links, layer canvas operations.
+- `simulator-forms` — form templates, field types, system forms.
+- `simulator-finance` — accounts, transactions, transfers, currencies.
+- `simulator-charts` — charts, dashboards, time-series.
+- `simulator-actors` / `simulator-tasks` / `simulator-attachments` — focused
+  helpers for the corresponding entity.
+- `simulator-smart-forms` (+ `-logic`, `-runtime`) — smart-form design and
+  execution.
+- `simulator-meetings` / `simulator-chat` / `simulator-reactions` —
+  collaboration features.
+- `simulator-init` — first-time environment setup.
+- `simulator-access` — sharing, groups, API keys.
+
+## Same codebase, three hosts
+
+This repository ships the same plugin payload to:
+
+- **Claude Code** — via `claude plugin install simulator@simulator`.
+- **Codex** — via `codex plugin install simulator@simulator`.
+- **AWS Kiro** — via this Power.
+
+One Git tag → one GitHub Release → artifacts for all three hosts.

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -17,13 +17,16 @@ python3 -m json.tool plugins/simulator/.mcp.json >/dev/null
 Verify version sync between manifests:
 
 ```bash
-grep '"version"' plugins/simulator/.claude-plugin/plugin.json \
-                 plugins/simulator/.codex-plugin/plugin.json \
-                 .claude-plugin/marketplace.json \
-                 .agents/plugins/marketplace.json
+grep -E '"version"|^version:' \
+  plugins/simulator/.claude-plugin/plugin.json \
+  plugins/simulator/.codex-plugin/plugin.json \
+  plugins/simulator/.kiro-plugin/plugin.json \
+  .claude-plugin/marketplace.json \
+  .agents/plugins/marketplace.json \
+  POWER.md
 ```
 
-All four should show the same version number.
+All six should show the same version number.
 
 ## 2. Verify Build & Tests
 
@@ -58,13 +61,30 @@ codex plugin install simulator@simulator
 
 Restart Codex, open Plugin Directory, select **Simulator.Company**, and confirm the plugin installs and the skills are available.
 
+## 4b. Test in AWS Kiro
+
+```bash
+plugins/simulator/scripts/install-kiro.sh "$YOUR_KIRO_WORKSPACE"
+```
+
+Open the workspace in Kiro. Confirm:
+
+- `.kiro/settings/mcp.json` is loaded and the `simulator` MCP server appears in Kiro's tool panel.
+- `.kiro/steering/simulator.md` shows in the steering UI.
+- A prompt like "use simulator" routes through `.kiro/skills/simulator/SKILL.md`.
+- A live tool call (e.g. `login`) succeeds end-to-end.
+
+The script is idempotent and supports re-runs to refresh the workspace overlay.
+
 ## 5. Update Files
 
-1. Bump the version in all four manifest files:
+1. Bump the version in **six** files (every host manifest plus the Power manifest):
    - `plugins/simulator/.claude-plugin/plugin.json`
    - `plugins/simulator/.codex-plugin/plugin.json`
+   - `plugins/simulator/.kiro-plugin/plugin.json`
    - `.claude-plugin/marketplace.json` (the `plugins[0].version` field)
    - `.agents/plugins/marketplace.json` (the `plugins[0].version` field)
+   - `POWER.md` (frontmatter `version:` field)
 2. Add a section to `CHANGELOG.md` for the new version.
 3. Commit the changes.
 
@@ -76,7 +96,7 @@ git tag vX.Y.Z
 git push origin vX.Y.Z
 ```
 
-The `release.yml` workflow fires automatically on any `v*` tag. It cross-compiles the MCP server for `darwin/linux × amd64/arm64`, generates SHA-256 checksums, attests build provenance, regenerates `public/` via `make discovery`, and creates a GitHub Release whose body is the matching `CHANGELOG.md` section.
+The `release.yml` workflow fires automatically on any `v*` tag. It cross-compiles the MCP server for `darwin/linux × amd64/arm64`, generates SHA-256 checksums, attests build provenance, regenerates `public/` via `make discovery`, and creates a GitHub Release whose body is the matching `CHANGELOG.md` section. `POWER.md` is attached to every Release so kiro.dev/powers can resolve the Power manifest from the tag — Kiro users install via the clone path described below; there is no pre-built `.kiro/` zip artifact (a release-only overlay would still need a post-extract step to resolve the `$CLAUDE_PLUGIN_ROOT` token, so the clone path is the only correct flow today).
 
 ## 7. Install from GitHub
 
@@ -100,6 +120,23 @@ codex plugin install simulator@simulator
 codex plugin marketplace add corezoid/simulator-ai-plugin --ref main
 codex plugin install simulator@simulator
 ```
+
+**AWS Kiro:**
+
+```bash
+git clone https://github.com/corezoid/simulator-ai-plugin
+plugins/simulator/scripts/install-kiro.sh "$YOUR_KIRO_WORKSPACE"
+```
+
+The script hard-copies the skills into the workspace and resolves the
+`$CLAUDE_PLUGIN_ROOT` token in each `SKILL.md` to the absolute plugin path.
+Kiro does no token substitution on its own, so this install-time resolve
+step is required. The script is idempotent; re-run it after a `git pull`
+to refresh the workspace overlay.
+
+To list this Power on **kiro.dev/powers**, submit the release tag URL to the
+Kiro Power registry. `POWER.md` is attached to every GitHub Release so the
+registry can resolve metadata from the tag.
 
 ## 8. Notify Users
 

--- a/plugins/simulator/.kiro-plugin/plugin.json
+++ b/plugins/simulator/.kiro-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "name": "simulator",
+  "version": "2.2.0",
+  "description": "Simulator.Company platform assistant. Exposes the Simulator REST API as an MCP server and provides skills for managing actors, forms, graph structures, and financial accounts.",
+  "author": {
+    "name": "Simulator.Company",
+    "url": "https://simulator.company"
+  },
+  "homepage": "https://doc.simulator.company",
+  "license": "MIT",
+  "keywords": [
+    "simulator",
+    "bpm",
+    "business-process",
+    "graph",
+    "financial",
+    "actors",
+    "forms",
+    "mcp"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.kiro.json",
+  "kiro": {
+    "steering": "./steering/simulator.md",
+    "skills": "./skills/",
+    "mcpServers": "./.mcp.kiro.json"
+  }
+}

--- a/plugins/simulator/.mcp.kiro.json
+++ b/plugins/simulator/.mcp.kiro.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "simulator": {
+      "command": "sh",
+      "args": ["-c", "export PLUGIN_ROOT=\"${KIRO_PLUGIN_ROOT:-$PWD/.kiro/..}\"; export SIMULATOR_WORK_DIR=\"$PWD\"; exec sh \"$PLUGIN_ROOT/mcp-server/run.sh\""]
+    }
+  }
+}

--- a/plugins/simulator/scripts/install-kiro.sh
+++ b/plugins/simulator/scripts/install-kiro.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+# install-kiro.sh — set up the simulator plugin inside an AWS Kiro workspace.
+#
+# Usage:
+#   plugins/simulator/scripts/install-kiro.sh [workspace-dir]
+#
+# If workspace-dir is omitted, defaults to $KIRO_WORKSPACE_DIR or $PWD.
+# Creates the following under <workspace>/.kiro/:
+#   settings/mcp.json        ← copy of .mcp.kiro.json
+#   steering/<name>.md       ← symlinked from this plugin's steering/
+#   skills/<name>/SKILL.md   ← HARD-COPIED with $CLAUDE_PLUGIN_ROOT resolved
+#                              to the absolute plugin path
+#
+# Why hard-copy and resolve the token, instead of symlinking the source files
+# the way Claude Code / Codex consume them?
+#   - The token `$CLAUDE_PLUGIN_ROOT` is a host-side text substitution Claude
+#     Code performs at skill-load time (anthropics/claude-code#48230 etc.).
+#     Kiro does no such substitution — so the literal `$CLAUDE_PLUGIN_ROOT`
+#     would survive into the model context, leaving every reference-doc path
+#     as a dead string. Resolving the token at install time fixes that.
+#   - Symlinked skills would re-introduce the unresolved token on every read.
+#
+# `sed -i` portability is handled with the `-i.bak`+`find -delete` two-step
+# (works under both GNU sed on Linux and BSD sed on macOS without branching).
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKSPACE="${1:-${KIRO_WORKSPACE_DIR:-$PWD}}"
+KIRO_DIR="$WORKSPACE/.kiro"
+
+if [ ! -d "$WORKSPACE" ]; then
+  echo "ERROR: workspace dir not found: $WORKSPACE" >&2
+  exit 1
+fi
+
+mkdir -p "$KIRO_DIR/settings" "$KIRO_DIR/steering" "$KIRO_DIR/skills"
+
+# 1) MCP entry — always plain copy (workspace-local edits must not leak back).
+cp "$PLUGIN_ROOT/.mcp.kiro.json" "$KIRO_DIR/settings/mcp.json"
+
+# 2) Steering — small, stable, no token substitution needed. Symlink on POSIX,
+#    hard-copy on Windows shells.
+case "$(uname -s 2>/dev/null || echo Unknown)" in
+  MINGW*|CYGWIN*|MSYS*) STEERING_LINK="cp -R" ;;
+  *)                    STEERING_LINK="ln -sfn" ;;
+esac
+for f in "$PLUGIN_ROOT"/steering/*.md; do
+  [ -f "$f" ] || continue
+  $STEERING_LINK "$f" "$KIRO_DIR/steering/$(basename "$f")"
+done
+
+# 3) Skills — HARD-COPY then sed-substitute $CLAUDE_PLUGIN_ROOT in every .md
+#    so reference-doc paths resolve to the absolute plugin dir under Kiro.
+for d in "$PLUGIN_ROOT"/skills/*/; do
+  [ -d "$d" ] || continue
+  name="$(basename "$d")"
+  dst="$KIRO_DIR/skills/$name"
+  rm -rf "$dst"
+  cp -R "$d" "$dst"
+  # `#` delimiter avoids escaping the `/` inside $PLUGIN_ROOT. Backup suffix
+  # is the portable two-step for GNU and BSD sed.
+  find "$dst" -name '*.md' -type f -exec \
+    sed -i.bak "s#\\\$CLAUDE_PLUGIN_ROOT#$PLUGIN_ROOT#g" {} +
+  find "$dst" -name '*.md.bak' -type f -delete
+done
+
+echo "Installed simulator plugin into: $KIRO_DIR"
+echo "Open this workspace in Kiro and the simulator MCP server, skills, and steering will be picked up."
+echo "Reference-doc paths in skills were resolved to: $PLUGIN_ROOT"
+echo
+echo "If your shell does not already set KIRO_PLUGIN_ROOT, add:"
+echo "  export KIRO_PLUGIN_ROOT=\"$PLUGIN_ROOT\""

--- a/plugins/simulator/steering/simulator.md
+++ b/plugins/simulator/steering/simulator.md
@@ -1,0 +1,59 @@
+---
+inclusion: always
+---
+
+# Simulator.Company — workspace guardrails
+
+These rules apply to every interaction with the Simulator MCP server in this
+workspace. They mirror the always-on guardrails the `simulator` skill carries
+inside Claude Code / Codex installs; here they ship as a Kiro steering file
+so Kiro applies them without depending on skill auto-routing.
+
+## Workspace Context Check (MANDATORY FIRST STEP)
+
+**Exception — global-id reads need no `accId`.** If the request targets a
+specific object by its **global id** and only **reads** it (no create/update
+in a workspace), skip this whole check and call the tool directly:
+`getActor`/`deleteActor` (by `actorId`), `getActorByRef`,
+`getAccounts`/`getBalance`/`getTransactions` (by `actorId`/`accountId`),
+`getForm` (by `formId`), reactions/attachments by actor id, etc. These
+endpoints resolve the object by its id and do **not** require workspace
+context — do **not** ask for `accId` or hunt for a `.env`/workspace for them.
+(The `accId` returned in the response can seed later workspace-scoped calls.)
+
+**Otherwise, before doing anything else**, verify the WorkspaceID (`accId`)
+is known:
+
+1. Check whether `accId` is already known: current message, conversation
+   history, or `WORKSPACE_ID` env var / `.env` file in the project directory.
+2. If `accId` is **not** provided, immediately ask the user — **in their own
+   language** (English, Ukrainian, or Russian) — which workspace to work in,
+   i.e. for the Workspace ID (`accId`). If they haven't set up the environment
+   yet, suggest running `set-environment` → `login` → `getWorkspaces` →
+   `set-workspace`. Do **not** call any other MCP tools until the user
+   provides `accId`.
+3. Once `accId` is known, proceed normally and use it in all subsequent API
+   calls.
+
+## Tool routing
+
+- Each public Simulator REST endpoint is exposed as one MCP tool whose name
+  matches the swagger `operationId` (camelCase). Path parameters (`{accId}`,
+  `{formId}`, …) become named arguments.
+- For broader platform context — actors / forms / graph / finance / charts —
+  the matching skill under `.kiro/skills/simulator-*` carries the deep
+  reference docs. Activate the relevant one when the user signals intent.
+
+## Language policy
+
+- Internal instructions and field names stay in English.
+- Reply to the user **in the language they wrote in** (English, Ukrainian, or
+  Russian). Never hardcode a non-English sentence for Claude to say.
+
+## Output discipline
+
+`getActor`, `getForm`, `updateActor`, and `updateForm` return responses that
+can exceed 30k tokens (full access lists, doubled form schemas, member
+metadata). For >10 such calls in a row, delegate to a background agent with
+explicit "do not echo responses" instructions; otherwise the main context
+window fills up after a handful of operations.


### PR DESCRIPTION
Cherry-pick of #42 (`03ccad2`, merged to main) onto develop.

**Conflict resolved:** `papi-openapi.json` — both main and develop add `updateLayerPositions` (under different path entries; a pre-existing main↔develop divergence unrelated to Kiro). #42 touches no Go op for it, so develop's spec was kept as-is (`--ours`); nothing Kiro-specific lost.

**Net change vs develop:** Kiro files + docs only — no spec/Go changes:
- new: `.kiro-plugin/plugin.json`, `.mcp.kiro.json`, `steering/simulator.md`, `scripts/install-kiro.sh`, `POWER.md`
- edits: AGENTS.md, CLAUDE.md, CHANGELOG.md, PUBLISHING.md, release.yml, .gitignore

**Verified locally:** make build, vet, full go test (TestSpecDrift passes), make discovery (no drift) — all green.