### PR TITLE
chore(repo): make develop the PR base convention (docs + CI guard)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,6 @@
 <!-- See CONTRIBUTING.md before opening a PR. -->
+<!-- BASE BRANCH: target `develop`, not `main`. `main` is release-only and a CI guard
+     rejects feature/fix PRs into it. Release/hotfix promotions use `release/*` / `hotfix/*`. -->
 
 ## What & why
 

--- a/.github/workflows/guard-base-branch.yml
+++ b/.github/workflows/guard-base-branch.yml
@@ -1,0 +1,37 @@
+name: Guard base branch
+
+# `main` is release-only: it may receive changes solely by promoting `develop`
+# (a `develop` → `main` release PR) or via a `release/*` / `hotfix/*` branch.
+# This job fails any other PR opened against `main`, so feature/fix work is forced
+# through `develop`. It only runs for PRs whose base is `main`, so PRs into
+# `develop` are unaffected. Make it a required status check in `main`'s branch
+# protection to turn this from advisory into a hard gate.
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    name: Base branch is develop / release / hotfix
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject feature/fix PRs targeting main
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          echo "PR base: main"
+          echo "PR head: $HEAD_REF"
+          case "$HEAD_REF" in
+            develop|release/*|hotfix/*)
+              echo "✓ '$HEAD_REF' may target main."
+              ;;
+            *)
+              echo "::error::PRs into 'main' must come from 'develop', 'release/*', or 'hotfix/*' (got '$HEAD_REF')."
+              echo "main is release-only. Retarget this PR to 'develop' (Edit → change base), or promote via a release/hotfix branch. See CONTRIBUTING.md."
+              exit 1
+              ;;
+          esac

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,11 @@ reinstall. Verify with `/mcp`. Full guide: README → "Local development".
   hosts. AWS Kiro doesn't substitute the token at all — `install-kiro.sh` and the release
   generator hard-copy the skills and `sed`-replace the token with the absolute plugin path
   at install time instead.
+- **Branching model.** `develop` is the integration branch and the **default base for
+  every feature/fix PR**; `main` is release-only and receives changes solely by promoting
+  `develop` (or a `release/*` / `hotfix/*` branch). Never open a feature/fix PR against
+  `main` — a CI guard (`.github/workflows/guard-base-branch.yml`) rejects any PR into `main`
+  whose head isn't `develop`, `release/*`, or `hotfix/*`.
 - **Versioning.** The plugin version appears in **six** files — keep them in lockstep:
   `plugins/simulator/.claude-plugin/plugin.json`,
   `plugins/simulator/.codex-plugin/plugin.json`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,12 +67,24 @@ docs: document set-environment in README
 chore(skills): regenerate discovery artifacts
 ```
 
+## Branching model
+
+We follow a simple `develop`-integration flow:
+
+- **`develop`** is the integration branch and the **default base for every feature/fix PR.**
+- **`main`** holds releases only. It receives changes **exclusively** by promoting
+  `develop` (a release PR `develop` → `main`) or via a `release/*` / `hotfix/*` branch.
+- Do **not** open feature/fix PRs against `main` — a CI guard
+  (`.github/workflows/guard-base-branch.yml`) fails any PR into `main` whose source
+  branch isn't `develop`, `release/*`, or `hotfix/*`.
+
 ## Pull requests
 
-1. Branch off `main`.
-2. Keep the change focused; update docs and the changelog alongside code.
-3. Ensure `make build && make vet && make test` pass.
-4. Fill in the PR template.
+1. Branch off `develop` (e.g. `git switch -c feat/my-change develop`).
+2. Target **`develop`** as the PR base (it's the repo default, so this is automatic).
+3. Keep the change focused; update docs and the changelog alongside code.
+4. Ensure `make build && make vet && make test` pass.
+5. Fill in the PR template.
 
 ## Reporting issues
 


### PR DESCRIPTION
Makes "feature/fix PRs go to `develop`, not `main`" an enforced repo convention.

## Changes
- **CONTRIBUTING.md** — new *Branching model* section + fixed the old `Branch off \`main\`` step (the root cause of PRs landing on main). PRs now branch off and target `develop`.
- **AGENTS.md** — branching-model convention for agents.
- **PR template** — base-branch reminder near the top.
- **.github/workflows/guard-base-branch.yml** — fails any PR into `main` whose head isn't `develop` / `release/*` / `hotfix/*`. Only runs for PRs based on `main`, so `develop` PRs are unaffected.

## Companion repo-settings changes (admin, done separately)
- Default branch → `develop` (so new PRs auto-target develop).
- Branch protection on `main`: require PRs + this guard as a required status check.

Guard job name (for the required-check setting): **`Base branch is develop / release / hotfix`**.