### PR TITLE
docs(graph): document text-label nodes in manageLayerActors layerSettings

### DIFF
--- a/plugins/simulator/mcp-server/internal/tools/graph.go
+++ b/plugins/simulator/mcp-server/internal/tools/graph.go
@@ -186,7 +186,7 @@ var graphOps = []Operation{
 	},
 	{
 		Name: "manageLayerActors", Method: "POST", Path: "/graph_layers/actors/{actorId}",
-		Summary: "Place or remove nodes/edges on a layer. Pass an array of {action: create|delete, data: {id, type: node|edge, position?}} items. An edge placement may also carry a line style — see `items`.",
+		Summary: "Place or remove nodes/edges on a layer. Pass an array of {action: create|delete, data: {id, type: node|edge, position?}} items. An edge placement may also carry a line style — see `items`. A NODE placement can render the actor's `description` as a borderless text label instead of a node circle via `data.layerSettings:{isTextNode:true, textNodeScale:1.5, textWidth:300, textHeight:50}` — size the box to the text (≈16·scale px/char) or it wraps and breaks; see the simulator-graph skill.",
 		Params: []Param{
 			{Name: "actorId", In: InPath, Type: "string", Required: true, Desc: "Layer actor UUID."},
 			{Name: "items", In: InBodyRoot, Type: "array", Required: true, Desc: "Array of {action, data:{id, type, position?, laIdSource?, laIdTarget?}} actions. " +

--- a/plugins/simulator/skills/simulator-graph/SKILL.md
+++ b/plugins/simulator/skills/simulator-graph/SKILL.md
@@ -213,6 +213,30 @@ actors:
 
 ---
 
+## Text-label nodes
+
+Render an actor's `description` as borderless text (no node circle) by placing it with
+`isTextNode` in its `data.layerSettings` on `manageLayerActors`:
+
+```
+createActor(formId=3279, description="Section title")          // the text lives in `description`
+manageLayerActors(actorId="<layerId>", items=[
+  { action:"create", data:{ id:"<actorId>", type:"node", position:{x:0,y:0},
+      layerSettings:{ isTextNode:true, textNodeScale:1.5, textWidth:320, textHeight:44 } } }
+])
+```
+
+- `isTextNode:true` — render the node as a text label
+- `textNodeScale` — font-size multiplier
+- `textWidth` / `textHeight` — text-box size in px. **Scale it to the text** — roughly
+  `16·scale` px per character wide and `28·scale` px per line tall — or large/long text wraps
+  and breaks mid-word.
+
+Good for section titles, axis labels and annotations on a graph. To change it, delete the
+placement and re-create it with the new `layerSettings`.
+
+---
+
 ## Graph File Format Reference
 
 ```yaml


### PR DESCRIPTION
## Problem
A node placement's `data.layerSettings:{isTextNode:true, textNodeScale, textWidth, textHeight}` makes the backend render the actor's `description` as a **borderless text label** instead of a node circle — ideal for section titles, axis labels and annotations. The field was already accepted on the wire but undocumented, so callers could not discover it.

## What & why
- Note the text-label option on the `manageLayerActors` summary.
- Add a **"Text-label nodes"** section to the `simulator-graph` skill, including the box-sizing rule (≈16·scale px per character, ≈28·scale px per line) so large text does not wrap and break mid-word.

Documentation only — the `items` array is a passthrough; this surfaces the field.

## How to use
```
createActor(formId=3279, description="Section title")
manageLayerActors(actorId="<layerId>", items=[
  { action:"create", data:{ id:"<actorId>", type:"node", position:{x:0,y:0},
      layerSettings:{ isTextNode:true, textNodeScale:1.5, textWidth:320, textHeight:44 } } }
])
```

## How tested
- `go build ./...`, `go test ./internal/tools/...`, spec-drift gate — all green.
- **Live** on a real layer via the MCP: a node placed with `{isTextNode:true, textNodeScale:1, textWidth:820, textHeight:44}` renders its description as a single-line text label.

Found while building an ADAM/EVE company map — text labels were reachable in the backend but not surfaced by the tool or skill. Independent of the sibling edge-styling and pictureObject PRs (all three merge cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
