### PR TITLE
chore(release): release-time versioning flow + 2.5.0 (actor geolocation)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "simulator",
-      "version": "2.4.2",
+      "version": "2.5.0",
       "source": {
         "source": "local",
         "path": "./plugins/simulator"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "simulator",
       "source": "./plugins/simulator",
       "description": "Simulator.Company platform assistant. Exposes the Simulator REST API as an MCP server and provides skills for managing actors, forms, graph structures, and financial accounts.",
-      "version": "2.4.2",
+      "version": "2.5.0",
       "author": {
         "name": "Simulator.Company",
         "url": "https://simulator.company"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,13 +109,23 @@ reinstall. Verify with `/mcp`. Full guide: README → "Local development".
   `develop` (or a `release/*` / `hotfix/*` branch). Never open a feature/fix PR against
   `main` — a CI guard (`.github/workflows/guard-base-branch.yml`) rejects any PR into `main`
   whose head isn't `develop`, `release/*`, or `hotfix/*`.
-- **Versioning.** The plugin version appears in **six** files — keep them in lockstep:
-  `plugins/simulator/.claude-plugin/plugin.json`,
-  `plugins/simulator/.codex-plugin/plugin.json`,
-  `plugins/simulator/.kiro-plugin/plugin.json`,
-  `.claude-plugin/marketplace.json`,
-  `.agents/plugins/marketplace.json`,
-  `POWER.md` (frontmatter), plus the top-of-file entry in `CHANGELOG.md`.
+- **Versioning & releases.** The version is minted at **release time**, not per PR — many PRs
+  land on `develop` during the week, so a per-PR bump just makes contributors collide on the
+  same number.
+  - **In a PR:** do **not** touch the version. Append a one-line entry under the
+    `## [Unreleased]` section at the top of `CHANGELOG.md` (under `### Added` / `### Changed` /
+    `### Fixed`). Appending a bullet avoids the merge conflicts a version bump causes.
+  - **At release (promoting `develop` → `main`):** run `make release VERSION=x.y.z`. It rewrites
+    `## [Unreleased]` into a dated `## [x.y.z]` section (and starts a fresh empty `Unreleased`),
+    then bumps the version in lockstep across the **six** files that carry it:
+    `plugins/simulator/.claude-plugin/plugin.json`,
+    `plugins/simulator/.codex-plugin/plugin.json`,
+    `plugins/simulator/.kiro-plugin/plugin.json`,
+    `.claude-plugin/marketplace.json`,
+    `.agents/plugins/marketplace.json`,
+    `POWER.md` (frontmatter). The script does not commit/tag/push — review the diff, commit,
+    merge to `main`, then tag `vx.y.z`. The `Release` workflow reads the `## [x.y.z]` CHANGELOG
+    section for the GitHub release notes, so the section must exist before the tag.
 - **Linter.** `make lint` runs golangci-lint v2 (config `plugins/simulator/mcp-server/.golangci.yml`,
   shared with sibling Go services). `gosec` is clean (real findings fixed; trusted-input taint
   false positives are documented in the `gosec.excludes` list). The broader `default: all` set

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+<!-- PRs: add your entry under ## [Unreleased] (### Added / Changed / Fixed).
+     Do NOT bump the version or add a dated section — that is minted at release
+     time by `make release VERSION=x.y.z`. See AGENTS.md → Versioning & releases. -->
+
+## [Unreleased]
+
+## [2.5.0] - 2026-07-14
+
+### Added
+- **Actor geolocation — `geoPosition` / `geoName` on `createActor` / `updateActor` (#74).** An actor now carries an optional real-world position independent of its form `data`: `geoPosition` — `{"lat": <number>, "lon": <number>}` in WGS84 decimal degrees, or `null` to clear — and `geoName` — a location-name string (max 255 chars), or `null`. Coordinates are validated backend-side: latitude is hard-bounded to -90..90 (out of range rejected), longitude outside ±180 wraps cyclically, and values round to 6 decimals; `lat`/`lon` are set as a pair. Documented in `/simulator-actors` and `docs/entities/actors.md`; drift snapshot and an eval scenario updated.
+
 ## [2.4.2]
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,4 +47,8 @@ Guidance for Claude Code when working in the **simulator-ai-plugin** repository.
   orchestration and edge-placement branches are only partly covered — change it carefully and
   extend the tests when you touch those paths.
 - Keep TLS verification on by default; never log or commit tokens / `.env`.
-- Bump the plugin version in all manifests + `CHANGELOG.md` together.
+- **Don't bump the plugin version in a PR.** A PR only appends a bullet under the
+  `## [Unreleased]` section at the top of `CHANGELOG.md` (`### Added` / `Changed` / `Fixed`).
+  The version — across the six manifests plus a dated `CHANGELOG` section — is minted once at
+  release time by `make release VERSION=x.y.z`. See the "Versioning & releases" convention in
+  [`AGENTS.md`](AGENTS.md).

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ MCP := plugins/simulator/mcp-server
 # line, e.g. `make inspect PROFILE=prod`.
 PROFILE ?= local
 
-.PHONY: help discovery build vet lint test run-local run-prod inspect eval eval-skills eval-live
+.PHONY: help discovery build vet lint test run-local run-prod inspect eval eval-skills eval-live release
 
 help:
 	@echo "Targets:"
@@ -17,6 +17,7 @@ help:
 	@echo "  eval            Behavioural eval, dry — canned fixtures, no backend (needs ANTHROPIC_API_KEY; skips otherwise)."
 	@echo "  eval-skills     Behavioural eval, dry, with the SKILL.md files injected as the system prompt."
 	@echo "  eval-live       Behavioural eval executing tools against the backend (throwaway workspace)."
+	@echo "  release         Mint a release: promote CHANGELOG ## [Unreleased] → ## [VERSION] and bump the six manifests. Usage: make release VERSION=x.y.z"
 
 # Regenerate AI-discovery artifacts (public/) from the plugin SKILL.md files.
 discovery:
@@ -64,3 +65,11 @@ eval-skills:
 
 eval-live:
 	cd $(MCP) && go run ./cmd/evalrunner --execute
+
+# Mint a release version in one step (see scripts/release.sh). Versions are NOT
+# bumped per PR — a PR only appends a bullet under CHANGELOG's ## [Unreleased];
+# this promotes that section to ## [VERSION] and bumps the six manifests.
+# Does not commit/tag/push. Usage: make release VERSION=2.5.0
+release:
+	@test -n "$(VERSION)" || { echo "ERROR: set VERSION, e.g. make release VERSION=2.5.0" >&2; exit 1; }
+	@sh scripts/release.sh "$(VERSION)"

--- a/POWER.md
+++ b/POWER.md
@@ -1,7 +1,7 @@
 ---
 name: simulator
 displayName: Simulator.Company
-version: 2.4.2
+version: 2.5.0
 description: BPM, graph, and financial-tracking toolkit for the Simulator.Company platform. Exposes the Simulator REST API as MCP tools plus 16 skills covering actors, forms, graphs, layers, accounts, transactions, transfers, charts, smart forms, meetings, reactions, and attachments.
 author:
   name: Simulator.Company

--- a/plugins/simulator/.claude-plugin/plugin.json
+++ b/plugins/simulator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simulator",
-  "version": "2.4.2",
+  "version": "2.5.0",
   "description": "Simulator.Company platform assistant. Exposes the Simulator REST API as an MCP server and provides skills for managing actors, forms, graph structures, and financial accounts.",
   "author": {
     "name": "Simulator.Company",

--- a/plugins/simulator/.codex-plugin/plugin.json
+++ b/plugins/simulator/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simulator",
-  "version": "2.4.2",
+  "version": "2.5.0",
   "description": "Simulator.Company platform assistant. Exposes the Simulator REST API as an MCP server and provides skills for managing actors, forms, graph structures, and financial accounts.",
   "author": {
     "name": "Simulator.Company",

--- a/plugins/simulator/.kiro-plugin/plugin.json
+++ b/plugins/simulator/.kiro-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simulator",
-  "version": "2.4.2",
+  "version": "2.5.0",
   "description": "Simulator.Company platform assistant. Exposes the Simulator REST API as an MCP server and provides skills for managing actors, forms, graph structures, and financial accounts.",
   "author": {
     "name": "Simulator.Company",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+#
+# release.sh — mint a plugin release version in one step.
+#
+# The version is NOT bumped per PR (that caused number collisions when several
+# PRs landed on develop in the same week). Instead PRs only append a bullet under
+# the `## [Unreleased]` section of CHANGELOG.md, and this script mints the version
+# once, when promoting develop → main:
+#
+#   1. rewrites `## [Unreleased]` into a dated `## [x.y.z]` section and starts a
+#      fresh empty `## [Unreleased]` above it;
+#   2. bumps the version in lockstep across the six files that carry it.
+#
+# It does NOT commit, tag, or push — review the result, commit it, merge to main,
+# then tag `vx.y.z` (the Release workflow reads the `## [x.y.z]` CHANGELOG section
+# for the GitHub release notes).
+#
+# Usage:  make release VERSION=2.5.0     (or)     scripts/release.sh 2.5.0
+
+set -euo pipefail
+
+VERSION="${1:-}"
+if [ -z "$VERSION" ]; then
+  echo "ERROR: no version given. Usage: scripts/release.sh <x.y.z>  (or: make release VERSION=x.y.z)" >&2
+  exit 1
+fi
+if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'; then
+  echo "ERROR: version '$VERSION' is not semver (expected x.y.z, optionally x.y.z-suffix)." >&2
+  exit 1
+fi
+
+# Repo root = the parent of this script's dir, so the script works from anywhere.
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+CHANGELOG="CHANGELOG.md"
+
+# The six files that carry the plugin version, in lockstep.
+VERSION_FILES="
+plugins/simulator/.claude-plugin/plugin.json
+plugins/simulator/.codex-plugin/plugin.json
+plugins/simulator/.kiro-plugin/plugin.json
+.claude-plugin/marketplace.json
+.agents/plugins/marketplace.json
+POWER.md
+"
+
+# Current version is the one declared in the canonical plugin manifest.
+CURRENT="$(grep -m1 '"version"' plugins/simulator/.claude-plugin/plugin.json | sed -E 's/.*"version": *"([^"]+)".*/\1/')"
+if [ -z "$CURRENT" ]; then
+  echo "ERROR: could not read the current version from plugins/simulator/.claude-plugin/plugin.json" >&2
+  exit 1
+fi
+if [ "$CURRENT" = "$VERSION" ]; then
+  echo "ERROR: current version is already $VERSION — nothing to bump." >&2
+  exit 1
+fi
+
+# Fail fast if the six files are not already in lockstep — a drifted file would
+# be silently missed by the exact-string bump below.
+drift=0
+for f in $VERSION_FILES; do
+  case "$f" in
+    POWER.md) v="$(grep -m1 '^version:' "$f" | sed -E 's/^version: *//')" ;;
+    *)        v="$(grep -m1 '"version"' "$f" | sed -E 's/.*"version": *"([^"]+)".*/\1/')" ;;
+  esac
+  if [ "$v" != "$CURRENT" ]; then
+    echo "ERROR: $f is at '$v' but the canonical version is '$CURRENT' — the version files are out of lockstep. Fix them before releasing." >&2
+    drift=1
+  fi
+done
+[ "$drift" -eq 0 ] || exit 1
+
+# CHANGELOG must have an Unreleased section to promote.
+if ! grep -q '^## \[Unreleased\]' "$CHANGELOG"; then
+  echo "ERROR: no '## [Unreleased]' section in $CHANGELOG — add one (PRs append their entries there)." >&2
+  exit 1
+fi
+
+DATE="$(date +%F)"
+CURRENT_RE="$(printf '%s' "$CURRENT" | sed 's/\./\\./g')"
+
+echo "Releasing $CURRENT → $VERSION ($DATE)"
+
+# 1) CHANGELOG: leave `## [Unreleased]` in place (now empty) and insert a dated
+#    `## [x.y.z]` header right below it, so the accumulated Unreleased entries
+#    become this version's notes.
+tmp="$(mktemp)"
+awk -v ver="$VERSION" -v date="$DATE" '
+  !done && /^## \[Unreleased\]/ {
+    print
+    print ""
+    print "## [" ver "] - " date
+    done = 1
+    next
+  }
+  { print }
+' "$CHANGELOG" > "$tmp" && mv "$tmp" "$CHANGELOG"
+
+# Warn (do not fail) if the new section has no entries — a release with an empty
+# changelog is legal but usually a mistake.
+if awk -v ver="$VERSION" '
+  $0 ~ "^## \\[" ver "\\]" {inseg=1; next}
+  inseg && /^## /{exit}
+  inseg && /[^[:space:]]/{found=1}
+  END{exit found?0:1}
+' "$CHANGELOG"; then :; else
+  echo "WARNING: the new ## [$VERSION] section has no entries — was ## [Unreleased] empty?" >&2
+fi
+
+# 2) Bump the version in the six files (exact old→new string, so unrelated
+#    version fields in other files — swagger specs, SKILL.md — are untouched).
+for f in $VERSION_FILES; do
+  tmp="$(mktemp)"
+  case "$f" in
+    POWER.md) sed "s/^version: ${CURRENT_RE}\$/version: ${VERSION}/" "$f" > "$tmp" ;;
+    *)        sed "s/\"version\": \"${CURRENT_RE}\"/\"version\": \"${VERSION}\"/" "$f" > "$tmp" ;;
+  esac
+  mv "$tmp" "$f"
+  echo "  bumped $f"
+done
+
+cat <<EOF
+
+Done. Version files and CHANGELOG are at $VERSION.
+Next:
+  1. review the diff:            git diff
+  2. commit:                     git commit -am "chore(release): $VERSION"
+  3. merge develop → main, then tag on main:
+                                 git tag v$VERSION && git push origin v$VERSION
+     (the Release workflow builds binaries and reads the ## [$VERSION] notes)
+EOF


### PR DESCRIPTION
## What & why

Versions were bumped **per PR**, which collides when several PRs land on `develop` in the same week — #71 and #72 both wanted `2.4.1`, and #74 (geolocation) merged with **no** bump at all. This moves version minting to **release time**.

### PR-time (new rule)
- A PR **does not touch the version**. It appends a one-line entry under `## [Unreleased]` at the top of `CHANGELOG.md` (`### Added` / `Changed` / `Fixed`). Appending a bullet avoids the merge conflicts a version bump causes.
- House rules updated: `CLAUDE.md` and `AGENTS.md` (§ Versioning & releases).

### Release-time (`develop` → `main`)
- `scripts/release.sh` + **`make release VERSION=x.y.z`**:
  - verifies the six version files are in lockstep (fails otherwise),
  - rewrites `## [Unreleased]` → dated `## [x.y.z]` and starts a fresh empty `Unreleased`,
  - bumps the version across the six manifests via an exact old→new replace (swagger / `SKILL.md` `version` fields are left untouched),
  - **does not commit/tag/push** — prints the next steps. The existing `Release` workflow reads the `## [x.y.z]` section for the GitHub release notes.

### Closes the geolocation version gap
- Ran `make release VERSION=2.5.0` so the already-merged actor-geolocation feature (#74) is versioned. All six manifests → `2.5.0`; `CHANGELOG` gets a dated `## [2.5.0]` section; a fresh empty `## [Unreleased]` is ready for the next PRs.

## Files
- `scripts/release.sh` (new), `Makefile` (`release` target + help)
- `CHANGELOG.md` (Unreleased convention + `[2.5.0]`), six version manifests → `2.5.0`
- `CLAUDE.md`, `AGENTS.md` (house rules)

## Testing
- `make build` + `make vet` green; all six manifests valid JSON and at `2.5.0`; unrelated swagger `version` untouched; `release.yml`'s changelog-extraction `awk` finds the `## [2.5.0]` section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)