### PR TITLE
fix(smart-forms): pushSmartForm Windows path-separator bug when creating a new page

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "simulator",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "source": {
         "source": "local",
         "path": "./plugins/simulator"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "simulator",
       "source": "./plugins/simulator",
       "description": "Simulator.Company platform assistant. Exposes the Simulator REST API as an MCP server and provides skills for managing actors, forms, graph structures, and financial accounts.",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "author": {
         "name": "Simulator.Company",
         "url": "https://simulator.company"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.4.1]
+
+### Fixed
+- **`pushSmartForm` failed on Windows when creating files in a new subfolder (e.g. a new Smart Form page `pages/<id>/config`).** Phase 2 mapped the server's create response back to local paths using `filepath.Dir`, which yields backslash-separated paths on Windows and misses the slash-keyed folder map — so the push aborted with "server did not return id for created file …" even though the server had already created the folder and files (a subsequent `pullSmartForm` showed them). The response mapping now reuses `resolveParentID` (the same `ToSlash`-normalized lookup used when POSTing), keeping the key consistent across OSes. macOS/Linux behaviour is unchanged (`ToSlash` is a no-op there).
+
 ## [2.4.0]
 
 ### Added

--- a/POWER.md
+++ b/POWER.md
@@ -1,7 +1,7 @@
 ---
 name: simulator
 displayName: Simulator.Company
-version: 2.4.0
+version: 2.4.1
 description: BPM, graph, and financial-tracking toolkit for the Simulator.Company platform. Exposes the Simulator REST API as MCP tools plus 16 skills covering actors, forms, graphs, layers, accounts, transactions, transfers, charts, smart forms, meetings, reactions, and attachments.
 author:
   name: Simulator.Company

--- a/plugins/simulator/.claude-plugin/plugin.json
+++ b/plugins/simulator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simulator",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Simulator.Company platform assistant. Exposes the Simulator REST API as an MCP server and provides skills for managing actors, forms, graph structures, and financial accounts.",
   "author": {
     "name": "Simulator.Company",

--- a/plugins/simulator/.codex-plugin/plugin.json
+++ b/plugins/simulator/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simulator",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Simulator.Company platform assistant. Exposes the Simulator REST API as an MCP server and provides skills for managing actors, forms, graph structures, and financial accounts.",
   "author": {
     "name": "Simulator.Company",

--- a/plugins/simulator/.kiro-plugin/plugin.json
+++ b/plugins/simulator/.kiro-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simulator",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Simulator.Company platform assistant. Exposes the Simulator REST API as an MCP server and provides skills for managing actors, forms, graph structures, and financial accounts.",
   "author": {
     "name": "Simulator.Company",

--- a/plugins/simulator/mcp-server/internal/engines/smartform/push.go
+++ b/plugins/simulator/mcp-server/internal/engines/smartform/push.go
@@ -242,10 +242,11 @@ func handlePushSmartForm(ctx context.Context, req mcp.CallToolRequest) (*mcp.Cal
 			byKey[fmt.Sprintf("%d/%s", c.FolderID, c.Title)] = c
 		}
 		for _, relPath := range newFilePaths {
-			parentID := manifest.Folders[filepath.Dir(relPath)]
-			if filepath.Dir(relPath) == "." {
-				parentID = manifest.EnvRootFolderID
-			}
+			// Reuse resolveParentID (with ToSlash) so the lookup key matches the
+			// parentID actually POSTed above. Computing filepath.Dir inline here
+			// breaks on Windows, where it yields backslash-separated paths that
+			// miss the slash-keyed manifest.Folders map.
+			parentID, _ := resolveParentID(relPath, manifest.Folders, manifest.EnvRootFolderID)
 			key := fmt.Sprintf("%d/%s", parentID, filepath.Base(relPath))
 			c, ok := byKey[key]
 			if !ok {


### PR DESCRIPTION
## What

Fixes `pushSmartForm` failing on **Windows** when creating files inside a new subfolder — the common case being a new Smart Form page (`pages/<id>/config` + `locale`).

## Root cause

In `handlePushSmartForm` Phase 2 (create-files), the tool mapped the server's create response back to local paths using `filepath.Dir(relPath)`. On Windows `filepath.Dir` returns **backslash**-separated paths (`pages\survey`), which miss the always-slash-keyed `manifest.Folders` map. The lookup returned `0`, the response key never matched, and the push aborted with:

```
[Error] server did not return id for created file "pages/<id>/config"
```

Crucially, the POST that *creates* the objects used `resolveParentID` (which normalizes with `ToSlash`), so the folder and files were **already created server-side** — a subsequent `pullSmartForm` showed the new page. That is the reported symptom: *push errors, but pull shows the page.*

macOS/Linux were unaffected because `filepath.Dir` uses `/` there.

## Fix

The response mapping now reuses `resolveParentID` — the exact same `ToSlash`-normalized lookup used when POSTing — so the key is consistent with the parent id actually sent, on every OS. The change is a no-op on macOS/Linux (`ToSlash` does nothing when paths already use `/`).

## Testing

- `go build ./...` and `go vet ./...` — clean.
- Full module suite `go test ./...` — green.
- A local (uncommitted) regression test confirmed on Windows that the old inline `filepath.Dir` lookup returns `0` while `resolveParentID` returns the correct folder id; the assertions are OS-independent and pass on Linux/macOS too.
- Verified end-to-end: `pullSmartForm` → add a new `pages/<id>/` folder locally → `pushSmartForm` now succeeds instead of erroring.

## Version

Patch bump `2.4.0 → 2.4.1` across all manifests (`.claude-plugin`, `.codex-plugin`, `.kiro-plugin`, `marketplace.json`) + `CHANGELOG.md`, per repo house rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
