### PR TITLE
docs(graph): document edge colour & width in manageLayerActors layerSettings

### DIFF
--- a/plugins/simulator/mcp-server/internal/tools/graph.go
+++ b/plugins/simulator/mcp-server/internal/tools/graph.go
@@ -190,7 +190,7 @@ var graphOps = []Operation{
 		Params: []Param{
 			{Name: "actorId", In: InPath, Type: "string", Required: true, Desc: "Layer actor UUID."},
 			{Name: "items", In: InBodyRoot, Type: "array", Required: true, Desc: "Array of {action, data:{id, type, position?, laIdSource?, laIdTarget?}} actions. " +
-				"For an EDGE (type:\"edge\"), data also accepts `layerSettings:{lineStyle:\"solid\"|\"dashed\"|\"dotted\", color:\"#RRGGBB\" (line colour), width:\"2\" (stroke width, string)}` to style the line — dash pattern, colour and thickness (omit → solid default). " +
+				"For an EDGE (type:\"edge\"), data also accepts `layerSettings:{lineStyle:\"solid\"|\"dashed\"|\"dotted\", curveStyle:\"curved\"|\"rounded\"|\"roundedDownward\"|\"straight\", color:\"#RRGGBB\" (6-digit hex only — no #abc shorthand, no alpha), width:2 (integer ≥ 1), routingPoints:[{w:number, d:number}] (manual-routing waypoints)}` to style the line (omit → solid). " +
 				"To CHANGE an existing edge's style, delete its placement and create it again with the new lineStyle — re-creating without deleting first adds a duplicate edge placement."},
 			{Name: "withNum", In: InQuery, Type: "boolean", Desc: "Return counts in the response."},
 		},

--- a/plugins/simulator/mcp-server/internal/tools/graph.go
+++ b/plugins/simulator/mcp-server/internal/tools/graph.go
@@ -190,7 +190,7 @@ var graphOps = []Operation{
 		Params: []Param{
 			{Name: "actorId", In: InPath, Type: "string", Required: true, Desc: "Layer actor UUID."},
 			{Name: "items", In: InBodyRoot, Type: "array", Required: true, Desc: "Array of {action, data:{id, type, position?, laIdSource?, laIdTarget?}} actions. " +
-				"For an EDGE (type:\"edge\"), data also accepts `layerSettings:{lineStyle:\"solid\"|\"dashed\"|\"dotted\"}` to style the line (omit → solid). " +
+				"For an EDGE (type:\"edge\"), data also accepts `layerSettings:{lineStyle:\"solid\"|\"dashed\"|\"dotted\", color:\"#RRGGBB\" (line colour), width:\"2\" (stroke width, string)}` to style the line — dash pattern, colour and thickness (omit → solid default). " +
 				"To CHANGE an existing edge's style, delete its placement and create it again with the new lineStyle — re-creating without deleting first adds a duplicate edge placement."},
 			{Name: "withNum", In: InQuery, Type: "boolean", Desc: "Return counts in the response."},
 		},

--- a/plugins/simulator/skills/simulator-graph/SKILL.md
+++ b/plugins/simulator/skills/simulator-graph/SKILL.md
@@ -157,7 +157,7 @@ pushGraphFile(layerId="<layerId>")
 
 ---
 
-## Styling edges — colour, dash, width
+## Styling edges — colour, dash, width, curve
 
 An edge placement's `data.layerSettings` controls how the line renders, applied **when
 you place the edge** via `manageLayerActors`:
@@ -165,17 +165,21 @@ you place the edge** via `manageLayerActors`:
 ```
 manageLayerActors(actorId="<layerId>", items=[
   { action:"create", data:{ id:"<edgeId>", type:"edge", laIdSource:<laA>, laIdTarget:<laB>,
-      layerSettings:{ lineStyle:"dashed", color:"#E8924E", width:"2" } } }
+      layerSettings:{ lineStyle:"dashed", color:"#E8924E", width:2, curveStyle:"straight" } } }
 ])
 ```
 
 - `lineStyle` — `solid` | `dashed` | `dotted`
-- `color` — hex line colour (e.g. `#9AA5B1` grey, `#E8924E` orange, `#6E9BD6` blue)
-- `width` — stroke width, as a string (e.g. `"2"`)
+- `curveStyle` — `curved` | `rounded` | `roundedDownward` | `straight`
+- `color` — 6-digit hex `#RRGGBB` (e.g. `#9AA5B1` grey, `#E8924E` orange) — no 3-digit shorthand, no alpha
+- `width` — stroke width, an integer ≥ 1 (e.g. `2`)
+- `routingPoints` — optional array of `{ w:number, d:number }` waypoints for manual edge routing
 
-Use it to encode meaning in edges — coloured solid = data/structure flows, grey dashed =
-logical cross-links. To change an edge already on the layer, delete its placement and
-re-create it with the new `layerSettings` (re-creating without deleting first adds a duplicate).
+These are the pong-server edge `layerSettings` keys (`saveEdgeLayerSettingsSchema`); on
+`manageLayerActors` they ride through unvalidated, so use the canonical types above — an integer
+`width` and a 6-digit hex `color`. Use it to encode meaning in edges — coloured solid = data/structure
+flows, grey dashed = logical cross-links. To change an edge already on the layer, delete its placement
+and re-create it with the new `layerSettings` (re-creating without deleting first adds a duplicate).
 
 ---
 

--- a/plugins/simulator/skills/simulator-graph/SKILL.md
+++ b/plugins/simulator/skills/simulator-graph/SKILL.md
@@ -157,6 +157,28 @@ pushGraphFile(layerId="<layerId>")
 
 ---
 
+## Styling edges — colour, dash, width
+
+An edge placement's `data.layerSettings` controls how the line renders, applied **when
+you place the edge** via `manageLayerActors`:
+
+```
+manageLayerActors(actorId="<layerId>", items=[
+  { action:"create", data:{ id:"<edgeId>", type:"edge", laIdSource:<laA>, laIdTarget:<laB>,
+      layerSettings:{ lineStyle:"dashed", color:"#E8924E", width:"2" } } }
+])
+```
+
+- `lineStyle` — `solid` | `dashed` | `dotted`
+- `color` — hex line colour (e.g. `#9AA5B1` grey, `#E8924E` orange, `#6E9BD6` blue)
+- `width` — stroke width, as a string (e.g. `"2"`)
+
+Use it to encode meaning in edges — coloured solid = data/structure flows, grey dashed =
+logical cross-links. To change an edge already on the layer, delete its placement and
+re-create it with the new `layerSettings` (re-creating without deleting first adds a duplicate).
+
+---
+
 ## Custom Form Data — Populating `actors.data`
 
 When the user specifies a **custom `formId`** (or a non-system `formName`) for one or more actors, you **must** fetch the form schema before writing the YAML file or pushing to the server.


### PR DESCRIPTION
## Problem
`manageLayerActors` passes each item's `data.layerSettings` to the backend verbatim, and the backend **renders** an edge's line **colour**, **dash pattern** and **width** from it. But the tool documented only `lineStyle`, so `color` and `width` were undiscoverable — a caller could not set an edge's colour/thickness even though the backend already accepts it.

## What & why
- Add `color` and `width` alongside `lineStyle` in the edge `layerSettings` description on `manageLayerActors`.
- Add a **"Styling edges"** section to the `simulator-graph` skill.

Documentation only — the `items` array is a passthrough, so the field already reaches the wire; this just surfaces it so the model/user can use it.

## How to use
```
manageLayerActors(actorId="<layerId>", items=[
  { action:"create", data:{ id:"<edgeId>", type:"edge", laIdSource:<laA>, laIdTarget:<laB>,
      layerSettings:{ lineStyle:"dashed", color:"#E8924E", width:"2" } } }
])
```
To restyle an edge already on the layer, delete its placement and re-create it with the new `layerSettings`.

## How tested
- `go build ./...`, `go test ./internal/tools/...`, spec-drift gate — all green.
- **Live** on a real layer via the MCP: a placement with `{color:"#7C3AED", width:"5", lineStyle:"dashed"}` renders a purple, thick, dashed edge.

Found while building an ADAM/EVE company map — the styling was reachable in the backend but not surfaced by the tool or skill. Independent of the sibling text-label-node and pictureObject PRs (all three merge cleanly with each other).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
