### PR TITLE
docs(integration): sync-diff now covered by graph sync test suite

### DIFF
--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -281,7 +281,7 @@ replaces the 3k-line `server.go`: simple CRUD is generated from the curated spec
 5. ✅ **Engines ported** → `internal/engines` (pull/push graph sync, `compactGraphLayout`,
    `pruneLongEdges`, `getAllLayerPlacements`, `createChart`) reusing the proven legacy logic,
    registered via `engines.RegisterTools`. *(thin runtime config + cosmetic form-name stubs;
-   sync-diff unit tests still TODO)*
+   sync-diff tests are now covered by the graph sync test suite)*
 6. ✅ **Media ported** (`upload` + `svg` rasterise) → `internal/engines`.
 7. ✅ **Apps + smart-form tools** (`apps.go`): createApplication, createSmartForm,
    listSmartForms, manageAppContent. *(getApplication dropped — no backend route; the drift


### PR DESCRIPTION
## What

Replace stale migration-note wording in `docs/INTEGRATION.md` that still said sync-diff unit tests were TODO.

## Why

The graph sync test suite (`plugins/simulator/mcp-server/internal/engines/graph/sync_test.go`, alongside `security_test.go`, `limit_test.go`, `jsonint_test.go`) now covers this, so the note is out of date.

## Change

```diff
-   sync-diff unit tests still TODO)*
+   sync-diff tests are now covered by the graph sync test suite)*
```

Docs-only, low risk.

Closes #41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)