### PR TITLE
docs(tools): getForm filter guidance — request `form`, not `sections`

### DIFF
--- a/plugins/simulator/mcp-server/internal/tools/forms.go
+++ b/plugins/simulator/mcp-server/internal/tools/forms.go
@@ -41,7 +41,7 @@ var formOps = []Operation{
 	},
 	{
 		Name: "getForm", Method: "GET", Path: "/forms/{formId}",
-		Summary: "Get a form template by its integer id. Pass `filter` to fetch only the fields you need (form templates can be large), but keep `description` (the form's purpose) and `sections` (which carry each field's `description` helper text) whenever you need to understand what the form or its fields mean.",
+		Summary: "Get a form template by its integer id. Pass `filter` to fetch only the fields you need (form templates can be large). `filter` projects TOP-LEVEL keys only, so to get the fields keep `form` — the sections/fields live under `form.sections` (each field carries its helper text); a `sections` key (or the dotted `form.sections`) is silently dropped, so request `form`. Keep `description` (the form's purpose) too when you need to understand what the form or its fields mean.",
 		Params: []Param{
 			{Name: "formId", In: InPath, Type: "number", Required: true, Desc: "Form id."},
 			{Name: "withRelations", In: InQuery, Type: "boolean", Desc: "Include related entities."},


### PR DESCRIPTION
## What & why

The `getForm` tool Summary told callers to keep `sections` in `filter`, but a form's
sections/fields live under **`form.sections`**, and `filter` projects **top-level keys only** —
so `filter=…,sections` (and even the dotted `form.sections`) returns nothing; you must request
**`form`**. This is a real footgun (I hit it: asked for `sections`, got an empty projection).

**Verified live** against form `600389`:

```
filter="id,title,sections"  -> {"id":…,"title":…}                 (sections silently dropped)
filter="form.sections"      -> {}                                 (dotted path not projected)
filter="id,title,form"      -> {"id":…,"title":…,"form":{"sections":[…]}}   (correct)
```

The fix updates the `getForm` Summary to say keep `form` (fields are `form.sections`, each with its
`description` helper text) and to note the top-level-only projection. `description` (the form's
purpose, a real top-level field) is unchanged.

Description-only string in `internal/tools/forms.go`; no behaviour change. `make discovery` yields
no `public/` diff (discovery is generated from SKILL.md frontmatter, not tool descriptions).

## Type of change

- [x] Docs

## Checklist

- [x] `make build && make vet && make test` pass locally (green)
- [ ] Tool table / drift gate — **N/A** (no tool added/renamed; only a Summary string edited)
- [x] Skill frontmatter unchanged; ran `make discovery` → no `public/` changes
- [x] Reference docs stay under `plugins/simulator/docs/` (n/a — this is a tool Summary)
- [x] No tokens or `.env` committed; TLS verification left on
- [ ] Version bump + `CHANGELOG.md` — **N/A** (description-only)

## Notes for reviewers

Repro (any form id): `getForm(id, filter="…,sections")` drops sections; `getForm(id, filter="form")`
returns them under `form.sections`. Fix is text-only in the `getForm` `Summary` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jre7vEAF11q8KV9HxjrzwC
