### PR TITLE
fix(kiro): self-healing MCP path resolution in dev checkouts, bump to 2.4.1

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "simulator",
-      "version": "2.4.1",
+      "version": "2.4.2",
       "source": {
         "source": "local",
         "path": "./plugins/simulator"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "simulator",
       "source": "./plugins/simulator",
       "description": "Simulator.Company platform assistant. Exposes the Simulator REST API as an MCP server and provides skills for managing actors, forms, graph structures, and financial accounts.",
-      "version": "2.4.1",
+      "version": "2.4.2",
       "author": {
         "name": "Simulator.Company",
         "url": "https://simulator.company"

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ dump.rdb
 # Runtime overlays under .kiro/ are generated from the canonical skills tree —
 # committing them would only invite drift.
 /dist/
+
+# Kiro
+.env
+.kiro

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.4.2]
+
+### Fixed
+- **Kiro MCP server path resolution in a dev checkout.** `.mcp.kiro.json`'s `${KIRO_PLUGIN_ROOT:-$PWD/.kiro/..}` fallback resolved to the repo root (not `plugins/simulator/`) when a developer opened the repo directly in Kiro without running `install-kiro.sh`, so the server tried (and failed) to run `<repo>/mcp-server/run.sh`. It now probes for `mcp-server/run.sh` at that path and falls back to `plugins/simulator/` when missing, with a final guard that prints a clear error and exits if neither candidate has it. `install-kiro.sh` also now `sed`-resolves the same fallback to the absolute plugin path (escaping `\`, `&`, and the `#` delimiter) when generating a workspace's `mcp.json`, instead of a plain copy, so an external workspace's config no longer depends on `KIRO_PLUGIN_ROOT` at all. README's Kiro install instructions updated to match.
+
 ## [2.4.1]
 
 ### Fixed

--- a/POWER.md
+++ b/POWER.md
@@ -1,7 +1,7 @@
 ---
 name: simulator
 displayName: Simulator.Company
-version: 2.4.1
+version: 2.4.2
 description: BPM, graph, and financial-tracking toolkit for the Simulator.Company platform. Exposes the Simulator REST API as MCP tools plus 16 skills covering actors, forms, graphs, layers, accounts, transactions, transfers, charts, smart forms, meetings, reactions, and attachments.
 author:
   name: Simulator.Company

--- a/README.md
+++ b/README.md
@@ -90,10 +90,10 @@ Kiro has no marketplace command and does not resolve the `$CLAUDE_PLUGIN_ROOT` t
 ```bash
 git clone https://github.com/corezoid/simulator-ai-plugin
 cd simulator-ai-plugin
-plugins/simulator/scripts/install-kiro.sh [workspace-dir]   # defaults to $KIRO_WORKSPACE_DIR or the current dir
+sh plugins/simulator/scripts/install-kiro.sh .   # installs into the current dir; pass another workspace-dir instead of `.` to target elsewhere
 ```
 
-This writes the MCP entry to `<workspace>/.kiro/settings/mcp.json`, symlinks the steering file into `.kiro/steering/`, and hard-copies each skill into `.kiro/skills/<name>/` with `$CLAUDE_PLUGIN_ROOT` replaced by the absolute plugin path. Open the workspace in Kiro and the MCP server, skills, and steering are picked up automatically. The plugin is also published to [kiro.dev/powers](https://kiro.dev/powers) — see [`POWER.md`](POWER.md).
+This writes the MCP entry to `<workspace>/.kiro/settings/mcp.json` with the plugin path resolved to an absolute path (no reliance on `KIRO_PLUGIN_ROOT` or workspace layout), symlinks the steering file into `.kiro/steering/`, and hard-copies each skill into `.kiro/skills/<name>/` with `$CLAUDE_PLUGIN_ROOT` replaced the same way. Open the workspace in Kiro and the MCP server, skills, and steering are picked up automatically. `.mcp.kiro.json` also self-heals if Kiro loads it directly without the script ever having run — it probes for `mcp-server/run.sh` next to its workspace-root guess and falls back to `plugins/simulator/` when that guess misses. The plugin is also published to [kiro.dev/powers](https://kiro.dev/powers) — see [`POWER.md`](POWER.md).
 
 ### Updating
 

--- a/plugins/simulator/.claude-plugin/plugin.json
+++ b/plugins/simulator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simulator",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Simulator.Company platform assistant. Exposes the Simulator REST API as an MCP server and provides skills for managing actors, forms, graph structures, and financial accounts.",
   "author": {
     "name": "Simulator.Company",

--- a/plugins/simulator/.codex-plugin/plugin.json
+++ b/plugins/simulator/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simulator",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Simulator.Company platform assistant. Exposes the Simulator REST API as an MCP server and provides skills for managing actors, forms, graph structures, and financial accounts.",
   "author": {
     "name": "Simulator.Company",

--- a/plugins/simulator/.kiro-plugin/plugin.json
+++ b/plugins/simulator/.kiro-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simulator",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Simulator.Company platform assistant. Exposes the Simulator REST API as an MCP server and provides skills for managing actors, forms, graph structures, and financial accounts.",
   "author": {
     "name": "Simulator.Company",

--- a/plugins/simulator/.mcp.kiro.json
+++ b/plugins/simulator/.mcp.kiro.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "simulator": {
       "command": "sh",
-      "args": ["-c", "PLUGIN_ROOT=\"${KIRO_PLUGIN_ROOT:-$PWD/.kiro/..}\"; [ -f \"$PLUGIN_ROOT/mcp-server/run.sh\" ] || PLUGIN_ROOT=\"$PLUGIN_ROOT/plugins/simulator\"; export PLUGIN_ROOT SIMULATOR_WORK_DIR=\"$PWD\"; exec sh \"$PLUGIN_ROOT/mcp-server/run.sh\""]
+      "args": ["-c", "PLUGIN_ROOT=\"${KIRO_PLUGIN_ROOT:-$PWD/.kiro/..}\"; [ -f \"$PLUGIN_ROOT/mcp-server/run.sh\" ] || PLUGIN_ROOT=\"$PLUGIN_ROOT/plugins/simulator\"; [ -f \"$PLUGIN_ROOT/mcp-server/run.sh\" ] || { echo \"ERROR: cannot locate mcp-server/run.sh (checked KIRO_PLUGIN_ROOT and the plugins/simulator fallback under $PLUGIN_ROOT)\" >&2; exit 1; }; export PLUGIN_ROOT SIMULATOR_WORK_DIR=\"$PWD\"; exec sh \"$PLUGIN_ROOT/mcp-server/run.sh\""]
     }
   }
 }

--- a/plugins/simulator/.mcp.kiro.json
+++ b/plugins/simulator/.mcp.kiro.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "simulator": {
       "command": "sh",
-      "args": ["-c", "export PLUGIN_ROOT=\"${KIRO_PLUGIN_ROOT:-$PWD/.kiro/..}\"; export SIMULATOR_WORK_DIR=\"$PWD\"; exec sh \"$PLUGIN_ROOT/mcp-server/run.sh\""]
+      "args": ["-c", "PLUGIN_ROOT=\"${KIRO_PLUGIN_ROOT:-$PWD/.kiro/..}\"; [ -f \"$PLUGIN_ROOT/mcp-server/run.sh\" ] || PLUGIN_ROOT=\"$PLUGIN_ROOT/plugins/simulator\"; export PLUGIN_ROOT SIMULATOR_WORK_DIR=\"$PWD\"; exec sh \"$PLUGIN_ROOT/mcp-server/run.sh\""]
     }
   }
 }

--- a/plugins/simulator/scripts/install-kiro.sh
+++ b/plugins/simulator/scripts/install-kiro.sh
@@ -39,7 +39,10 @@ mkdir -p "$KIRO_DIR/settings" "$KIRO_DIR/steering" "$KIRO_DIR/skills"
 
 # 1) MCP entry — resolve the KIRO_PLUGIN_ROOT fallback to the known absolute
 #    plugin path so the generated mcp.json works without the env var being set.
-sed 's#\${KIRO_PLUGIN_ROOT:-\$PWD/.kiro/..}#'"$PLUGIN_ROOT"'#g' \
+#    Escape \, & and our # delimiter so a stray one of those in PLUGIN_ROOT
+#    (e.g. a `#` in the clone path) can't corrupt the sed replacement.
+PLUGIN_ROOT_ESCAPED="$(printf '%s\n' "$PLUGIN_ROOT" | sed 's/[\&#]/\\&/g')"
+sed 's#\${KIRO_PLUGIN_ROOT:-\$PWD/.kiro/..}#'"$PLUGIN_ROOT_ESCAPED"'#g' \
   "$PLUGIN_ROOT/.mcp.kiro.json" > "$KIRO_DIR/settings/mcp.json"
 
 # 2) Steering — small, stable, no token substitution needed. Symlink on POSIX,

--- a/plugins/simulator/scripts/install-kiro.sh
+++ b/plugins/simulator/scripts/install-kiro.sh
@@ -37,8 +37,10 @@ fi
 
 mkdir -p "$KIRO_DIR/settings" "$KIRO_DIR/steering" "$KIRO_DIR/skills"
 
-# 1) MCP entry — always plain copy (workspace-local edits must not leak back).
-cp "$PLUGIN_ROOT/.mcp.kiro.json" "$KIRO_DIR/settings/mcp.json"
+# 1) MCP entry — resolve the KIRO_PLUGIN_ROOT fallback to the known absolute
+#    plugin path so the generated mcp.json works without the env var being set.
+sed 's#\${KIRO_PLUGIN_ROOT:-\$PWD/.kiro/..}#'"$PLUGIN_ROOT"'#g' \
+  "$PLUGIN_ROOT/.mcp.kiro.json" > "$KIRO_DIR/settings/mcp.json"
 
 # 2) Steering — small, stable, no token substitution needed. Symlink on POSIX,
 #    hard-copy on Windows shells.


### PR DESCRIPTION
What & why

When a developer clones the repo and opens it directly in AWS Kiro without running install-kiro.sh, the MCP server failed to start. .mcp.kiro.json's ${KIRO_PLUGIN_ROOT:-$PWD/.kiro/..} fallback resolved to the repo root (since .kiro/ lives there), not plugins/simulator/, so it tried to run the nonexistent <repo>/mcp-server/run.sh instead of <repo>/plugins/simulator/mcp-server/run.sh. The bug only surfaced in local dev — an installed plugin has KIRO_PLUGIN_ROOT set correctly by the host.

Fixes:
- .mcp.kiro.json — probes for mcp-server/run.sh at the resolved path and falls back to appending plugins/simulator/ when it's missing, so both the installed-plugin and dev-checkout layouts resolve correctly without any install step.
- install-kiro.sh — now sed-resolves the same KIRO_PLUGIN_ROOT fallback to the absolute plugin path when generating a workspace's mcp.json, instead of a plain copy. An externally-installed workspace's config is now self-contained and no longer depends on KIRO_PLUGIN_ROOT being set at runtime at all.
- README.md — Kiro install instructions updated: the install command now shows sh plugins/simulator/scripts/install-kiro.sh ., and the surrounding text documents both fixes.
- .gitignore — added .env and .kiro (workspace-local Kiro overlay, generated by install-kiro.sh, must not be committed).

Type of change

- [x] Bug fix
- [ ] New MCP tool / capability
- [ ] Skill behaviour
- [x] Docs
- [ ] Chore / refactor

Checklist

- [x] make build && make vet pass locally
- [ ] If I added/renamed a tool — N/A, no tool changes
- [ ] If I changed skill frontmatter — N/A, no skill changes
- [x] Reference docs that skills load at runtime stay under plugins/simulator/docs/ — N/A, untouched
- [x] No tokens or .env committed; TLS verification left on by default
- [x] Version bumped in all manifests (.claude-plugin/plugin.json, .kiro-plugin/plugin.json, .codex-plugin/plugin.json,CHANGELOG.md entry added — 2.4.0 → 2.4.1

Notes for reviewers

Manually verified all three scenarios: installed-plugin path (KIRO_PLUGIN_ROOT pre-set), dev-checkout path (unset, probequires .kiro/ to already exist as a directory, which it will since that's where mcp.json itself lives), andinstall-kiro.sh against an external workspace (generated mcp.json has a valid, hardcoded absolute path; resolved run.sh path is correct).