### PR TITLE
feat(skills): resolve target entity before creating; offer Total for debit/credit pairs

### DIFF
--- a/plugins/simulator/skills/simulator-finance/SKILL.md
+++ b/plugins/simulator/skills/simulator-finance/SKILL.md
@@ -234,6 +234,13 @@ deleteAccount(actorId="<actor UUID>", currencyId=1, nameId="<aname>", accountTyp
 > different account names can share one currency. (If the named unit IS the account name and the
 > currency is implicit, resolve the name and let `getAccounts` reveal the currency.)
 
+> **Multiple accounts on the same (nameId, currencyId) — offer Debit / Credit / Total.**
+> Simulator accounts are directional ledger entries: an actor can hold two rows for the
+> same `(nameId, currencyId)` pair — one `incomeType="debit"`, one `incomeType="credit"`
+> — instead of one netted balance. If `getAccounts` returns more than one account for the
+> pair you resolved, don't ask the user to choose only between "Debit" and "Credit": also
+> offer **Total** (the net balance, `credit.amount - debit.amount`) as a third option. Ask which the user wants before proceeding.
+
 ## Formula (computed) accounts
 
 Make an account's balance a **computed expression over other accounts** with

--- a/plugins/simulator/skills/simulator/SKILL.md
+++ b/plugins/simulator/skills/simulator/SKILL.md
@@ -80,6 +80,39 @@ To create or edit skills, use **`/simulator-skills`**.
 
 ---
 
+## Step 0.5 — resolve the target entity before touching domain data
+
+When the user names a business/domain entity to create or configure (e.g. "smart
+contract", "supplier", "onboarding case" — anything that isn't already an established
+actor/form id from context), resolve WHAT to create before calling any entity-specific
+tool (accounts, transactions, triggers, tags, etc.):
+
+0. **Reuse an already-resolved mapping.** If this exact term was already resolved and
+   confirmed earlier in this same conversation — the user picked a form/mechanism for it,
+   or you already found/created the actor for it — don't re-run the form search or
+   re-ask again; go straight to using that resolved entity.
+1. **Search template forms first:** `searchForms`/`getForms` matched against each form's
+   `title`/`description`. A workspace-specific business form (e.g. a custom "Smart
+   Contract" template) takes priority over any platform system mechanism that merely
+   sounds related.
+2. **Check for prior actors of that form**, not just the form itself: `searchActors`
+   scoped to the matched form (or `searchAll`) for actors already tied to the same target
+   (e.g. the same monitored account/actor) — reuse/update instead of creating a
+   duplicate.
+3. **Don't let incidental discovery hijack the task.** If, while inspecting accounts or
+   other data, you stumble onto an existing platform mechanism (`AccountTriggers`, `Tags`,
+   etc.) that looks related, that is a *data point to mention to the user*, not a
+   substitute for steps 1–2. Do not pivot the whole task into configuring that mechanism
+   without first checking whether a business template form was what the user meant.
+4. **If more than one candidate matches** (multiple forms, or a form plus a system
+   mechanism), list them for the user and let them pick — never silently substitute one
+   for another based on superficial name similarity. Create only after the user confirms.
+
+This applies before "Workspace Context Check"-style domain workflows (finance, graph,
+forms, etc.) take over — it is about *which entity*, not yet *how* to operate on it.
+
+---
+
 ## Response & output conventions
 
 These apply to **every** answer you produce, regardless of which sub-skill is active:


### PR DESCRIPTION

- simulator: add "Step 0.5" — search for a matching template form (and check for prior actors of it) before creating a new actor, instead of defaulting to a similarly-named platform mechanism (e.g. AccountTriggers) for phrases like "smart contract". Reuse an already-resolved mapping within the same conversation instead of re-searching/re-asking every time.
- simulator-finance: when an actor holds both a debit and a credit account for the same (nameId, currencyId) pair, offer "Total" (credit.amount - debit.amount) as a third choice alongside Debit/Credit — it's always computed, never a stored row.

<!-- See CONTRIBUTING.md before opening a PR. -->
<!-- BASE BRANCH: target `develop`, not `main`. `main` is release-only and a CI guard
     rejects feature/fix PRs into it. Release/hotfix promotions use `release/*` / `hotfix/*`. -->

## What & why

<!-- What does this change do, and what problem does it solve? -->

## Type of change

- [ ] Bug fix
- [ ] New MCP tool / capability
- [ ] Skill behaviour
- [ ] Docs
- [ ] Chore / refactor

## Checklist

- [ ] `make build && make vet && make test` pass locally
- [ ] If I added/renamed a tool: updated the MCP-tools table in `README.md` and §4 of `docs/ARCHITECTURE.md`, and it validates against the drift gate
- [ ] If I changed skill frontmatter: regenerated `public/` with `make discovery` (no hand-edits)
- [ ] Reference docs that skills load at runtime stay under `plugins/simulator/docs/`
- [ ] No tokens or `.env` committed; TLS verification left on by default
- [ ] Version bumped in all manifests + `CHANGELOG.md` entry added (if this is a release-worthy change)

## Notes for reviewers

<!-- Anything that needs extra attention — e.g. graph-sync logic, which has no unit tests yet. -->
