### PR TITLE
feat(actors): let updateActor set/change an actor's ref

### DIFF
--- a/plugins/simulator/mcp-server/internal/tools/actors.go
+++ b/plugins/simulator/mcp-server/internal/tools/actors.go
@@ -125,6 +125,7 @@ var actorOps = []Operation{
 			{Name: "appId", In: InBody, Type: "string", Desc: appIdDesc},
 			{Name: "appSettings", In: InBody, Type: "object", Desc: appSettingsDesc},
 			{Name: "hole", In: InBody, Type: "boolean", Desc: holeDesc},
+			{Name: "ref", In: InBody, Type: "string", Desc: "Set or change the actor's external reference — a stable business key, 1-255 chars, UNIQUE per form (formId). Lets you address the actor by (formId, ref) via getActorByRef instead of its UUID — the same key createActor sets, now editable after creation. Omit to leave it unchanged."},
 		},
 	},
 	{

--- a/plugins/simulator/skills/simulator-actors/SKILL.md
+++ b/plugins/simulator/skills/simulator-actors/SKILL.md
@@ -194,8 +194,13 @@ updateActor(
 ```
 
 `updateActor` is a **partial** update of `data` — keys you include are replaced, the rest
-are untouched. You can also set `title`/`description`/`color`/`status`. To clear a
+are untouched. You can also set `title`/`description`/`color`/`status`/`ref`. To clear a
 multi-value field, send `[]`.
+
+**Re-key by `ref`.** `updateActor(formId, actorId, ref="…")` sets or changes the actor's
+external reference — a stable business key, **unique per form** — the same key `createActor`
+accepts, but now editable after creation. Then address the actor by its key instead of its
+UUID: `getActorByRef(formId, ref)`. Omit `ref` to leave it unchanged.
 
 **Embed a smart form (script) in an actor.** Set `appId` (on `createActor` / `updateActor`)
 to a Smart Form (CDU/Script app) actor id — the actor's card then renders/runs that smart


### PR DESCRIPTION
## Problem

`createActor` accepts a `ref` — the external, **per-form** business key that `getActorByRef(formId, ref)` resolves actors by — but the plugin offered no way to **set or change** that key once an actor exists. The only workaround was recreating the actor, which mints a new UUID and breaks its links/placements.

## What & why

Adds an optional `ref` body param to `updateActor`, bringing it to parity with `createActor`. An existing actor can now be (re)keyed in place:

```
updateActor(formId=3279, actorId="<UUID>", ref="director")
getActorByRef(formId=3279, ref="director")   # → that actor, no UUID needed
```

## How to use

- `ref` is a stable business key, 1–255 chars, **unique per form (`formId`)** — same constraint `createActor` documents.
- Partial, like the other fields: **omit `ref` → left unchanged**.
- Resolve the actor afterwards with `getActorByRef(formId, ref)`.

## Limitations / notes

- Uniqueness is scoped to the form, **not global** — the same `ref` may exist under different forms.
- The papi endpoint `PUT /actors/actor/{formId}/{actorId}` accepts `ref` in the body **even though the field is not listed in that endpoint's request schema** in `testdata/papi-openapi.json`. Verified against the live API (not the spec). The spec-drift test only checks method/path/operationId, so it stays green.

## How tested

- `go build ./...` + `go test ./internal/tools/` (incl. spec-drift) — green.
- Live: `updateActor(3279, <actorId>, ref="…")` → `getActorByRef(3279, "…")` returned the same actor; confirmed distinct refs resolve to distinct actors (two nodes both titled "Director" keyed `director` / `hrs_director`).
- Trial 3-way merge with the other three open PRs (#55/#56/#57) on `develop` → **0 conflicts**, combined build+test green.

## Files

- `internal/tools/actors.go` — `ref` param on `updateActor`.
- `skills/simulator-actors/SKILL.md` — document re-keying by `ref` + `getActorByRef`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
