### PR TITLE
fix(codex): make MCP startup work in Codex

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,68 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      - name: MCP launcher resolves plugin root and preserves workspace
+        run: |
+          python3 - <<'EOF'
+          import json, os, pathlib, stat, subprocess, tempfile
+
+          with open("plugins/simulator/.mcp.json") as f:
+              cfg = json.load(f)
+
+          server = cfg.get("mcpServers", cfg)["simulator"]
+
+          def fake_run_sh(plugin_root):
+              run = pathlib.Path(plugin_root) / "mcp-server" / "run.sh"
+              run.parent.mkdir(parents=True, exist_ok=True)
+              run.write_text("#!/bin/sh\nprintf '%s\n' \"$SIMULATOR_WORK_DIR\" > \"$PROBE_OUT\"\n")
+              run.chmod(run.stat().st_mode | stat.S_IXUSR)
+              return run
+
+          def run_case(label, env_extra, home_builder):
+              with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as workspace:
+                  probe_out = pathlib.Path(home) / "probe.txt"
+                  env = {
+                      "HOME": home,
+                      "PATH": os.environ["PATH"],
+                      "PROBE_OUT": str(probe_out),
+                      **env_extra,
+                  }
+                  env.update(home_builder(home, probe_out) or {})
+                  res = subprocess.run(
+                      [server["command"], *server.get("args", [])],
+                      cwd=workspace,
+                      env=env,
+                      text=True,
+                      capture_output=True,
+                      timeout=10,
+                  )
+                  if res.returncode != 0:
+                      raise SystemExit(f"{label}: launcher failed\nstdout={res.stdout}\nstderr={res.stderr}")
+                  got = probe_out.read_text().strip()
+                  want = os.path.realpath(workspace)
+                  if got != want:
+                      raise SystemExit(f"{label}: SIMULATOR_WORK_DIR={got!r}, want {want!r}")
+
+          with tempfile.TemporaryDirectory() as claude_root:
+              fake_run_sh(claude_root)
+              run_case("claude", {"CLAUDE_PLUGIN_ROOT": claude_root}, lambda home, out: None)
+
+          def codex_home_case(home, probe_out):
+              root = pathlib.Path(home) / ".codex" / "plugins" / "cache" / "simulator" / "simulator" / "999.0.0"
+              fake_run_sh(root)
+
+          run_case("codex-home", {}, codex_home_case)
+
+          def codex_home_env_case(home, probe_out):
+              codex_home = pathlib.Path(home) / "custom-codex-home"
+              root = codex_home / "plugins" / "cache" / "simulator" / "simulator" / "999.0.0"
+              fake_run_sh(root)
+              return {"CODEX_HOME": str(codex_home)}
+
+          run_case("codex-home-env", {}, codex_home_env_case)
+          print(".mcp.json launcher smoke test passed.")
+          EOF
+
       - name: Set up Go
         uses: actions/setup-go@v7
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,9 @@ reinstall. Verify with `/mcp`. Full guide: README → "Local development".
   skill-load time (anthropics/claude-code#48230, #47789, #44057). Renaming it breaks both
   hosts. AWS Kiro doesn't substitute the token at all — `install-kiro.sh` and the release
   generator hard-copy the skills and `sed`-replace the token with the absolute plugin path
-  at install time instead.
+  at install time instead. MCP subprocesses are not skill loading: Codex does not expose
+  `CLAUDE_PLUGIN_ROOT` there, so `.mcp.json` must keep the user's `PWD` as
+  `SIMULATOR_WORK_DIR` and resolve the installed plugin root separately.
 - **Branching model.** `develop` is the integration branch and the **default base for
   every feature/fix PR**; `main` is release-only and receives changes solely by promoting
   `develop` (or a `release/*` / `hotfix/*` branch). Never open a feature/fix PR against

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
   call — safe under the current single-threaded stdio transport, but a data race under `go test
   -race` if a concurrent transport (HTTP/SSE) were ever added. Now uses `atomic.Pointer[string]`,
   matching the `atomic.Bool` discipline already used for the telemetry `enabled` flag.
+- **Codex MCP startup no longer depends on `CLAUDE_PLUGIN_ROOT`.** The launcher now preserves the user's workspace in `SIMULATOR_WORK_DIR` while resolving the installed plugin root separately, so Codex can complete the MCP initialize handshake after a marketplace install.
 
 ## [2.5.0] - 2026-07-14
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,10 @@ Guidance for Claude Code when working in the **simulator-ai-plugin** repository.
   text substitution at skill-load time; renaming it breaks doc loading on both hosts
   (anthropics/claude-code#48230, #47789, #44057). For AWS Kiro — which does no such
   substitution — `install-kiro.sh` and the release-zip generator hard-copy the skills
-  and `sed`-replace the token with the absolute plugin path at install time.
+  and `sed`-replace the token with the absolute plugin path at install time. MCP
+  subprocesses are separate from skill loading: Codex does not expose
+  `CLAUDE_PLUGIN_ROOT` there, so `.mcp.json` must preserve the user's `PWD` as
+  `SIMULATOR_WORK_DIR` and resolve the installed plugin root separately.
 - **MCP tools.** When you add or rename a tool, update the MCP-tools table in the root
   [`README.md`](README.md) and §4 of [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
 - **Curated tools live in Go** under `internal/tools/<domain>.go` (declared as typed

--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ simulator-ai-plugin/
 │   ├── ARCHITECTURE.md          # Plugin & MCP-server architecture
 │   └── INTEGRATION.md           # pong-server integration plan & status
 ├── public/                      # Generated AI-discovery artifacts (llms.txt, .well-known/skills/index.json)
-└── plugins/simulator/           # Plugin root ($CLAUDE_PLUGIN_ROOT for Claude Code, Codex and Kiro)
+└── plugins/simulator/           # Plugin root (skill path token; MCP launcher resolves it per host)
     ├── .claude-plugin/
     │   └── plugin.json          # Claude Code plugin manifest
     ├── .codex-plugin/

--- a/plugins/simulator/.mcp.json
+++ b/plugins/simulator/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "simulator": {
       "command": "sh",
-      "args": ["-c", "export SIMULATOR_WORK_DIR=\"$PWD\"; exec sh \"$CLAUDE_PLUGIN_ROOT/mcp-server/run.sh\""]
+      "args": ["-c", "WORK_DIR=\"$PWD\"; PLUGIN_ROOT=\"$CLAUDE_PLUGIN_ROOT\"; if [ -n \"$PLUGIN_ROOT\" ] && [ ! -f \"$PLUGIN_ROOT/mcp-server/run.sh\" ]; then PLUGIN_ROOT=\"\"; fi; CODEX_CACHE_ROOT=\"\"; if [ -n \"$CODEX_HOME\" ]; then CODEX_CACHE_ROOT=\"$CODEX_HOME\"; elif [ -n \"$HOME\" ]; then CODEX_CACHE_ROOT=\"$HOME/.codex\"; fi; if [ -z \"$PLUGIN_ROOT\" ] && [ -n \"$CODEX_CACHE_ROOT\" ]; then OLD_IFS=$IFS; IFS=$(printf '\\n.'); IFS=${IFS%.}; for dir in $(ls -td \"$CODEX_CACHE_ROOT\"/plugins/cache/simulator/simulator/* 2>/dev/null); do IFS=$OLD_IFS; if [ -f \"$dir/mcp-server/run.sh\" ]; then PLUGIN_ROOT=\"$dir\"; break; fi; done; IFS=$OLD_IFS; fi; if [ -z \"$PLUGIN_ROOT\" ] && [ -f \"$PWD/mcp-server/run.sh\" ]; then PLUGIN_ROOT=\"$PWD\"; fi; if [ -z \"$PLUGIN_ROOT\" ] && [ -f \"$PWD/plugins/simulator/mcp-server/run.sh\" ]; then PLUGIN_ROOT=\"$PWD/plugins/simulator\"; fi; if [ -z \"$PLUGIN_ROOT\" ]; then echo \"ERROR: cannot locate Simulator plugin root; set CLAUDE_PLUGIN_ROOT or install simulator@simulator via Codex\" >&2; exit 1; fi; export SIMULATOR_WORK_DIR=\"$WORK_DIR\"; exec sh \"$PLUGIN_ROOT/mcp-server/run.sh\""]
     }
   }
 }


### PR DESCRIPTION
## What & why

Codex can install the Simulator plugin, but the MCP server failed before the JSON-RPC handshake because `.mcp.json` launched it through `$CLAUDE_PLUGIN_ROOT/mcp-server/run.sh`.

In Codex 0.145, `CLAUDE_PLUGIN_ROOT` is not exposed to MCP subprocesses, so the shell resolves that command to `/mcp-server/run.sh`, exits immediately, and Codex reports the startup failure as `connection closed: initialize response`.

This change keeps Claude Code working and adds Codex-safe plugin-root resolution:

- `.mcp.json` still honors `$CLAUDE_PLUGIN_ROOT` first for Claude Code compatibility.
- If that is unavailable, it resolves the installed Codex plugin root from `CODEX_HOME` or `~/.codex/plugins/cache/simulator/simulator/*`.
- The launcher preserves the user's current project directory as `SIMULATOR_WORK_DIR`; plugin root and workspace root are no longer conflated.
- Local dev-checkout fallbacks remain supported.
- CI now smoke-tests Claude-style and Codex-style launcher resolution.
- Docs clarify the MCP-vs-skill difference and the changelog records the Codex startup fix.

A plain `cwd: "."` would not be sufficient here: in Codex it makes `$PWD` the plugin cache directory, which would break workspace-sensitive MCP operations.

## Type of change

- [x] Bug fix
- [ ] New MCP tool / capability
- [ ] Skill behaviour
- [x] Docs
- [x] Chore / refactor

## Checklist

- [x] `make build && make vet && make test` pass locally
- [x] If I added/renamed a tool — N/A, no tool changes
- [x] If I changed skill frontmatter — N/A, no skill frontmatter changes; `make discovery` produces no `public/` drift
- [x] Reference docs that skills load at runtime stay under `plugins/simulator/docs/` — N/A, untouched
- [x] No tokens or `.env` committed; TLS verification left on by default
- [x] No version bump per the current release-time flow; `CHANGELOG.md` `## [Unreleased]` entry added

## Notes for reviewers

Verified both host paths explicitly:

- Claude compatibility smoke: env-var `CLAUDE_PLUGIN_ROOT` and text-substituted `$CLAUDE_PLUGIN_ROOT`; both complete `initialize` + `tools/list` with 148 tools.
- Codex install smoke: temporary `HOME`, `codex plugin marketplace add`, `codex plugin add simulator@simulator`, command from `codex mcp list`, then `initialize` + `tools/list` with 148 tools.

Additional local checks:

- `python3 -m json.tool` over all plugin/marketplace MCP manifests
- `sh -n plugins/simulator/mcp-server/run.sh`
- launcher matrix: valid `CLAUDE_PLUGIN_ROOT`, invalid `CLAUDE_PLUGIN_ROOT` + Codex fallback, `~/.codex`, `CODEX_HOME`, local plugin-root layout, local repo-root layout
- `make build`
- `make vet`
- `make test`
- `make discovery` + `git diff --exit-code -- public/`

`make lint` remains advisory and currently reports pre-existing Go lint issues; CI marks that step `continue-on-error`.