### PR TITLE
feat(actors): expose pictureObject on createActor / updateActor (napkin custom-image nodes)

### DIFF
--- a/plugins/simulator/mcp-server/internal/tools/actors.go
+++ b/plugins/simulator/mcp-server/internal/tools/actors.go
@@ -66,6 +66,16 @@ const holeDesc = "Mark this actor as a HOLE — an empty placeholder slot on the
 	"hollow node). A hole stands for a not-yet-filled position in the structure and becomes a normal " +
 	"actor once it is filled with data. Default false."
 
+// pictureObjectDesc documents the `pictureObject` field: ANY custom image rendered
+// AS the node body (the backend's "napkin" element) instead of a standard form
+// node — a line, a shape, an icon, a logo, a small diagram. A divider line is just
+// one use.
+const pictureObjectDesc = "Render a custom image AS the node itself — the backend's \"napkin\" element — instead of a normal form node. " +
+	"The image can be ANYTHING a PNG/SVG holds: a line, a circle, a rectangle, an icon, a logo, a hand-drawn shape, a small diagram. " +
+	"Object shape: {\"img\": \"data:image/png;base64,…\" (a PNG/SVG data URI), \"width\": 800, \"height\": 8 (display size in px), \"type\": \"napkin\"}. " +
+	"The image is anchored at its CENTRE and keeps the source's aspect ratio (set width; height follows) — e.g. for a thin divider line use a wide-and-short source PNG. " +
+	"Uses: dividers/separators, a custom shape or icon the form catalogue does not cover, an embedded picture or logo on a graph."
+
 // actorOps — actor (graph node) CRUD. Actors are instances of a form; their
 // fields live in the free-form `data` object keyed by the form's field schema.
 var actorOps = []Operation{
@@ -82,6 +92,7 @@ var actorOps = []Operation{
 			{Name: "description", In: InBody, Type: "string", Desc: "Optional description."},
 			{Name: "color", In: InBody, Type: "string", Desc: "Hex node color (e.g. #409547)."},
 			{Name: "picture", In: InBody, Type: "string", Desc: "Storage path / URL of the node icon."},
+			{Name: "pictureObject", In: InBody, Type: "object", Desc: pictureObjectDesc},
 			{Name: "ref", In: InBody, Type: "string", Desc: "Optional external reference (1-255 chars), unique per form."},
 			{Name: "appId", In: InBody, Type: "string", Desc: appIdDesc},
 			{Name: "appSettings", In: InBody, Type: "object", Desc: appSettingsDesc},
@@ -121,6 +132,7 @@ var actorOps = []Operation{
 			{Name: "title", In: InBody, Type: "string", Desc: "New title."},
 			{Name: "description", In: InBody, Type: "string", Desc: "New description."},
 			{Name: "color", In: InBody, Type: "string", Desc: "New hex color."},
+			{Name: "pictureObject", In: InBody, Type: "object", Desc: "Set/replace the node's custom image. " + pictureObjectDesc},
 			{Name: "status", In: InBody, Type: "string", Desc: "New status value."},
 			{Name: "appId", In: InBody, Type: "string", Desc: appIdDesc},
 			{Name: "appSettings", In: InBody, Type: "object", Desc: appSettingsDesc},

--- a/plugins/simulator/skills/simulator-graph/SKILL.md
+++ b/plugins/simulator/skills/simulator-graph/SKILL.md
@@ -246,6 +246,34 @@ edges:
 
 ---
 
+## Custom image nodes — any drawing, icon or shape (napkin)
+
+To put **any image** on a graph — a line, a circle, a rectangle, an icon, a logo, a
+hand-drawn shape, a small diagram, anything a PNG/SVG can hold — create an actor with a
+`pictureObject`: a custom image rendered AS the node body (the backend's "napkin"
+element), instead of a standard form node. A divider line is just one use.
+
+```
+createActor(formId=3279, color="#F04438", pictureObject={
+  img:    "data:image/png;base64,iVBORw0KGgo…",   // a PNG/SVG data URI
+  width:  800,                                     // display size on the canvas
+  height: 8,
+  type:   "napkin"
+}, contextLayerId="<layerId>")
+```
+
+- `img` — the image as a data URI (e.g. a thin red PNG to draw a divider line).
+- `width` / `height` — display size in px. The image is anchored at its **centre** and
+  keeps the source's **aspect ratio** (set `width`; `height` follows), so for a thin line
+  make the source PNG wide-and-short.
+- `type: "napkin"` — the custom-image element kind.
+
+A classic use is an ADAM/EVE-style horizontal divider: a wide, short red dashed PNG
+placed across the middle of the layer. Change a node's image later with the same
+`pictureObject` on `updateActor`.
+
+---
+
 ## Layout Algorithm — Coordinate Calculation
 
 **Never hardcode coordinates.** Calculate using dagre/Sugiyama layout.


### PR DESCRIPTION
## Problem
The backend can render **any custom image** AS an actor's node body — its "napkin" element — via a `pictureObject` field: a line, a circle, a rectangle, an icon, a logo, a hand-drawn shape, a small diagram. It covers what the form catalogue does not. `createActor` / `updateActor` forwarded every other actor field but not this one, so `pictureObject` was unreachable from the tools.

## What & why
- Expose `pictureObject` (`{img, width, height, type:"napkin"}`) on both **createActor** and **updateActor**.
- Add a **"Custom image nodes"** section to the `simulator-graph` skill, including the centre-anchor / aspect-ratio note (set `width`; `height` follows) so e.g. a thin divider line is drawn from a wide-and-short source PNG.

## How to use
```
createActor(formId=3279, color="#F04438", pictureObject={
  img:  "data:image/png;base64,iVBOR…",   // a PNG/SVG data URI
  width: 800, height: 8, type: "napkin"
}, contextLayerId="<layerId>")
```

## How tested
- `go build ./...`, `go test ./internal/tools/...`, spec-drift gate — all green.
- **Live** on a real layer via the MCP: `createActor` with a `pictureObject` stores it, and `getActor` reads it back (`{img, type:"napkin", width, height}` + colour).

Found while building an ADAM/EVE company map — the napkin element was reachable in the backend but not surfaced by the tools or skill. Independent of the sibling edge-styling and text-label-node PRs (all three merge cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
