### PR TITLE
docs(smart-forms): document CDU form links & button.extra spec

### DIFF
--- a/plugins/simulator/docs/user-flows/cdu-page-protocol.md
+++ b/plugins/simulator/docs/user-flows/cdu-page-protocol.md
@@ -265,7 +265,7 @@ All component `class` values (renderer `ComponentClasses`). Most are content/inp
 
 | `class` | Kind | Key fields (beyond base) | Notes / `type` enum |
 |---|---|---|---|
-| `button` | action | `title`, `type`, `tooltip`, `extra.{icon,url,action,autoSubmit}` | `type`: `default` `text` `secondary` `tertiary` `quaternary` `quinary` `error`; submits its form (or `action:'logout'`, opens `url`, auto-submit polling) |
+| `button` | action | `title` (bbcode), `type`, `tooltip`, `extra.{url,target,action,icon,rounded,mobileVisible,request,autoSubmit,options}` | `type`: `default` `text` `secondary` `tertiary` `quaternary` `quinary` `error`. Submits its form; **`extra.url` opens that URL instead of submitting** (`extra.target` `_self`(default)\|`_blank` — honoured by newer renderers; older ones ignore `target` and open in the **same tab** via `window.location.assign`); `extra.action:'logout'`; `extra.request` runs a bare `fetch` first and submits **only if it resolves**; `extra.autoSubmit` `{interval,maxCount}` polls (**interval clamped 5–60s**, default 30; `maxCount` 1–500, default 6); `extra.options[]` opens a click menu **and bypasses `url`/`request`/`action`/submit**. `default`/`secondary` show a spinner while submitting; the CDU schema also has `default` reflect required-validation (disabled while a required field is empty) — verify against your renderer version. |
 | `edit` | input | `value`, `type`, `placeholder`, `regexp`, `mask`, `errorMsg`, `helpMsg`, `submitOnEnter`, `resettable`, `extra.{length,lineNumbers}` | `type`: `text` `email` `int` `float` `phone` `multiline` `date` `password` `colorPicker` |
 | `select` | input | `value`, `options[]`, `type`, `submitOnChange`, `submitOnScroll` | `type`: `default` `autocomplete`; scroll-paginated options |
 | `multiselect` | input | `value[]`, `options[]`, `extra.length` | chip multi-select with search |
@@ -322,7 +322,13 @@ shape the page **before** it reaches the renderer. All are resolved server-side
   repeated `content` items (one per data row), so a single template renders a list. On submit
   responses, `replaceContentLoopWithContent` re-expands the loop for the affected form.
 - **`bbcode`** — `label`/`button`/`edit`/`check` titles support BBCode, rendered to HTML by the
-  client (`Utils.bbCodeToHtml`).
+  client (`Utils.bbCodeToHtml`). Supported tags (verified live): `[b]` `[i]` `[u]` `[color=#rgb]`
+  `[size=N]` `[br]`, and **`[url=https://…]text[/url]`** which renders a **clickable
+  `<a target="_blank">`** — the idiomatic way to put an inline text link in a form. Raw HTML in a
+  value (e.g. `<a href>`) is **escaped** and shown as literal text, so use `[url]`, not `<a>`. (`[url]`
+  opens a new tab; the renderer also supports `[iurl=…]…[/iurl]` for a same-tab link, plus more tags such
+  as `[bg=…]`, `[sup]`, `[ul]`/`[*]` — the list above is the common subset.) For a whole-button
+  link/action use `button` `extra.url` (§5). Build entity URLs with the `buildLink` MCP tool.
 
 > **`[[ ]]` is locale, `{{ }}` is view-model.** Both are substituted server-side in
 > `renderPage`; the renderer does no token interpolation itself.

--- a/plugins/simulator/skills/simulator-smart-forms/SKILL.md
+++ b/plugins/simulator/skills/simulator-smart-forms/SKILL.md
@@ -276,7 +276,7 @@ Every item has `class` + base fields (`id`, `value`, `visibility`, `required`, `
 
 | `class` | Notes |
 |---|---|
-| `button` | `title`, `type`: `default` `secondary` `tertiary` `text` `error`; `extra.icon`; submits its form; or `extra.action: 'logout'`; `extra.url` (open URL) |
+| `button` | `title` (bbcode), `type`: `default` `secondary` `tertiary` `text` `error`; submits its form. `extra.url` opens the URL **instead of submitting** (`extra.target` `_self`\|`_blank` — newer renderers only; older open same-tab); `extra.action:'logout'`; `extra.request` (bare fetch first, submits only if it resolves); `extra.autoSubmit {interval,maxCount}` (interval clamped 5–60s); `extra.options[]` (menu — bypasses `url`/`request`/`action`/submit); `extra.icon`, `rounded`, `mobileVisible` |
 | `copy` | `value` = text to copy; `title` = button label |
 
 ### Data & navigation components
@@ -328,7 +328,7 @@ All substitution is **server-side** — the renderer receives concrete values.
 | `{{key}}` | `viewModel` (default + Corezoid-supplied merged) | `"{{userName}}"` → `"Alice"` |
 | `"$ref": "#/button"` | `definitions/button` file | inlined at serve time |
 | `contentLoop` | section array expansion | one template → N rows |
-| BBCode | `label`/`button` titles | `[b]bold[/b]`, `[color=#f00]red[/color]` |
+| BBCode | `label`/`button`/`edit`/`check` titles | `[b] [i] [u] [color=#f00] [size=N] [br]`, and `[url=https://…]text[/url]` → clickable `<a target="_blank">` (inline link; `[iurl=…]` opens same-tab; renderer supports more, e.g. `[bg]`). Raw `<a>` HTML is escaped — use `[url]`. |
 
 ### locale file format
 


### PR DESCRIPTION
## What & why

Clarifies **how clickable links work inside a CDU Smart Form** and completes the `button`
`extra.*` spec — with the field behaviours exercised **live in `control-cdu`** (rendered test
pages, inspected the DOM, clicked buttons, watched navigation/network).

**Links & bbcode (verified live):**
- **`[url=https://…]text[/url]` bbcode** in a bbcode-rendered title (`label`/`button`/`edit`/`check`)
  renders a **clickable `<a target="_blank">`** — the idiomatic inline link. *(Corrects a common
  assumption that `[url]` in a label is inert — it is not.)*
- **Raw HTML** in a value (`<a href>`) is **escaped** to literal text; use `[url]`, not `<a>`.
- Every documented bbcode tag renders: `[b] [i] [u] [color] [size] [br] [url]`.

**`button.extra` (verified live):** `url` opens the URL **instead of submitting**; `target` `_self`
(same tab) / `_blank` (new tab); `icon`; `rounded`; `mobileVisible` (hidden on desktop); `options[]`
(click menu); `autoSubmit {interval,maxCount}` (submits on its own — observed the wizard auto-advance);
`action:'logout'` (session-expiration flow).

**`button.extra.request`** ({method,url} HTTP call before submit) is documented from the **official
spec** and is **present in the CDU schema** (`internal/cduschema/smart-forms-swagger.json`); it was
**not** click-verified here because a cross-origin request from the renderer is blocked in the test
environment (needs an allowed same-origin endpoint).

Docs-only. No skill **frontmatter** changed, so `make discovery` yields **no `public/` diff**.

## Type of change

- [x] Docs

## Checklist

- [x] `make build && make vet && make test` pass locally (green)
- [ ] Tool table / drift gate — **N/A** (no tools added or renamed)
- [x] Skill **frontmatter unchanged**; ran `make discovery` → no `public/` changes
- [x] Reference docs stay under `plugins/simulator/docs/`
- [x] No tokens or `.env` committed; TLS verification left on
- [ ] Version bump + `CHANGELOG.md` — **N/A** (docs-only)

## Notes for reviewers

Verified live on `mw.simulator.company` (control-cdu): `[url=…]…[/url]` → `<a target="_blank">`; raw
`<a>` stays literal; `[b] [i] [u] [color] [size] [br]` each render; `button.extra` — `url`+`target`
(`_blank` opens a new tab, `_self` navigates the same tab), `icon`, `rounded`, `mobileVisible`
(desktop-hidden), `options[]` (menu), `autoSubmit` (auto-advanced the wizard), `action:'logout'`
(session-expiration modal). Only `request` is documented from the spec + schema (cross-origin blocked
in the test env). Screenshots available on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jre7vEAF11q8KV9HxjrzwC
