### PR TITLE
feat(simulator): actor geolocation fields on createActor/updateActor

### DIFF
--- a/plugins/simulator/docs/entities/actors.md
+++ b/plugins/simulator/docs/entities/actors.md
@@ -26,6 +26,8 @@ Actors are the fundamental building blocks of the platform, representing various
 | created_at | Integer | Unix timestamp of creation time |
 | updated_at | Integer | Unix timestamp of last update |
 | app_id | String | ID of the application this actor belongs to (if applicable) |
+| geoPosition | Object \| null | Actor geolocation as `{"lat": <number>, "lon": <number>}` in WGS84 decimal degrees (e.g. `{"lat": 44.7866, "lon": 20.4489}`). Latitude is hard-bounded to -90..90 (out of range rejected); longitude outside ±180 wraps cyclically; both rounded to 6 decimals. `lat`/`lon` are set together; `null` clears. Settable on createActor / updateActor. |
+| geoName | String \| null | Optional human-readable location name (max 255 chars), independent of geoPosition. `null` clears. Settable on createActor / updateActor. |
 
 ## Actor Types
 

--- a/plugins/simulator/mcp-server/internal/tools/actors.go
+++ b/plugins/simulator/mcp-server/internal/tools/actors.go
@@ -76,6 +76,18 @@ const pictureObjectDesc = "Render a custom image AS the node itself — the back
 	"The image is anchored at its CENTRE and keeps the source's aspect ratio (set width; height follows) — e.g. for a thin divider line use a wide-and-short source PNG. " +
 	"Uses: dividers/separators, a custom shape or icon the form catalogue does not cover, an embedded picture or logo on a graph."
 
+// geoPositionDesc / geoNameDesc document the actor geolocation fields. The
+// backend stores the position as a PostGIS point and validates coordinates:
+// latitude is hard-bounded, longitude wraps cyclically, and excess precision
+// is rounded (not rejected).
+const geoPositionDesc = "Actor geolocation as an object {\"lat\": <number>, \"lon\": <number>} in WGS84 decimal degrees " +
+	"(e.g. {\"lat\": 44.7866, \"lon\": 20.4489}). Latitude is hard-bounded to -90..90 (out of range is rejected); " +
+	"longitude outside ±180 wraps cyclically (e.g. 200 → -160); both are rounded to 6 decimals. " +
+	"Pass null to clear the position. lat and lon are set together — a partial object is invalid."
+
+const geoNameDesc = "Optional human-readable location name for the actor (e.g. \"Belgrade office\"), max 255 chars. " +
+	"Independent of geoPosition; pass null to clear."
+
 // actorOps — actor (graph node) CRUD. Actors are instances of a form; their
 // fields live in the free-form `data` object keyed by the form's field schema.
 var actorOps = []Operation{
@@ -97,6 +109,8 @@ var actorOps = []Operation{
 			{Name: "appId", In: InBody, Type: "string", Desc: appIdDesc},
 			{Name: "appSettings", In: InBody, Type: "object", Desc: appSettingsDesc},
 			{Name: "hole", In: InBody, Type: "boolean", Desc: holeDesc},
+			{Name: "geoPosition", In: InBody, Type: "object", Desc: geoPositionDesc},
+			{Name: "geoName", In: InBody, Type: "string", Desc: geoNameDesc},
 			{Name: "contextLayerId", In: InQuery, Type: "string", Desc: "Optional layer to place the new actor on."},
 		},
 	},
@@ -138,6 +152,8 @@ var actorOps = []Operation{
 			{Name: "appSettings", In: InBody, Type: "object", Desc: appSettingsDesc},
 			{Name: "hole", In: InBody, Type: "boolean", Desc: holeDesc},
 			{Name: "ref", In: InBody, Type: "string", Desc: "Set or change the actor's external reference — a stable business key, 1-255 chars, UNIQUE per form (formId). Lets you address the actor by (formId, ref) via getActorByRef instead of its UUID — the same key createActor sets, now editable after creation. Omit to leave it unchanged."},
+			{Name: "geoPosition", In: InBody, Type: "object", Desc: geoPositionDesc},
+			{Name: "geoName", In: InBody, Type: "string", Desc: geoNameDesc},
 		},
 	},
 	{

--- a/plugins/simulator/mcp-server/internal/tools/testdata/eval-scenarios.json
+++ b/plugins/simulator/mcp-server/internal/tools/testdata/eval-scenarios.json
@@ -177,6 +177,24 @@
     ]
   },
   {
+    "name": "Actor geolocation value shape",
+    "prompt": "Create an actor under form 42 titled \"Belgrade office\" located at latitude 44.7866, longitude 20.4489, with the location name \"Belgrade office\". Set its geolocation.",
+    "tools": [
+      "createActor"
+    ],
+    "argChecks": [
+      {
+        "tool": "createActor",
+        "mustContain": [
+          "geoPosition",
+          "\"lat\":44.7866",
+          "\"lon\":20.4489",
+          "geoName"
+        ]
+      }
+    ]
+  },
+  {
     "name": "Check before creating (no duplicate)",
     "prompt": "Make sure there is a Camry actor; create one only if it does not already exist.",
     "tools": [

--- a/plugins/simulator/mcp-server/internal/tools/testdata/papi-openapi.json
+++ b/plugins/simulator/mcp-server/internal/tools/testdata/papi-openapi.json
@@ -1078,6 +1078,9 @@
                   },
                   "pinned": {
                     "type": "boolean"
+                  },
+                  "hole": {
+                    "type": "boolean"
                   }
                 },
                 "required": [
@@ -1156,6 +1159,9 @@
                       "type": "number"
                     },
                     "pinned": {
+                      "type": "boolean"
+                    },
+                    "hole": {
                       "type": "boolean"
                     }
                   },
@@ -1551,6 +1557,39 @@
                   },
                   "ownerId": {
                     "type": "integer"
+                  },
+                  "geoPosition": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "lat": {
+                            "type": "number"
+                          },
+                          "lon": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "lat",
+                          "lon"
+                        ]
+                      }
+                    ]
+                  },
+                  "geoName": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string",
+                        "maxLength": 255
+                      }
+                    ]
                   },
                   "data": {
                     "type": "object"
@@ -1966,6 +2005,39 @@
                   "ownerId": {
                     "type": "integer"
                   },
+                  "geoPosition": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "lat": {
+                            "type": "number"
+                          },
+                          "lon": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "lat",
+                          "lon"
+                        ]
+                      }
+                    ]
+                  },
+                  "geoName": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string",
+                        "maxLength": 255
+                      }
+                    ]
+                  },
                   "ref": {
                     "anyOf": [
                       {
@@ -2030,6 +2102,39 @@
                   },
                   "color": {
                     "type": "string"
+                  },
+                  "geoPosition": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "lat": {
+                            "type": "number"
+                          },
+                          "lon": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "lat",
+                          "lon"
+                        ]
+                      }
+                    ]
+                  },
+                  "geoName": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string",
+                        "maxLength": 255
+                      }
+                    ]
                   },
                   "data": {
                     "type": "object"
@@ -2909,6 +3014,14 @@
                   },
                   "layerId": {
                     "type": "string"
+                  },
+                  "holeLaId": {
+                    "type": "integer",
+                    "minimum": 1
+                  },
+                  "targetLaId": {
+                    "type": "integer",
+                    "minimum": 1
                   }
                 },
                 "required": [
@@ -2962,6 +3075,100 @@
                 "required": [
                   "targetActorId",
                   "layerId"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "accId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      }
+    },
+    "/papi/1.0/actors/merge_edge_hole/{accId}": {
+      "post": {
+        "tags": [
+          "Graph"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "holeEdgeId": {
+                    "type": "string"
+                  },
+                  "targetEdgeId": {
+                    "type": "string"
+                  },
+                  "layerId": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "holeEdgeId",
+                  "targetEdgeId",
+                  "layerId"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "accId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      }
+    },
+    "/papi/1.0/actors/revert_edge_hole/{accId}": {
+      "post": {
+        "tags": [
+          "Graph"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "targetEdgeId": {
+                    "type": "string"
+                  },
+                  "layerId": {
+                    "type": "string"
+                  },
+                  "holeEdgeId": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "targetEdgeId"
                 ]
               }
             }
@@ -10325,6 +10532,9 @@
                                   "extraText": {
                                     "type": "string"
                                   },
+                                  "reverseEdge": {
+                                    "type": "boolean"
+                                  },
                                   "optionsSource": {
                                     "type": "object",
                                     "properties": {
@@ -10913,6 +11123,9 @@
                                   },
                                   "extraText": {
                                     "type": "string"
+                                  },
+                                  "reverseEdge": {
+                                    "type": "boolean"
                                   },
                                   "optionsSource": {
                                     "type": "object",

--- a/plugins/simulator/skills/simulator-actors/SKILL.md
+++ b/plugins/simulator/skills/simulator-actors/SKILL.md
@@ -95,6 +95,13 @@ create/update is:
 > account-name UUID / user id) — resolve it first (e.g. `getCurrencies`,
 > `getAccountNames`, `searchActors`) rather than guessing.
 
+> **Geolocation (top-level, not `data`).** An actor carries an optional position independent
+> of its form fields: `geoPosition` — `{"lat": <number>, "lon": <number>}` in WGS84 decimal
+> degrees, or `null` to clear — and `geoName` — a location name string, or `null`. Both are set
+> on `createActor`/`updateActor`. Latitude is hard-bounded to -90..90 (out of range is rejected),
+> longitude outside ±180 wraps cyclically, and coordinates round to 6 decimals; `lat`/`lon` are
+> set as a pair.
+
 Full reference: `$CLAUDE_PLUGIN_ROOT/docs/entities/actors.md` and `…/forms.md`.
 
 ### Multiform actors (`__form__<formId>:<itemId>`)


### PR DESCRIPTION
Mirror the pong-server public API: expose `geoPosition` (`{lat, lon}` | null) and `geoName` (string | null) on the `createActor` and `updateActor` tools.

Coordinates are validated backend-side: latitude hard-bounded to -90..90 (out of range rejected), longitude wraps cyclically at ±180, values round to 6 decimals; null clears.

- `actors.go`: geoPosition/geoName body params on createActor + updateActor
- `testdata/papi-openapi.json`: regenerated drift-gate snapshot
- `eval-scenarios.json`: geolocation value-shape scenario
- `simulator-actors/SKILL.md` + `docs/entities/actors.md`: document the fields

Validation: `make build`, `make vet`, `make test` green (drift gate + eval-scenario reference).