### PR TITLE
feat(simulator): filterActors linkedToActorDirection param

### DIFF
--- a/plugins/simulator/mcp-server/internal/tools/actors.go
+++ b/plugins/simulator/mcp-server/internal/tools/actors.go
@@ -199,7 +199,7 @@ var actorOps = []Operation{
 		Name: "filterActors", Method: "GET", Path: "/actors_filters/{formId}",
 		Summary: "List/rank the actors of a form, optionally filtered by an account's balance. " +
 			"Set linkedToActorId to restrict candidates to a single anchor actor's graph neighbours " +
-			"(both directions along the hierarchy link) — that answers \"the actors related to X whose " +
+			"(both directions along the hierarchy link by default; set linkedToActorDirection=children for only the anchor's child actors, or =parents for only its parents) — that answers \"the actors related to X whose " +
 			"account N balance is > / < some value\". Give accountNameId+currencyId to select the account, " +
 			"amountFrom/amountTo for the balance threshold (amountFrom = balance >=, amountTo = balance <=), " +
 			"and orderBy=balance to rank by it. Returned balances are real decimal values (e.g. 1600 = 1600 USD); " +
@@ -210,6 +210,7 @@ var actorOps = []Operation{
 		Params: []Param{
 			{Name: "formId", In: InPath, Type: "number", Required: true, Desc: "Form id whose actors are filtered/ranked."},
 			{Name: "linkedToActorId", In: InQuery, Type: "string", Desc: "Anchor actor UUID. When set, only actors directly linked to this actor (parents or children along the hierarchy edge) are considered — use it for \"actors related to this one\". Omit for a form-wide listing."},
+			{Name: "linkedToActorDirection", In: InQuery, Type: "string", Enum: []string{"children", "parents", "both"}, Desc: "Which side of the hierarchy link to keep, relative to linkedToActorId (no effect without it). children = only the anchor's child actors (use to expand/collapse a node); parents = only its parents; both (default) = either direction."},
 			{Name: "accountNameId", In: InQuery, Type: "string", Desc: "Account name id to read the balance from (see getAccountNames). Required to filter/rank by balance."},
 			{Name: "currencyId", In: InQuery, Type: "number", Desc: "Currency id of the account (see getCurrencies). Pairs with accountNameId."},
 			{Name: "incomeType", In: InQuery, Type: "string", Enum: []string{"credit", "debit"}, Desc: "Restrict the balance to one direction. Omit to net credit minus debit."},

--- a/plugins/simulator/mcp-server/internal/tools/testdata/eval-scenarios.json
+++ b/plugins/simulator/mcp-server/internal/tools/testdata/eval-scenarios.json
@@ -270,6 +270,23 @@
     ]
   },
   {
+    "name": "List only the child actors of a node",
+    "prompt": "On form 42, list only the child actors of the node a4a7f284-2763-4bce-8b1b-c10bddd207ca (its direct children in the hierarchy), not its parents.",
+    "tools": [
+      "filterActors"
+    ],
+    "argChecks": [
+      {
+        "tool": "filterActors",
+        "mustContain": [
+          "linkedToActorId",
+          "linkedToActorDirection",
+          "children"
+        ]
+      }
+    ]
+  },
+  {
     "name": "Search actors on a layer",
     "prompt": "On layer 14b284e0-5f77-4b40-bdde-f7058b05939f, find the actors matching \"camry\".",
     "tools": [

--- a/plugins/simulator/skills/simulator-actors/SKILL.md
+++ b/plugins/simulator/skills/simulator-actors/SKILL.md
@@ -272,6 +272,10 @@ filterActors(
   amountFrom=1000,                    # balance >= 1000
   orderBy="balance", orderValue="DESC",
   withStats=true)
+
+# Only the CHILD actors of a node (e.g. expand/collapse a node's children)
+filterActors(formId=42, linkedToActorId="<anchor UUID>", linkedToActorDirection="children")
+# ...or only its parents: linkedToActorDirection="parents"; omit / "both" = either direction (default)
 ```
 
 - `q` filters on actor **data** fields; `search` does full-text on the title; `status`

--- a/plugins/simulator/skills/simulator-graph/SKILL.md
+++ b/plugins/simulator/skills/simulator-graph/SKILL.md
@@ -694,6 +694,8 @@ filterActors(formId=<formId>, linkedToActorId="<anchorActorId>",
              accountNameId="<nameId>", currencyId=<id>,
              amountFrom=<min>, amountTo=<max>,        // amountFrom = balance >=, amountTo = balance <=
              orderBy="balance", orderValue="DESC")    // omit linkedToActorId for a form-wide ranking
+// linkedToActorDirection="children" keeps only the anchor's children (expand/collapse a node),
+// "parents" only its parents; omit / "both" = either direction (default).
 
 // Save tokens: every read/traversal tool above (getRelatedActors, getActor,
 // getLayerActors, searchLayerActors, searchActors, filterActors, ...) accepts an


### PR DESCRIPTION
Mirror pong-server CE-15667: add `linkedToActorDirection` (children|parents|both) query param to the `filterActors` tool. Refines `linkedToActorId` — `children` returns only the anchor's child actors (node collapse), `parents` only its parents, `both` (default) keeps the existing bidirectional behavior.

- actors.go: new query Param + directionality note in the summary
- eval-scenarios.json: children-only filtering scenario
- simulator-actors / simulator-graph skills: document the new arg

Validated: `make build && make vet && make test` (drift + eval gates green).

Ref: CE-15667