### PR TITLE
feat(graph): add .graph import/export clone tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,10 @@ the actor/node items.)
 | `pullGraphFile`          | Fetch all actors and edges from a layer and write them to `<layerId>.yaml` in the working directory  |
 | `pushGraphFile`          | Read `<layerId>.yaml` and sync it with the server layer: create / update / remove to match the file  |
 | `getAllLayerPlacements`  | Return every actor placement on a layer in one paginated call                                        |
+| `createGraphExportTask`  | Start an async `.graph` export task for selected graph/layer actors, forms, or a confirmed workspace-wide export |
+| `getGraphImportExportTask` | Read an async `.graph` export/import task status, file metadata, manifest counters, and backend errors |
+| `importGraphArchive`     | Import an uploaded or local `.graph` archive with guarded REF strategy options; requires confirmation |
+| `cloneGraphLayer` / `cloneGraphObjects` | Clone graph/layer objects via export → download → upload → import, returning target ids/URL when safely resolvable |
 | `compactGraphLayout`     | Auto-layout a layer into domain-clustered grids (replaces the pull → edit → push loop)               |
 | `pruneLongEdges`         | Delete edges longer than a distance threshold; preserves hierarchy edges                             |
 | `uploadActorPicture` / `uploadActorPictureBulk` | Set actor pictures from URL / file / base64; auto-rasterise SVG → PNG; bulk dedupes by SHA-256 |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -269,6 +269,10 @@ ported from the original implementation:
 | `pullGraphFile`          | `sync_graph.go`          | Export a layer's actors + edges to `<layerId>.yaml`                  |
 | `pushGraphFile`          | `sync_graph.go` / `push_graph.go` | Diff a local YAML against the layer and create/update/delete |
 | `getAllLayerPlacements`  | `get_layer_placements.go`| Return every placement on a layer in one paginated call             |
+| `createGraphExportTask`  | `import_export.go`       | Start an async `.graph` export task for selected actors/forms       |
+| `getGraphImportExportTask` | `import_export.go`     | Read export/import task status, manifest counters, file metadata, and errors |
+| `importGraphArchive`     | `import_export.go`       | Upload/import a `.graph` archive with guarded REF collision strategy |
+| `cloneGraphLayer` / `cloneGraphObjects` | `import_export.go` | Clone graph/layer objects via export → download → upload → import |
 | `compactGraphLayout`     | `compact_layout.go`      | Auto-layout a layer into domain-clustered grids                     |
 | `pruneLongEdges`         | `prune_edges.go`         | Delete edges longer than a distance threshold; preserves hierarchy  |
 | `uploadActorPicture(Bulk)`| `upload.go` + `svg.go`  | Set actor pictures (URL/file/base64); auto-rasterise SVG→PNG        |

--- a/plugins/simulator/mcp-server/app/mcpserver/unified_test.go
+++ b/plugins/simulator/mcp-server/app/mcpserver/unified_test.go
@@ -3,6 +3,7 @@ package mcpserver_test
 import (
 	"context"
 	"errors"
+	"slices"
 	"testing"
 
 	mcpserver "github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/app/mcpserver"
@@ -10,7 +11,7 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
-// One stateless server: tools/list switches between the full curated catalogue
+// One stateless server: tools/list switches between the full curated catalog
 // (no actor on ctx) and the per-actor subset (WithActorID on ctx) based on the
 // per-request value alone. Same server instance, two views.
 func TestUnifiedServerSwitchesModeOnCtxActor(t *testing.T) {
@@ -46,9 +47,14 @@ func TestUnifiedServerSwitchesModeOnCtxActor(t *testing.T) {
 		t.Fatalf("tools/list (full): %v", err)
 	}
 	full := toolMap(fullList.Tools)
-	for _, want := range []string{"getCurrencies", "getWorkspaces", "createForm"} {
+	for _, want := range []string{"getCurrencies", "getWorkspaces", "createForm", "createGraphExportTask", "getGraphImportExportTask", "importGraphArchive", "cloneGraphLayer", "cloneGraphObjects"} {
 		if _, ok := full[want]; !ok {
 			t.Errorf("full mode is missing workspace-wide tool %q", want)
+		}
+	}
+	for _, name := range []string{"cloneGraphLayer", "cloneGraphObjects"} {
+		if schemaRequires(full[name], "refReplacePrefix") {
+			t.Errorf("%s must not mark refReplacePrefix globally required; it is required only with refStrategy=replace", name)
 		}
 	}
 	if _, ok := full["getActor"]; !ok {
@@ -56,7 +62,8 @@ func TestUnifiedServerSwitchesModeOnCtxActor(t *testing.T) {
 	}
 	// In full mode the actor-scoped tools still expose actorId — the model
 	// supplies it explicitly.
-	if !schemaContains(t, full["getActor"], `"actorId"`) {
+	getActor := full["getActor"]
+	if getActor == nil || !schemaContains(t, *getActor, `"actorId"`) {
 		t.Error("full mode getActor should expose actorId in its schema")
 	}
 
@@ -82,47 +89,52 @@ func TestUnifiedServerSwitchesModeOnCtxActor(t *testing.T) {
 		}
 	}
 	// Workspace-wide tools and engine tools are filtered out.
-	for _, notWant := range []string{"getCurrencies", "getWorkspaces", "createForm", "login", "set-workspace", "set-environment"} {
+	for _, notWant := range []string{"getCurrencies", "getWorkspaces", "createForm", "login", "set-workspace", "set-environment", "createGraphExportTask", "getGraphImportExportTask", "importGraphArchive", "cloneGraphLayer", "cloneGraphObjects"} {
 		if _, ok := actor[notWant]; ok {
 			t.Errorf("actor mode must not expose %q", notWant)
 		}
 	}
 	// Bound identity is stripped from every actor-mode schema.
 	for name, tool := range actor {
-		if schemaContains(t, tool, `"actorId"`) {
+		if schemaContains(t, *tool, `"actorId"`) {
 			t.Errorf("actor mode leaks the bound actorId in %q", name)
 		}
 	}
 	for _, name := range []string{"getAccessRules", "saveAccessRules"} {
 		for _, hidden := range []string{`"objType"`, `"objId"`} {
-			if schemaContains(t, actor[name], hidden) {
+			tool := actor[name]
+			if tool != nil && schemaContains(t, *tool, hidden) {
 				t.Errorf("actor mode leaks bound %s in %q", hidden, name)
 			}
 		}
 	}
 	for _, name := range []string{"createLink", "existLink"} {
-		if schemaContains(t, actor[name], `"source"`) {
+		tool := actor[name]
+		if tool != nil && schemaContains(t, *tool, `"source"`) {
 			t.Errorf("actor mode leaks the bound source in %q", name)
 		}
 	}
 
 	// Flipping the same client back to full mode (no actor on the next call's
-	// ctx) restores the full catalogue — the switch is per request, not per
+	// ctx) restores the full catalog — the switch is per request, not per
 	// session, so the test for that is just symmetric coverage.
 	again, err := cli.ListTools(ctx, mcp.ListToolsRequest{})
 	if err != nil {
 		t.Fatalf("tools/list (full, second call): %v", err)
 	}
 	if got := len(again.Tools); got <= len(actor) {
-		t.Errorf("full-mode catalogue smaller than actor-mode (%d vs %d) — filter is leaking state", got, len(actor))
+		t.Errorf("full-mode catalog smaller than actor-mode (%d vs %d) — filter is leaking state", got, len(actor))
 	}
 }
 
-func toolMap(list []mcp.Tool) map[string]mcp.Tool {
-	out := make(map[string]mcp.Tool, len(list))
-	for _, t := range list {
-		out[t.Name] = t
+func toolMap(list []mcp.Tool) map[string]*mcp.Tool {
+	out := make(map[string]*mcp.Tool, len(list))
+	for i := range list {
+		out[list[i].Name] = &list[i]
 	}
 	return out
 }
 
+func schemaRequires(tool *mcp.Tool, name string) bool {
+	return tool != nil && slices.Contains(tool.InputSchema.Required, name)
+}

--- a/plugins/simulator/mcp-server/internal/engines/graph/import_export.go
+++ b/plugins/simulator/mcp-server/internal/engines/graph/import_export.go
@@ -1,0 +1,1866 @@
+//nolint:goconst // API payload keys and strategy literals are easier to review inline.
+package graph
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"mime/multipart"
+	"net/http"
+	"net/textproto"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/internal/engines/ecore"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	graphArchiveFetchCap = 100 << 20 // 100 MiB
+	graphArchiveLocalCap = 100 << 20 // 100 MiB
+	graphTaskPollDelay   = 3 * time.Second
+)
+
+type graphTaskResponse struct {
+	Data graphTask `json:"data"`
+}
+
+type graphTaskListResponse struct {
+	Data graphTaskListData `json:"data"`
+}
+
+type graphTaskListData struct {
+	Tasks []graphTask
+}
+
+func (d *graphTaskListData) UnmarshalJSON(raw []byte) error {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil
+	}
+	if raw[0] == '[' {
+		return json.Unmarshal(raw, &d.Tasks)
+	}
+	var obj struct {
+		Tasks []graphTask `json:"tasks"`
+	}
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return err
+	}
+	d.Tasks = obj.Tasks
+	return nil
+}
+
+type graphTask struct {
+	ID        int             `json:"id"`
+	Status    string          `json:"status"`
+	Name      string          `json:"name"`
+	Data      json.RawMessage `json:"data,omitempty"`
+	Details   json.RawMessage `json:"details,omitempty"`
+	AccID     string          `json:"accId,omitempty"`
+	CreatedAt int64           `json:"createdAt,omitempty"`
+	TimeStart *int64          `json:"timeStart,omitempty"`
+	TimeEnd   *int64          `json:"timeEnd,omitempty"`
+}
+
+type graphTaskDetails struct {
+	Error    bool            `json:"error,omitempty"`
+	ErrMsg   string          `json:"errMsg,omitempty"`
+	ErrStack string          `json:"errStack,omitempty"`
+	Actor    *graphTaskActor `json:"actor,omitempty"`
+	File     *graphTaskFile  `json:"file,omitempty"`
+	Manifest *graphManifest  `json:"manifest,omitempty"`
+}
+
+type graphTaskActor struct {
+	ID    string `json:"id,omitempty"`
+	Title string `json:"title,omitempty"`
+}
+
+type graphTaskFile struct {
+	ID       int    `json:"id,omitempty"`
+	FileName string `json:"fileName,omitempty"`
+	Title    string `json:"title,omitempty"`
+	Size     int    `json:"size,omitempty"`
+	Type     string `json:"type,omitempty"`
+}
+
+type graphManifest struct {
+	Version string `json:"version,omitempty"`
+	Created string `json:"created,omitempty"`
+	Author  string `json:"author,omitempty"`
+	Stats   struct {
+		Counters map[string]int `json:"counters,omitempty"`
+	} `json:"stats"`
+}
+
+type graphSourceInfo struct {
+	URL         string `json:"url,omitempty"`
+	WorkspaceID string `json:"workspaceId,omitempty"`
+	GraphID     string `json:"graphId,omitempty"`
+	LayerID     string `json:"layerId,omitempty"`
+	SourceKind  string `json:"sourceKind,omitempty"`
+}
+
+type graphArchiveActorMeta struct {
+	ID     string `json:"id,omitempty"`
+	FormID int    `json:"formId,omitempty"`
+	Ref    string `json:"ref,omitempty"`
+	Title  string `json:"title,omitempty"`
+}
+
+type graphResolvedActor struct {
+	ID        string `json:"id,omitempty"`
+	FormID    int    `json:"formId,omitempty"`
+	Ref       string `json:"ref,omitempty"`
+	Title     string `json:"title,omitempty"`
+	FormTitle string `json:"formTitle,omitempty"`
+	CreatedAt int64  `json:"createdAt,omitempty"`
+}
+
+type graphActorSearchResponse struct {
+	Data graphActorSearchData `json:"data"`
+}
+
+type graphActorSearchData struct {
+	List  []graphResolvedActor `json:"list"`
+	Total int                  `json:"total,omitempty"`
+}
+
+func (d *graphActorSearchData) UnmarshalJSON(raw []byte) error {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil
+	}
+	if raw[0] == '[' {
+		return json.Unmarshal(raw, &d.List)
+	}
+	var obj struct {
+		List  []graphResolvedActor `json:"list"`
+		Items []graphResolvedActor `json:"items"`
+		Data  []graphResolvedActor `json:"data"`
+		Total int                  `json:"total,omitempty"`
+	}
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return err
+	}
+	switch {
+	case obj.List != nil:
+		d.List = obj.List
+	case obj.Items != nil:
+		d.List = obj.Items
+	case obj.Data != nil:
+		d.List = obj.Data
+	}
+	d.Total = obj.Total
+	return nil
+}
+
+type graphImportExportClient struct {
+	baseURL string
+	auth    string
+	http    *http.Client
+}
+
+func newGraphImportExportClient(ctx context.Context) (*graphImportExportClient, error) {
+	auth := ecore.AuthHeaderForContext(ctx)
+	if strings.TrimSpace(auth) == "" {
+		return nil, errors.New("missing Authorization header")
+	}
+	return &graphImportExportClient{
+		baseURL: graphImportExportBaseURL(ctx, auth),
+		auth:    auth,
+		http:    ecore.APIHTTPClient(),
+	}, nil
+}
+
+func graphImportExportBaseURL(ctx context.Context, authHeader string) string {
+	base := strings.TrimRight(ecore.BuildBaseURLForContext(ctx), "/")
+	if !strings.HasPrefix(strings.TrimSpace(authHeader), "Bearer ") {
+		return base
+	}
+	if strings.Contains(base, "/papi/") {
+		return strings.Replace(base, "/papi/", "/api/", 1)
+	}
+	if trimmed, ok := strings.CutSuffix(base, "/papi"); ok {
+		return trimmed + "/api"
+	}
+	return base
+}
+
+func (c *graphImportExportClient) doJSON(ctx context.Context, method, reqPath string, body, out any) error {
+	var reader io.Reader
+	if body != nil {
+		raw, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("marshal request body: %w", err)
+		}
+		reader = bytes.NewReader(raw)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+reqPath, reader)
+	if err != nil {
+		return fmt.Errorf("new request: %w", err)
+	}
+	req.Header.Set("Authorization", c.auth)
+	req.Header.Set("X-App-Client", "web")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("http request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(respBody))
+	}
+	if out == nil {
+		return nil
+	}
+	if err := json.Unmarshal(respBody, out); err != nil {
+		return fmt.Errorf("parse response: %w (body: %.200s)", err, respBody)
+	}
+	return nil
+}
+
+func (c *graphImportExportClient) download(ctx context.Context, fileName string) (data []byte, contentType string, err error) {
+	reqPath := "/download/" + encodeGraphArchivePath(fileName)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+reqPath, http.NoBody)
+	if err != nil {
+		return nil, "", fmt.Errorf("new request: %w", err)
+	}
+	req.Header.Set("Authorization", c.auth)
+	req.Header.Set("X-App-Client", "web")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, "", fmt.Errorf("http request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, err = io.ReadAll(io.LimitReader(resp.Body, graphArchiveFetchCap+1))
+	if err != nil {
+		return nil, "", fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, "", fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(data))
+	}
+	if len(data) > graphArchiveFetchCap {
+		return nil, "", fmt.Errorf("graph archive is too large (%d+ bytes; max %d)", graphArchiveFetchCap, graphArchiveFetchCap)
+	}
+	return data, resp.Header.Get("Content-Type"), nil
+}
+
+func (c *graphImportExportClient) upload(ctx context.Context, accID, filename string, fileBytes []byte) (*graphTaskFile, error) {
+	if accID == "" {
+		return nil, errors.New("workspace ID (accId) is empty")
+	}
+	if len(fileBytes) == 0 {
+		return nil, errors.New("file is empty")
+	}
+	if err := validateGraphArchiveBytes(fileBytes); err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	partHeader := make(textproto.MIMEHeader)
+	partHeader.Set("Content-Disposition", fmt.Sprintf(`form-data; name="file"; filename=%q`, filename))
+	partHeader.Set("Content-Type", "application/octet-stream")
+	part, err := mw.CreatePart(partHeader)
+	if err != nil {
+		return nil, fmt.Errorf("create multipart part: %w", err)
+	}
+	if _, err := part.Write(fileBytes); err != nil {
+		return nil, fmt.Errorf("write file bytes: %w", err)
+	}
+	if err := mw.Close(); err != nil {
+		return nil, fmt.Errorf("close multipart writer: %w", err)
+	}
+
+	reqURL := fmt.Sprintf("%s/upload/%s?ttl=0", c.baseURL, url.PathEscape(accID))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, &buf)
+	if err != nil {
+		return nil, fmt.Errorf("new request: %w", err)
+	}
+	req.Header.Set("Authorization", c.auth)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("http request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var ur struct {
+		Data       graphTaskFile `json:"data"`
+		StatusCode int           `json:"statusCode,omitempty"`
+		Message    string        `json:"message,omitempty"`
+	}
+	if err := json.Unmarshal(respBody, &ur); err != nil {
+		return nil, fmt.Errorf("parse response: %w (body: %.200s)", err, respBody)
+	}
+	if ur.Data.FileName == "" {
+		return nil, fmt.Errorf("empty fileName in response: %.200s", respBody)
+	}
+	return &ur.Data, nil
+}
+
+func (c *graphImportExportClient) createTask(ctx context.Context, accID, name string, body any) (*graphTask, error) {
+	var resp graphTaskResponse
+	if err := c.doJSON(ctx, http.MethodPost, "/tasks/"+url.PathEscape(accID)+"/"+name, body, &resp); err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *graphImportExportClient) getTask(ctx context.Context, accID, name string, taskID int) (*graphTask, error) {
+	if taskID <= 0 {
+		return nil, errors.New("taskID is required")
+	}
+	reqPath := fmt.Sprintf("/tasks/%s/%s/%d", url.PathEscape(accID), name, taskID)
+	var resp graphTaskResponse
+	if err := c.doJSON(ctx, http.MethodGet, reqPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	if resp.Data.ID == 0 {
+		return nil, fmt.Errorf("%s task %d not found", name, taskID)
+	}
+	return &resp.Data, nil
+}
+
+func (c *graphImportExportClient) listTasks(ctx context.Context, accID, name string, limit, offset int) ([]graphTask, error) {
+	if limit <= 0 {
+		limit = 15
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	reqPath := fmt.Sprintf("/tasks/list/%s/%s?limit=%d&offset=%d", url.PathEscape(accID), name, limit, offset)
+	var resp graphTaskListResponse
+	if err := c.doJSON(ctx, http.MethodGet, reqPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Data.Tasks, nil
+}
+
+func (c *graphImportExportClient) findTask(ctx context.Context, accID, name string, taskID, limit int) (*graphTask, error) {
+	if taskID > 0 {
+		if task, err := c.getTask(ctx, accID, name, taskID); err == nil {
+			return task, nil
+		}
+	}
+	tasks, err := c.listTasks(ctx, accID, name, limit, 0)
+	if err != nil {
+		return nil, err
+	}
+	for i := range tasks {
+		if tasks[i].ID == taskID {
+			return &tasks[i], nil
+		}
+	}
+	if taskID > 0 {
+		if task, err := c.getTask(ctx, accID, name, taskID); err == nil {
+			return task, nil
+		}
+	}
+	return nil, fmt.Errorf("%s task %d not found in the first %d tasks", name, taskID, limit)
+}
+
+func (c *graphImportExportClient) getActorByRef(ctx context.Context, formID int, ref string) (*graphResolvedActor, error) {
+	if formID <= 0 || strings.TrimSpace(ref) == "" {
+		return nil, errors.New("formID and ref are required")
+	}
+	reqPath := fmt.Sprintf("/actors/ref/%d/%s?filter=id,title,ref,formId,formTitle,createdAt", formID, url.PathEscape(ref))
+	var resp struct {
+		Data graphResolvedActor `json:"data"`
+	}
+	if err := c.doJSON(ctx, http.MethodGet, reqPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	if resp.Data.ID == "" {
+		return nil, fmt.Errorf("empty actor id for formId=%d ref=%q", formID, ref)
+	}
+	return &resp.Data, nil
+}
+
+func (c *graphImportExportClient) getActorMetadata(ctx context.Context, actorID string) (*graphResolvedActor, error) {
+	if strings.TrimSpace(actorID) == "" {
+		return nil, errors.New("actorID is required")
+	}
+	reqPath := "/actors/" + url.PathEscape(actorID) + "?filter=id,title,ref,formId,formTitle,createdAt"
+	var resp struct {
+		Data graphResolvedActor `json:"data"`
+	}
+	if err := c.doJSON(ctx, http.MethodGet, reqPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	if resp.Data.ID == "" {
+		return nil, fmt.Errorf("empty actor id for %s", actorID)
+	}
+	return &resp.Data, nil
+}
+
+func (c *graphImportExportClient) searchActorsByTitle(ctx context.Context, accID, title string, formID, limit int) ([]graphResolvedActor, error) {
+	if strings.TrimSpace(accID) == "" || strings.TrimSpace(title) == "" {
+		return nil, errors.New("accID and title are required")
+	}
+	if limit <= 0 {
+		limit = 50
+	}
+	q := url.Values{}
+	q.Set("filter", "id,title,ref,formId,formTitle,createdAt")
+	q.Set("limit", strconv.Itoa(limit))
+	q.Set("searchType", "text")
+	if formID > 0 {
+		q.Set("formId", strconv.Itoa(formID))
+	}
+	reqPath := fmt.Sprintf("/actors_filters/search/%s/%s?%s", url.PathEscape(accID), url.PathEscape(title), q.Encode())
+	var resp graphActorSearchResponse
+	if err := c.doJSON(ctx, http.MethodGet, reqPath, nil, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Data.List, nil
+}
+
+func (c *graphImportExportClient) waitTask(ctx context.Context, accID, name string, taskID, waitSec int) (*graphTask, *graphTaskDetails, error) {
+	if waitSec <= 0 {
+		task, err := c.findTask(ctx, accID, name, taskID, 50)
+		if err != nil {
+			return nil, nil, err
+		}
+		details, err := parseGraphTaskDetails(task)
+		if err != nil {
+			return nil, nil, err
+		}
+		return task, details, nil
+	}
+	deadline := time.Now().Add(time.Duration(waitSec) * time.Second)
+	for {
+		task, err := c.findTask(ctx, accID, name, taskID, 50)
+		if err != nil {
+			return nil, nil, err
+		}
+		details, err := parseGraphTaskDetails(task)
+		if err != nil {
+			return nil, nil, err
+		}
+		if isFinalGraphTaskStatus(task.Status) {
+			return task, details, nil
+		}
+		if time.Now().Add(graphTaskPollDelay).After(deadline) {
+			return task, details, nil
+		}
+		select {
+		case <-ctx.Done():
+			return nil, nil, ctx.Err()
+		case <-time.After(graphTaskPollDelay):
+		}
+	}
+}
+
+func parseGraphTaskDetails(task *graphTask) (*graphTaskDetails, error) { //nolint:nilnil // Empty task details are valid for queued tasks.
+	if task == nil || len(task.Details) == 0 || string(task.Details) == "null" {
+		return nil, nil //nolint:nilnil // Empty details means there is no details payload yet.
+	}
+	var raw json.RawMessage
+	if len(task.Details) > 0 && task.Details[0] == '"' {
+		var s string
+		if err := json.Unmarshal(task.Details, &s); err != nil {
+			return nil, err
+		}
+		if strings.TrimSpace(s) == "" {
+			return nil, nil //nolint:nilnil // Empty details string means there is no details payload yet.
+		}
+		raw = json.RawMessage(s)
+	} else {
+		raw = task.Details
+	}
+	var details graphTaskDetails
+	if err := json.Unmarshal(raw, &details); err != nil {
+		return nil, err
+	}
+	return &details, nil
+}
+
+func isFinalGraphTaskStatus(status string) bool {
+	switch normalizeGraphTaskStatus(status) {
+	case "completed", "failed", "canceled":
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizeGraphTaskStatus(status string) string {
+	return strings.ToLower(strings.TrimSpace(status))
+}
+
+func graphTaskOutput(task *graphTask, details *graphTaskDetails) map[string]any {
+	out := map[string]any{
+		"id":        task.ID,
+		"status":    task.Status,
+		"name":      task.Name,
+		"accId":     task.AccID,
+		"createdAt": task.CreatedAt,
+	}
+	if len(task.Data) > 0 && string(task.Data) != "null" {
+		var data any
+		if err := json.Unmarshal(task.Data, &data); err == nil {
+			out["data"] = data
+		}
+	}
+	if task.TimeStart != nil {
+		out["timeStart"] = *task.TimeStart
+	}
+	if task.TimeEnd != nil {
+		out["timeEnd"] = *task.TimeEnd
+	}
+	if details != nil {
+		out["details"] = details
+	}
+	return out
+}
+
+func graphTaskCounters(details *graphTaskDetails) map[string]int {
+	if details == nil || details.Manifest == nil {
+		return nil
+	}
+	return details.Manifest.Stats.Counters
+}
+
+func graphCountersEqual(a, b map[string]int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, av := range a {
+		if b[k] != av {
+			return false
+		}
+	}
+	return true
+}
+
+func graphTaskFailureHint(message string) string {
+	msg := strings.ToLower(message)
+	if strings.Contains(msg, "access") || strings.Contains(msg, "permission") ||
+		strings.Contains(msg, "forbidden") || strings.Contains(msg, "denied") {
+		return "Export requires access to every object included by the selected graph/layer recursion. If a layer contains actors, forms, accounts, files, or linked objects the current user cannot read, the backend can reject the export; grant access or export a narrower selection."
+	}
+	return ""
+}
+
+func parseGraphSourceURL(raw string) (*graphSourceInfo, error) { //nolint:nilnil // Empty sourceUrl is optional and handled by explicit ids.
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil //nolint:nilnil // sourceUrl is optional; callers may provide explicit ids instead.
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return nil, fmt.Errorf("parse sourceUrl: %w", err)
+	}
+	parts := strings.Split(strings.Trim(u.EscapedPath(), "/"), "/")
+	for i, p := range parts {
+		decoded, err := url.PathUnescape(p)
+		if err == nil {
+			parts[i] = decoded
+		}
+	}
+	info := &graphSourceInfo{URL: raw}
+	for i := range parts {
+		if parts[i] != "actors_graph" || i+1 >= len(parts) {
+			continue
+		}
+		info.WorkspaceID = parts[i+1]
+		for j := i + 2; j < len(parts); j++ {
+			if parts[j] == "graph" && j+1 < len(parts) {
+				info.GraphID = parts[j+1]
+			}
+			if parts[j] == "layers" && j+1 < len(parts) {
+				info.LayerID = parts[j+1]
+			}
+		}
+		break
+	}
+	if info.GraphID == "" && info.LayerID == "" {
+		return nil, errors.New("sourceUrl must be a Simulator graph URL like /actors_graph/<workspace>/graph/<graphId>/layers/<layerId>")
+	}
+	if info.GraphID != "" && !ecore.IsUUID(info.GraphID) && info.GraphID != "0" {
+		return nil, fmt.Errorf("sourceUrl graph id must be a UUID or 0, got %q", info.GraphID)
+	}
+	if info.LayerID != "" && !ecore.IsUUID(info.LayerID) {
+		return nil, fmt.Errorf("sourceUrl layer id must be a UUID, got %q", info.LayerID)
+	}
+	if info.WorkspaceID != "" && len(info.WorkspaceID) != 8 && !ecore.IsUUID(info.WorkspaceID) {
+		return nil, fmt.Errorf("sourceUrl workspace segment must be a full UUID or 8-char short id, got %q", info.WorkspaceID)
+	}
+	return info, nil
+}
+
+func resolveSourceWorkspace(ctx context.Context, parsed string) string {
+	parsed = strings.TrimSpace(parsed)
+	if parsed == "" {
+		return ""
+	}
+	current := ecore.WorkspaceIDForContext(ctx)
+	if ecore.IsUUID(parsed) {
+		return parsed
+	}
+	if current != "" && len(parsed) == 8 && strings.HasPrefix(current, parsed) {
+		return current
+	}
+	return parsed
+}
+
+func graphSelectionProvided(args map[string]any) bool {
+	if boolArg(args, "allWorkspace") {
+		return true
+	}
+	actorIDs, _ := actorIDSliceArg(args)
+	formIDs, _ := intSliceArg(args, "formIds")
+	return len(actorIDs) > 0 || len(formIDs) > 0
+}
+
+func copyToolArgs(args map[string]any) map[string]any {
+	out := make(map[string]any, len(args))
+	maps.Copy(out, args)
+	return out
+}
+
+func applyGraphSourceURL(ctx context.Context, args map[string]any) (*graphSourceInfo, error) {
+	sourceURL := strings.TrimSpace(stringArg(args, "sourceUrl"))
+	if sourceURL == "" {
+		sourceURL = strings.TrimSpace(stringArg(args, "graphUrl"))
+	}
+	info, err := parseGraphSourceURL(sourceURL)
+	if err != nil || info == nil {
+		return info, err
+	}
+	if strings.TrimSpace(stringArg(args, "sourceAccId")) == "" {
+		if accID := resolveSourceWorkspace(ctx, info.WorkspaceID); accID != "" {
+			args["sourceAccId"] = accID
+			info.WorkspaceID = accID
+		}
+	} else if accID := resolveSourceWorkspace(ctx, stringArg(args, "sourceAccId")); accID != "" {
+		info.WorkspaceID = accID
+	}
+	kind := strings.TrimSpace(stringArgDefault(args, "sourceKind", "auto"))
+	if kind == "" {
+		kind = "auto"
+	}
+	switch kind {
+	case "auto":
+		if info.LayerID != "" {
+			kind = "layer"
+		} else {
+			kind = "graph"
+		}
+	case "layer", "graph":
+	default:
+		return nil, fmt.Errorf("sourceKind must be auto, layer, or graph, got %q", kind)
+	}
+	info.SourceKind = kind
+	if !graphSelectionProvided(args) {
+		switch kind {
+		case "layer":
+			if info.LayerID == "" {
+				return nil, errors.New("sourceKind=layer requires a URL with /layers/<layerId>")
+			}
+			args["actorIds"] = []any{info.LayerID}
+		case "graph":
+			if info.GraphID == "" || info.GraphID == "0" {
+				return nil, errors.New("sourceKind=graph requires a URL with /graph/<graphActorId>")
+			}
+			args["actorIds"] = []any{info.GraphID}
+		}
+	}
+	return info, nil
+}
+
+func requireGraphTaskOK(name string, task *graphTask, details *graphTaskDetails) error {
+	if task == nil {
+		return fmt.Errorf("%s task is missing", name)
+	}
+	switch normalizeGraphTaskStatus(task.Status) {
+	case "failed":
+		if details != nil && details.ErrMsg != "" {
+			return fmt.Errorf("%s task %d failed: %s", name, task.ID, details.ErrMsg)
+		}
+		return fmt.Errorf("%s task %d failed", name, task.ID)
+	case "canceled":
+		return fmt.Errorf("%s task %d was canceled", name, task.ID)
+	case "completed":
+		return nil
+	default:
+		return fmt.Errorf("%s task %d is still %s", name, task.ID, task.Status)
+	}
+}
+
+func buildGraphExportBody(args map[string]any) (map[string]any, error) {
+	allWorkspace := boolArg(args, "allWorkspace")
+	if allWorkspace {
+		if !boolArg(args, "confirmAllWorkspaceExport") {
+			return nil, errors.New("allWorkspace export requires confirmAllWorkspaceExport=true")
+		}
+		return map[string]any{"allWorkspace": true}, nil
+	}
+
+	actorIDs, err := actorIDSliceArg(args)
+	if err != nil {
+		return nil, err
+	}
+	formIDs, err := intSliceArg(args, "formIds")
+	if err != nil {
+		return nil, err
+	}
+	if actorIDs == nil {
+		actorIDs = []string{}
+	}
+	if formIDs == nil {
+		formIDs = []int{}
+	}
+	if len(actorIDs) == 0 && len(formIDs) == 0 {
+		return nil, errors.New("provide actorIds, formIds, or allWorkspace=true")
+	}
+	for _, actorID := range actorIDs {
+		if !ecore.IsUUID(actorID) {
+			return nil, fmt.Errorf("actorIds must contain valid UUIDs, got %q", actorID)
+		}
+	}
+
+	ops := map[string]any{
+		"transactions":         boolArg(args, "transactions"),
+		"processes":            boolArg(args, "processes"),
+		"users":                boolArg(args, "users"),
+		"attachments":          boolArgDefault(args, "attachments", false),
+		"balances":             boolArg(args, "balances"),
+		"connectorsToAccounts": boolArg(args, "connectorsToAccounts"),
+		"accountToActors":      boolArg(args, "accountToActors"),
+	}
+	if level, ok, err := maxRecursionLevelArg(args); err != nil {
+		return nil, err
+	} else if ok {
+		ops["maxRecursionLevel"] = level
+	}
+
+	return map[string]any{
+		"actors":               actorIDs,
+		"forms":                formIDs,
+		"ops":                  ops,
+		"balances":             boolArg(args, "balances"),
+		"connectorsToAccounts": boolArg(args, "connectorsToAccounts"),
+		"systemCounters":       boolArg(args, "systemCounters"),
+		"accountToActors":      boolArg(args, "accountToActors"),
+	}, nil
+}
+
+func buildGraphImportBody(fileName, title string, args map[string]any) (map[string]any, error) {
+	if !boolArg(args, "confirmImport") && !boolArg(args, "confirmClone") {
+		return nil, errors.New("import creates or updates workspace objects; pass confirmImport=true")
+	}
+	strategy := strings.TrimSpace(stringArgDefault(args, "refStrategy", "replace"))
+	if strategy == "" {
+		strategy = "replace"
+	}
+	switch strategy {
+	case "replace", "reuse", "error":
+	default:
+		return nil, fmt.Errorf("refStrategy must be replace, reuse, or error, got %q", strategy)
+	}
+	if strategy == "reuse" && !boolArg(args, "allowReuseImport") {
+		return nil, errors.New("refStrategy=reuse can update existing matching REF objects; pass allowReuseImport=true if this is intended")
+	}
+
+	prefix := strings.TrimSpace(stringArg(args, "refReplacePrefix"))
+	if strategy == "replace" {
+		if prefix == "" {
+			return nil, errors.New("refStrategy=replace requires non-empty refReplacePrefix so imported refs cannot collide silently")
+		}
+		if len(prefix) < 8 {
+			return nil, errors.New("refReplacePrefix must be at least 8 characters")
+		}
+	} else if prefix != "" {
+		return nil, errors.New("refReplacePrefix is only valid with refStrategy=replace; omit it for refStrategy=reuse or refStrategy=error")
+	}
+
+	ops := map[string]any{
+		"processesRefStrategy":   strategy,
+		"actorRefStrategy":       strategy,
+		"formRefStrategy":        strategy,
+		"transferRefStrategy":    strategy,
+		"transactionRefStrategy": strategy,
+	}
+	if prefix != "" {
+		ops["actorRefReplacePrefix"] = prefix
+		ops["formRefReplacePrefix"] = prefix
+		ops["transferRefReplacePrefix"] = prefix
+		ops["transactionRefReplacePrefix"] = prefix
+	}
+
+	users, err := objectSliceArg(args, "users")
+	if err != nil {
+		return nil, err
+	}
+	scripts, err := objectSliceArg(args, "scripts")
+	if err != nil {
+		return nil, err
+	}
+	if title == "" {
+		title = path.Base(fileName)
+	}
+	return map[string]any{
+		"fileName": fileName,
+		"title":    title,
+		"users":    users,
+		"scripts":  scripts,
+		"ops":      ops,
+	}, nil
+}
+
+func graphToolError(prefix string, err error) (*mcp.CallToolResult, error) {
+	return mcp.NewToolResultError(prefix + err.Error()), nil
+}
+
+func graphToolErrorf(format string, args ...any) (*mcp.CallToolResult, error) {
+	return mcp.NewToolResultError(fmt.Sprintf(format, args...)), nil
+}
+
+func graphToolJSON(toolName string, value any) (*mcp.CallToolResult, error) {
+	out, err := json.Marshal(value)
+	if err != nil {
+		return graphToolErrorf("[Error] %s: marshal result: %v", toolName, err)
+	}
+	return mcp.NewToolResultText(string(out)), nil
+}
+
+func handleCreateGraphExportTask(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic // mcp-go handler signature uses value requests.
+	if authResult := ecore.EnsureAuth(ctx); authResult != nil {
+		return authResult, nil
+	}
+	args := req.GetArguments()
+	accID := workspaceArg(ctx, args, "accId")
+	if accID == "" {
+		return mcp.NewToolResultError("[Error] createGraphExportTask: no workspace set — run set-workspace or pass accId"), nil
+	}
+	body, err := buildGraphExportBody(args)
+	if err != nil {
+		return graphToolError("[Error] createGraphExportTask: ", err)
+	}
+	client, err := newGraphImportExportClient(ctx)
+	if err != nil {
+		return graphToolError("[Error] createGraphExportTask: ", err)
+	}
+	task, err := client.createTask(ctx, accID, "export", body)
+	if err != nil {
+		return graphToolErrorf("[Error] createGraphExportTask: %v", err)
+	}
+	details, _ := parseGraphTaskDetails(task)
+	waitSec := intArg(args, "waitSec")
+	if waitSec > 0 {
+		task, details, err = client.waitTask(ctx, accID, "export", task.ID, waitSec)
+		if err != nil {
+			return graphToolErrorf("[Error] createGraphExportTask: %v", err)
+		}
+	}
+	return graphToolJSON("createGraphExportTask", graphTaskOutput(task, details))
+}
+
+func handleGetGraphImportExportTask(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic // mcp-go handler signature uses value requests.
+	if authResult := ecore.EnsureAuth(ctx); authResult != nil {
+		return authResult, nil
+	}
+	args := req.GetArguments()
+	accID := workspaceArg(ctx, args, "accId")
+	if accID == "" {
+		return mcp.NewToolResultError("[Error] getGraphImportExportTask: no workspace set — run set-workspace or pass accId"), nil
+	}
+	name := strings.TrimSpace(stringArgDefault(args, "name", "export"))
+	if name != "export" && name != "import" {
+		return mcp.NewToolResultError("[Error] getGraphImportExportTask: name must be export or import"), nil
+	}
+	limit := intArgDefault(args, "limit", 15)
+	offset := intArg(args, "offset")
+	client, err := newGraphImportExportClient(ctx)
+	if err != nil {
+		return graphToolError("[Error] getGraphImportExportTask: ", err)
+	}
+	if taskID := intArg(args, "taskId"); taskID > 0 {
+		task, err := client.findTask(ctx, accID, name, taskID, limit)
+		if err != nil {
+			return graphToolErrorf("[Error] getGraphImportExportTask: %v", err)
+		}
+		details, err := parseGraphTaskDetails(task)
+		if err != nil {
+			return graphToolErrorf("[Error] getGraphImportExportTask: parse details: %v", err)
+		}
+		return graphToolJSON("getGraphImportExportTask", graphTaskOutput(task, details))
+	}
+	tasks, err := client.listTasks(ctx, accID, name, limit, offset)
+	if err != nil {
+		return graphToolErrorf("[Error] getGraphImportExportTask: %v", err)
+	}
+	out := make([]map[string]any, 0, len(tasks))
+	for i := range tasks {
+		details, err := parseGraphTaskDetails(&tasks[i])
+		if err != nil {
+			return graphToolErrorf("[Error] getGraphImportExportTask: parse details for task %d: %v", tasks[i].ID, err)
+		}
+		out = append(out, graphTaskOutput(&tasks[i], details))
+	}
+	return graphToolJSON("getGraphImportExportTask", map[string]any{"tasks": out, "limit": limit, "offset": offset})
+}
+
+func handleImportGraphArchive(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic // mcp-go handler signature uses value requests.
+	if authResult := ecore.EnsureAuth(ctx); authResult != nil {
+		return authResult, nil
+	}
+	args := req.GetArguments()
+	accID := workspaceArg(ctx, args, "accId")
+	if accID == "" {
+		return mcp.NewToolResultError("[Error] importGraphArchive: no workspace set — run set-workspace or pass accId"), nil
+	}
+	fileName := strings.TrimSpace(stringArg(args, "fileName"))
+	localPath := strings.TrimSpace(stringArg(args, "localPath"))
+	title := strings.TrimSpace(stringArg(args, "title"))
+	if (fileName == "") == (localPath == "") {
+		return mcp.NewToolResultError("[Error] importGraphArchive: provide exactly one of fileName or localPath"), nil
+	}
+	if _, err := buildGraphImportBody("placeholder.graph", title, args); err != nil {
+		return graphToolError("[Error] importGraphArchive: ", err)
+	}
+	client, err := newGraphImportExportClient(ctx)
+	if err != nil {
+		return graphToolError("[Error] importGraphArchive: ", err)
+	}
+	var uploaded *graphTaskFile
+	if localPath != "" {
+		archiveBytes, filename, err := readLocalGraphArchive(localPath)
+		if err != nil {
+			return graphToolError("[Error] importGraphArchive: ", err)
+		}
+		uploaded, err = client.upload(ctx, accID, filename, archiveBytes)
+		if err != nil {
+			return graphToolErrorf("[Error] importGraphArchive upload: %v", err)
+		}
+		fileName = uploaded.FileName
+		if title == "" {
+			title = uploaded.Title
+		}
+	}
+	body, err := buildGraphImportBody(fileName, title, args)
+	if err != nil {
+		return graphToolError("[Error] importGraphArchive: ", err)
+	}
+	task, err := client.createTask(ctx, accID, "import", body)
+	if err != nil {
+		return graphToolErrorf("[Error] importGraphArchive: %v", err)
+	}
+	details, _ := parseGraphTaskDetails(task)
+	waitSec := intArg(args, "waitSec")
+	if waitSec > 0 {
+		task, details, err = client.waitTask(ctx, accID, "import", task.ID, waitSec)
+		if err != nil {
+			return graphToolErrorf("[Error] importGraphArchive: %v", err)
+		}
+	}
+	result := graphTaskOutput(task, details)
+	if uploaded != nil {
+		result["uploadedFile"] = uploaded
+	}
+	return graphToolJSON("importGraphArchive", result)
+}
+
+func handleCloneGraphObjects(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic // mcp-go handler signature uses value requests.
+	if authResult := ecore.EnsureAuth(ctx); authResult != nil {
+		return authResult, nil
+	}
+	args := copyToolArgs(req.GetArguments())
+	if !boolArg(args, "confirmClone") {
+		return mcp.NewToolResultError("[Error] cloneGraphObjects: cloning imports objects into a workspace; pass confirmClone=true"), nil
+	}
+	sourceInfo, err := applyGraphSourceURL(ctx, args)
+	if err != nil {
+		return graphToolError("[Error] cloneGraphObjects sourceUrl: ", err)
+	}
+	sourceAccID := workspaceArg(ctx, args, "sourceAccId")
+	exportBody, err := buildGraphExportBody(args)
+	if err != nil {
+		return graphToolError("[Error] cloneGraphObjects export: ", err)
+	}
+	selection := map[string]any{}
+	if actorIDs, err := actorIDSliceArg(args); err == nil && len(actorIDs) > 0 {
+		selection["actorIds"] = actorIDs
+	}
+	if formIDs, err := intSliceArg(args, "formIds"); err == nil && len(formIDs) > 0 {
+		selection["formIds"] = formIDs
+	}
+	if boolArg(args, "allWorkspace") {
+		selection["allWorkspace"] = true
+	}
+	if sourceInfo != nil {
+		selection["sourceUrl"] = sourceInfo.URL
+		selection["sourceWorkspaceId"] = sourceInfo.WorkspaceID
+		selection["sourceGraphId"] = sourceInfo.GraphID
+		selection["sourceLayerId"] = sourceInfo.LayerID
+		selection["sourceKind"] = sourceInfo.SourceKind
+	}
+	return runGraphClone(ctx, "cloneGraphObjects", args, sourceAccID, exportBody, selection)
+}
+
+func handleCloneGraphLayer(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic // mcp-go handler signature uses value requests.
+	if authResult := ecore.EnsureAuth(ctx); authResult != nil {
+		return authResult, nil
+	}
+	args := copyToolArgs(req.GetArguments())
+	if !boolArg(args, "confirmClone") {
+		return mcp.NewToolResultError("[Error] cloneGraphLayer: cloning imports objects into a workspace; pass confirmClone=true"), nil
+	}
+	sourceInfo, err := applyGraphSourceURL(ctx, args)
+	if err != nil {
+		return graphToolError("[Error] cloneGraphLayer sourceUrl: ", err)
+	}
+	layerID := strings.TrimSpace(stringArg(args, "layerId"))
+	if layerID == "" && sourceInfo != nil {
+		layerID = sourceInfo.LayerID
+	}
+	if layerID == "" {
+		return mcp.NewToolResultError("[Error] cloneGraphLayer: layerId is required"), nil
+	}
+	if r := ecore.RequireUUID("layerId", layerID); r != nil {
+		return r, nil
+	}
+	sourceAccID := workspaceArg(ctx, args, "sourceAccId")
+
+	exportArgs := map[string]any{}
+	maps.Copy(exportArgs, args)
+	exportArgs["actorIds"] = []any{layerID}
+	body, err := buildGraphExportBody(exportArgs)
+	if err != nil {
+		return graphToolError("[Error] cloneGraphLayer export: ", err)
+	}
+	subject := map[string]any{"layerId": layerID, "sourceLayerId": layerID}
+	if sourceInfo != nil {
+		subject["sourceUrl"] = sourceInfo.URL
+		subject["sourceWorkspaceId"] = sourceInfo.WorkspaceID
+		subject["sourceGraphId"] = sourceInfo.GraphID
+		subject["sourceLayerId"] = sourceInfo.LayerID
+		subject["sourceKind"] = "layer"
+	}
+	return runGraphClone(ctx, "cloneGraphLayer", args, sourceAccID, body, subject)
+}
+
+func runGraphClone(ctx context.Context, toolName string, args map[string]any, sourceAccID string, exportBody, subject map[string]any) (*mcp.CallToolResult, error) {
+	if sourceAccID == "" {
+		return mcp.NewToolResultError(fmt.Sprintf("[Error] %s: no source workspace set — run set-workspace or pass sourceAccId", toolName)), nil
+	}
+	targetAccID := strings.TrimSpace(stringArg(args, "targetAccId"))
+	if targetAccID == "" {
+		targetAccID = sourceAccID
+	}
+	client, err := newGraphImportExportClient(ctx)
+	if err != nil {
+		return graphToolErrorf("[Error] %s: %s", toolName, err.Error())
+	}
+
+	waitSec := intArgDefault(args, "waitSec", 300)
+	exportTask, err := client.createTask(ctx, sourceAccID, "export", exportBody)
+	if err != nil {
+		return graphToolErrorf("[Error] %s create export: %v", toolName, err)
+	}
+	exportTask, exportDetails, err := client.waitTask(ctx, sourceAccID, "export", exportTask.ID, waitSec)
+	if err != nil {
+		return graphToolErrorf("[Error] %s wait export: %v", toolName, err)
+	}
+	if err := requireGraphTaskOK("export", exportTask, exportDetails); err != nil {
+		failure := map[string]any{
+			"exportTask": graphTaskOutput(exportTask, exportDetails),
+			"error":      err.Error(),
+		}
+		if hint := graphTaskFailureHint(err.Error()); hint != "" {
+			failure["hint"] = hint
+		}
+		out, err := json.Marshal(failure)
+		if err != nil {
+			return graphToolErrorf("[Error] %s: marshal export failure: %v", toolName, err)
+		}
+		return graphToolErrorf("[Error] %s: %s", toolName, string(out))
+	}
+	if exportDetails == nil || exportDetails.File == nil || exportDetails.File.FileName == "" {
+		return graphToolErrorf("[Error] %s: completed export did not return details.file.fileName", toolName)
+	}
+
+	graphBytes, contentType, err := client.download(ctx, exportDetails.File.FileName)
+	if err != nil {
+		return graphToolErrorf("[Error] %s download export: %v", toolName, err)
+	}
+	if err := validateGraphArchiveBytes(graphBytes); err != nil {
+		return graphToolErrorf("[Error] %s validate export: %v", toolName, err)
+	}
+	uploadTitle := exportDetails.File.Title
+	if uploadTitle == "" {
+		uploadTitle = fmt.Sprintf("graph-export-%d.graph", exportTask.ID)
+	}
+	if filepath.Ext(uploadTitle) == "" {
+		uploadTitle += ".graph"
+	}
+	uploaded, err := client.upload(ctx, targetAccID, uploadTitle, graphBytes)
+	if err != nil {
+		return graphToolErrorf("[Error] %s upload import archive: %v", toolName, err)
+	}
+
+	importArgs := map[string]any{}
+	maps.Copy(importArgs, args)
+	importArgs["confirmImport"] = true
+	delete(importArgs, "users")
+	delete(importArgs, "scripts")
+	if mappings, ok := args["userMappings"]; ok {
+		importArgs["users"] = mappings
+	}
+	if mappings, ok := args["scriptMappings"]; ok {
+		importArgs["scripts"] = mappings
+	}
+	body, err := buildGraphImportBody(uploaded.FileName, uploaded.Title, importArgs)
+	if err != nil {
+		return graphToolErrorf("[Error] %s import: %s", toolName, err.Error())
+	}
+	importTask, err := client.createTask(ctx, targetAccID, "import", body)
+	if err != nil {
+		return graphToolErrorf("[Error] %s create import: %v", toolName, err)
+	}
+	importTask, importDetails, err := client.waitTask(ctx, targetAccID, "import", importTask.ID, waitSec)
+	if err != nil {
+		return graphToolErrorf("[Error] %s wait import: %v", toolName, err)
+	}
+	if err := requireGraphTaskOK("import", importTask, importDetails); err != nil {
+		failure := map[string]any{
+			"exportTask":   graphTaskOutput(exportTask, exportDetails),
+			"uploadedFile": uploaded,
+			"importTask":   graphTaskOutput(importTask, importDetails),
+			"error":        err.Error(),
+		}
+		if hint := graphTaskFailureHint(err.Error()); hint != "" {
+			failure["hint"] = hint
+		}
+		out, err := json.Marshal(failure)
+		if err != nil {
+			return graphToolErrorf("[Error] %s: marshal import failure: %v", toolName, err)
+		}
+		return graphToolErrorf("[Error] %s: %s", toolName, string(out))
+	}
+
+	warnings := []string{
+		"Graph import creates or updates workspace objects. Use replace with a unique refReplacePrefix for normal cloning; reuse can update existing matching REF objects.",
+		"By default the import target is the current/source workspace in the same Simulator environment. To import elsewhere, pass targetAccId for that workspace or switch the MCP environment first.",
+		"Server export recursion can include substantially more than the visible graph/layer. Review manifest counters before using this on production workspaces.",
+	}
+	if targetAccID == sourceAccID {
+		warnings = append(warnings, "The target workspace is the same as the source workspace. With refStrategy=replace this creates duplicated objects under refReplacePrefix; with reuse it can update existing REF-matching objects.")
+	}
+	target, targetWarnings := resolveGraphCloneTarget(ctx, client, targetAccID, graphBytes, args, subject, importTask, importDetails)
+	warnings = append(warnings, targetWarnings...)
+
+	result := map[string]any{
+		"sourceAccId":        sourceAccID,
+		"targetAccId":        targetAccID,
+		"exportTask":         graphTaskOutput(exportTask, exportDetails),
+		"exportArchiveBytes": len(graphBytes),
+		"exportContentType":  contentType,
+		"uploadedFile":       uploaded,
+		"importTask":         graphTaskOutput(importTask, importDetails),
+		"refReplacePrefix":   stringArg(args, "refReplacePrefix"),
+		"importRefStrategy":  stringArgDefault(args, "refStrategy", "replace"),
+		"warnings":           warnings,
+	}
+	if len(target) > 0 {
+		result["target"] = target
+	}
+	if exportCounters, importCounters := graphTaskCounters(exportDetails), graphTaskCounters(importDetails); exportCounters != nil && importCounters != nil {
+		result["countersMatch"] = graphCountersEqual(exportCounters, importCounters)
+	}
+	maps.Copy(result, subject)
+	return graphToolJSON(toolName, result)
+}
+
+func readLocalGraphArchive(localPath string) (data []byte, filename string, err error) {
+	p := strings.TrimSpace(localPath)
+	if p == "" {
+		return nil, "", errors.New("localPath is empty")
+	}
+	if !filepath.IsAbs(p) {
+		return nil, "", errors.New("localPath must be absolute")
+	}
+	if strings.ToLower(filepath.Ext(p)) != ".graph" {
+		return nil, "", errors.New("localPath must point to a .graph archive")
+	}
+	info, err := os.Stat(p)
+	if err != nil {
+		return nil, "", err
+	}
+	if info.IsDir() {
+		return nil, "", errors.New("localPath points to a directory")
+	}
+	if info.Size() > graphArchiveLocalCap {
+		return nil, "", fmt.Errorf("localPath file is too large (%d bytes; max %d)", info.Size(), graphArchiveLocalCap)
+	}
+	data, err = os.ReadFile(p)
+	if err != nil {
+		return nil, "", err
+	}
+	if err := validateGraphArchiveBytes(data); err != nil {
+		return nil, "", err
+	}
+	return data, filepath.Base(p), nil
+}
+
+func validateGraphArchiveBytes(data []byte) error {
+	reader, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return fmt.Errorf("invalid .graph zip archive: %w", err)
+	}
+	hasManifest := false
+	hasActor := false
+	hasForm := false
+	for _, f := range reader.File {
+		switch {
+		case f.Name == "GraphManifest.yaml":
+			hasManifest = true
+		case strings.HasPrefix(f.Name, "topology/actors/") && strings.HasSuffix(f.Name, ".yaml"):
+			hasActor = true
+		case strings.HasPrefix(f.Name, "forms/") && strings.HasSuffix(f.Name, ".yaml"):
+			hasForm = true
+		}
+	}
+	if !hasManifest {
+		return errors.New(".graph archive is missing GraphManifest.yaml")
+	}
+	if !hasActor && !hasForm {
+		return errors.New(".graph archive must contain at least one actor or form yaml")
+	}
+	return nil
+}
+
+func extractGraphArchiveActorMetadata(data []byte, ids []string) (map[string]graphArchiveActorMeta, error) {
+	want := map[string]bool{}
+	for _, id := range ids {
+		id = strings.TrimSpace(id)
+		if id != "" {
+			want[id] = true
+		}
+	}
+	if len(want) == 0 {
+		return map[string]graphArchiveActorMeta{}, nil
+	}
+	reader, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return nil, fmt.Errorf("invalid .graph zip archive: %w", err)
+	}
+	out := map[string]graphArchiveActorMeta{}
+	for _, f := range reader.File {
+		if !strings.HasPrefix(f.Name, "topology/actors/") || !strings.HasSuffix(f.Name, ".yaml") {
+			continue
+		}
+		id := strings.TrimSuffix(path.Base(f.Name), ".yaml")
+		if !want[id] {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return nil, fmt.Errorf("open %s: %w", f.Name, err)
+		}
+		raw, readErr := io.ReadAll(io.LimitReader(rc, 1<<20))
+		closeErr := rc.Close()
+		if readErr != nil {
+			return nil, fmt.Errorf("read %s: %w", f.Name, readErr)
+		}
+		if closeErr != nil {
+			return nil, fmt.Errorf("close %s: %w", f.Name, closeErr)
+		}
+		var actor map[string]any
+		if err := yaml.Unmarshal(raw, &actor); err != nil {
+			return nil, fmt.Errorf("parse %s: %w", f.Name, err)
+		}
+		meta := graphArchiveActorMeta{
+			ID:     firstString(actor, "id"),
+			FormID: firstInt(actor, "formId", "formID", "form_id"),
+			Ref:    firstString(actor, "ref"),
+			Title:  firstString(actor, "title"),
+		}
+		if meta.ID == "" {
+			meta.ID = id
+		}
+		out[id] = meta
+	}
+	return out, nil
+}
+
+func firstString(m map[string]any, names ...string) string {
+	for _, name := range names {
+		if s, ok := m[name].(string); ok && strings.TrimSpace(s) != "" {
+			return strings.TrimSpace(s)
+		}
+	}
+	return ""
+}
+
+func firstInt(m map[string]any, names ...string) int {
+	for _, name := range names {
+		if n := toInt(m[name]); n > 0 {
+			return n
+		}
+	}
+	return 0
+}
+
+func encodeGraphArchivePath(fileName string) string {
+	parts := strings.Split(fileName, "/")
+	for i, p := range parts {
+		parts[i] = url.PathEscape(p)
+	}
+	return strings.Join(parts, "/")
+}
+
+func graphWebBaseURL(ctx context.Context) string {
+	base := strings.TrimRight(ecore.BuildBaseURLForContext(ctx), "/")
+	for _, suffix := range []string{"/papi/1.0", "/api/1.0", "/papi", "/api"} {
+		base = strings.TrimSuffix(base, suffix)
+	}
+	return strings.TrimRight(base, "/")
+}
+
+func graphShortAcc(acc string) string {
+	if len(acc) > 8 && acc[8] == '-' {
+		return acc[:8]
+	}
+	return acc
+}
+
+func buildGraphLayerURL(ctx context.Context, accID, graphID, layerID string) string {
+	base := graphWebBaseURL(ctx)
+	if base == "" || accID == "" || graphID == "" {
+		return ""
+	}
+	linkPath := fmt.Sprintf("%s/actors_graph/%s/graph/%s/layers", base, url.PathEscape(graphShortAcc(accID)), url.PathEscape(graphID))
+	if layerID != "" {
+		linkPath += "/" + url.PathEscape(layerID)
+	}
+	return linkPath
+}
+
+func resolveGraphCloneTarget(ctx context.Context, client *graphImportExportClient, targetAccID string, graphBytes []byte, args, subject map[string]any, importTask *graphTask, importDetails *graphTaskDetails) (target map[string]any, warnings []string) { //nolint:gocyclo // REF and no-REF target resolution paths stay together for consistent warnings.
+	target = map[string]any{}
+	warnings = []string{}
+	if importDetails != nil && importDetails.Actor != nil && importDetails.Actor.ID != "" {
+		target["importActor"] = importDetails.Actor
+	}
+	if stringArgDefault(args, "refStrategy", "replace") != "replace" {
+		warnings = append(warnings, "Target URL was not resolved automatically because refStrategy is not replace; resolve the imported object manually or use replace with a unique refReplacePrefix.")
+		return target, warnings
+	}
+	prefix := strings.TrimSpace(stringArg(args, "refReplacePrefix"))
+	if prefix == "" {
+		return target, warnings
+	}
+
+	sourceGraphID := strings.TrimSpace(stringArg(subject, "sourceGraphId"))
+	sourceLayerID := strings.TrimSpace(stringArg(subject, "sourceLayerId"))
+	if sourceLayerID == "" {
+		sourceLayerID = strings.TrimSpace(stringArg(subject, "layerId"))
+	}
+	sourceIDs := []string{}
+	if sourceGraphID != "" && sourceGraphID != "0" {
+		sourceIDs = append(sourceIDs, sourceGraphID)
+	}
+	if sourceLayerID != "" {
+		sourceIDs = append(sourceIDs, sourceLayerID)
+	}
+	if actorIDs, err := actorIDSliceArg(subject); err == nil {
+		for _, actorID := range actorIDs {
+			if actorID != "" {
+				sourceIDs = append(sourceIDs, actorID)
+			}
+		}
+	}
+	metas, err := extractGraphArchiveActorMetadata(graphBytes, sourceIDs)
+	if err != nil {
+		warnings = append(warnings, "Target URL was not resolved automatically: "+err.Error())
+		return target, warnings
+	}
+
+	targetActors := map[string]graphResolvedActor{}
+	resolve := func(sourceID string, warnMissing bool) *graphResolvedActor {
+		if sourceID == "" {
+			return nil
+		}
+		if resolved, ok := targetActors[sourceID]; ok {
+			return &resolved
+		}
+		meta, ok := metas[sourceID]
+		if !ok {
+			if warnMissing {
+				warnings = append(warnings, fmt.Sprintf("Target actor for source %s was not resolved: source actor metadata was not present in the export archive.", sourceID))
+			}
+			return nil
+		}
+		if meta.FormID <= 0 || meta.Ref == "" {
+			resolved, reason, err := resolveImportedActorWithoutRef(ctx, client, targetAccID, sourceID, meta, importTask)
+			if err != nil {
+				warnings = append(warnings, fmt.Sprintf("Target actor for source %s was not resolved without ref metadata: %v", sourceID, err))
+				return nil
+			}
+			if reason != "" {
+				warnings = append(warnings, reason)
+			}
+			if resolved == nil {
+				warnings = append(warnings, fmt.Sprintf("Target actor for source %s was not resolved: exported actor has no formId/ref metadata.", sourceID))
+				return nil
+			}
+			targetActors[sourceID] = *resolved
+			return resolved
+		}
+		resolved, err := client.getActorByRef(ctx, meta.FormID, prefix+meta.Ref)
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("Target actor for source %s was not resolved by ref: %v", sourceID, err))
+			return nil
+		}
+		targetActors[sourceID] = *resolved
+		return resolved
+	}
+
+	var targetGraph *graphResolvedActor
+	if sourceGraphID != "" && sourceGraphID != "0" {
+		targetGraph = resolve(sourceGraphID, stringArg(subject, "sourceKind") != "layer")
+	}
+	targetLayer := resolve(sourceLayerID, true)
+	if len(targetActors) > 0 {
+		target["actorsBySourceId"] = targetActors
+	}
+	if targetGraph != nil {
+		target["graphId"] = targetGraph.ID
+	}
+	if targetLayer != nil {
+		target["layerId"] = targetLayer.ID
+	}
+	switch {
+	case targetGraph != nil && targetLayer != nil:
+		target["url"] = buildGraphLayerURL(ctx, targetAccID, targetGraph.ID, targetLayer.ID)
+	case targetLayer != nil:
+		target["url"] = buildGraphLayerURL(ctx, targetAccID, targetLayer.ID, "")
+	case targetGraph != nil:
+		target["url"] = buildGraphLayerURL(ctx, targetAccID, targetGraph.ID, "")
+	}
+	return target, warnings
+}
+
+func resolveImportedActorWithoutRef(ctx context.Context, client *graphImportExportClient, targetAccID, sourceID string, meta graphArchiveActorMeta, importTask *graphTask) (*graphResolvedActor, string, error) {
+	title := strings.TrimSpace(meta.Title)
+	formID := meta.FormID
+	if title == "" || formID <= 0 {
+		source, err := client.getActorMetadata(ctx, sourceID)
+		if err != nil {
+			return nil, "", err
+		}
+		if title == "" {
+			title = strings.TrimSpace(source.Title)
+		}
+		if formID <= 0 {
+			formID = source.FormID
+		}
+	}
+	if title == "" || formID <= 0 {
+		return nil, "", nil
+	}
+	candidates := []graphResolvedActor{}
+	seenCandidates := map[string]bool{}
+	for _, query := range graphActorFallbackSearchQueries(title) {
+		found, err := client.searchActorsByTitle(ctx, targetAccID, query, formID, 50)
+		if err != nil {
+			return nil, "", err
+		}
+		for _, candidate := range found {
+			if candidate.ID == "" || seenCandidates[candidate.ID] {
+				continue
+			}
+			seenCandidates[candidate.ID] = true
+			candidates = append(candidates, candidate)
+		}
+	}
+	minCreatedAt := graphImportStartedAt(importTask)
+	matches := make([]graphResolvedActor, 0, len(candidates))
+	for _, candidate := range candidates {
+		if candidate.ID == "" || candidate.ID == sourceID {
+			continue
+		}
+		if candidate.Title != title {
+			continue
+		}
+		if formID > 0 && candidate.FormID != formID {
+			continue
+		}
+		if minCreatedAt > 0 {
+			if candidate.CreatedAt == 0 || candidate.CreatedAt < minCreatedAt-2 {
+				continue
+			}
+		}
+		matches = append(matches, candidate)
+	}
+	switch len(matches) {
+	case 0:
+		return nil, "", nil
+	case 1:
+		return &matches[0], fmt.Sprintf("Target actor for source %s was resolved by title/formId fallback because the source actor has no ref; verify the returned URL before using it in production.", sourceID), nil
+	default:
+		return nil, "", fmt.Errorf("found %d candidate actors named %q with formId=%d after import; not guessing", len(matches), title, formID)
+	}
+}
+
+func graphActorFallbackSearchQueries(title string) []string {
+	title = strings.TrimSpace(title)
+	if title == "" {
+		return nil
+	}
+	queries := []string{title}
+	parts := strings.Fields(title)
+	if len(parts) > 4 {
+		short := strings.Join(parts[:4], " ")
+		if short != title {
+			queries = append(queries, short)
+		}
+	}
+	return queries
+}
+
+func graphImportStartedAt(task *graphTask) int64 {
+	if task == nil {
+		return 0
+	}
+	if task.TimeStart != nil && *task.TimeStart > 0 {
+		return *task.TimeStart
+	}
+	return task.CreatedAt
+}
+
+func workspaceArg(ctx context.Context, args map[string]any, name string) string {
+	if s := strings.TrimSpace(stringArg(args, name)); s != "" {
+		return s
+	}
+	return ecore.WorkspaceIDForContext(ctx)
+}
+
+func stringArg(args map[string]any, name string) string {
+	if args == nil {
+		return ""
+	}
+	switch v := args[name].(type) {
+	case string:
+		return v
+	default:
+		return ""
+	}
+}
+
+func stringArgDefault(args map[string]any, name, def string) string {
+	if v := stringArg(args, name); v != "" {
+		return v
+	}
+	return def
+}
+
+func boolArg(args map[string]any, name string) bool {
+	if args == nil {
+		return false
+	}
+	v, ok := args[name]
+	if !ok {
+		return false
+	}
+	switch val := v.(type) {
+	case bool:
+		return val
+	case string:
+		b, _ := strconv.ParseBool(val)
+		return b
+	default:
+		return false
+	}
+}
+
+func boolArgDefault(args map[string]any, name string, def bool) bool {
+	if args == nil {
+		return def
+	}
+	if _, ok := args[name]; !ok {
+		return def
+	}
+	return boolArg(args, name)
+}
+
+func intArg(args map[string]any, name string) int {
+	if args == nil {
+		return 0
+	}
+	return toInt(args[name])
+}
+
+func intArgDefault(args map[string]any, name string, def int) int {
+	if args == nil {
+		return def
+	}
+	if _, ok := args[name]; !ok {
+		return def
+	}
+	v := intArg(args, name)
+	if v == 0 {
+		return def
+	}
+	return v
+}
+
+func actorIDSliceArg(args map[string]any) ([]string, error) {
+	if args == nil {
+		return nil, nil
+	}
+	raw, ok := args["actorIds"]
+	if !ok || raw == nil {
+		return nil, nil
+	}
+	if arr, ok := raw.([]string); ok {
+		out := make([]string, 0, len(arr))
+		for _, item := range arr {
+			if strings.TrimSpace(item) == "" {
+				return nil, errors.New("actorIds must contain non-empty strings")
+			}
+			out = append(out, strings.TrimSpace(item))
+		}
+		return out, nil
+	}
+	arr, ok := raw.([]any)
+	if !ok {
+		return nil, errors.New("actorIds must be an array")
+	}
+	out := make([]string, 0, len(arr))
+	for _, item := range arr {
+		s, ok := item.(string)
+		if !ok || strings.TrimSpace(s) == "" {
+			return nil, errors.New("actorIds must contain non-empty strings")
+		}
+		out = append(out, strings.TrimSpace(s))
+	}
+	return out, nil
+}
+
+func intSliceArg(args map[string]any, name string) ([]int, error) {
+	if args == nil {
+		return nil, nil
+	}
+	raw, ok := args[name]
+	if !ok || raw == nil {
+		return nil, nil
+	}
+	if arr, ok := raw.([]int); ok {
+		out := make([]int, 0, len(arr))
+		for _, n := range arr {
+			if n <= 0 {
+				return nil, fmt.Errorf("%s must contain positive numeric form ids", name)
+			}
+			out = append(out, n)
+		}
+		return out, nil
+	}
+	arr, ok := raw.([]any)
+	if !ok {
+		return nil, fmt.Errorf("%s must be an array", name)
+	}
+	out := make([]int, 0, len(arr))
+	for _, item := range arr {
+		n := toInt(item)
+		if n <= 0 {
+			return nil, fmt.Errorf("%s must contain positive numeric form ids", name)
+		}
+		out = append(out, n)
+	}
+	return out, nil
+}
+
+func objectSliceArg(args map[string]any, name string) ([]any, error) {
+	if args == nil {
+		return []any{}, nil
+	}
+	raw, ok := args[name]
+	if !ok || raw == nil {
+		return []any{}, nil
+	}
+	if arr, ok := raw.([]map[string]any); ok {
+		out := make([]any, 0, len(arr))
+		for _, item := range arr {
+			out = append(out, item)
+		}
+		return out, nil
+	}
+	arr, ok := raw.([]any)
+	if !ok {
+		return nil, fmt.Errorf("%s must be an array", name)
+	}
+	return arr, nil
+}
+
+func maxRecursionLevelArg(args map[string]any) (level int, ok bool, err error) {
+	if args == nil {
+		return 0, false, nil
+	}
+	raw, ok := args["maxRecursionLevel"]
+	if !ok || raw == nil {
+		return 0, false, nil
+	}
+	if s, ok := raw.(string); ok {
+		s = strings.TrimSpace(s)
+		if s == "" || s == "max" {
+			return 0, false, nil
+		}
+		n, err := strconv.Atoi(s)
+		if err != nil {
+			return 0, false, errors.New("maxRecursionLevel must be \"max\" or an integer 1..10")
+		}
+		if n < 1 || n > 10 {
+			return 0, false, errors.New("maxRecursionLevel must be 1..10")
+		}
+		return n, true, nil
+	}
+	n := toInt(raw)
+	if n < 1 || n > 10 {
+		return 0, false, errors.New("maxRecursionLevel must be 1..10")
+	}
+	return n, true, nil
+}
+
+func registerGraphImportExportTools(s *server.MCPServer) {
+	s.AddTool(
+		mcp.NewTool("createGraphExportTask",
+			mcp.WithDescription("Start an async Simulator .graph export task. To export/clone a layer, pass the layer actor UUID in actorIds. To export a graph, pass the graph root actor UUID. The server recursively exports referenced objects: maxRecursionLevel=max is the safest for a later import but can include much more than the visible graph/layer; lower numeric levels may create an archive that later fails to import. Export can fail if the current user lacks access to any object included by recursion. Review completed manifest counters before production use."),
+			mcp.WithString("accId", mcp.Description("Workspace id. Defaults to the configured/request workspace.")),
+			mcp.WithArray("actorIds", mcp.Description("Actor UUIDs to export. For a graph layer, include the layer actor UUID.")),
+			mcp.WithArray("formIds", mcp.Description("Numeric form ids to export.")),
+			mcp.WithBoolean("allWorkspace", mcp.Description("Export the whole workspace. Requires confirmAllWorkspaceExport=true.")),
+			mcp.WithBoolean("confirmAllWorkspaceExport", mcp.Description("Required guard for allWorkspace=true because it can export a large/sensitive archive.")),
+			mcp.WithString("maxRecursionLevel", mcp.Description("Reference recursion depth: \"max\" (default) or integer 1..10. For imports, \"max\" is safest; low values can be incomplete.")),
+			mcp.WithBoolean("attachments", mcp.Description("Include file attachments. Default false in MCP to avoid unintentionally exporting files.")),
+			mcp.WithBoolean("transactions", mcp.Description("Include transactions. Default false.")),
+			mcp.WithBoolean("processes", mcp.Description("Include linked Corezoid processes/projects/stages. Default false.")),
+			mcp.WithBoolean("users", mcp.Description("Include users/groups access mapping data. Default false.")),
+			mcp.WithBoolean("balances", mcp.Description("Include balances. Default false.")),
+			mcp.WithBoolean("connectorsToAccounts", mcp.Description("Include connector-to-account links. Default false.")),
+			mcp.WithBoolean("systemCounters", mcp.Description("Include system counters. Default false.")),
+			mcp.WithBoolean("accountToActors", mcp.Description("Include account-to-actor links. Default false.")),
+			mcp.WithNumber("waitSec", mcp.Description("Optional seconds to poll for completion before returning. Without it, returns the created task.")),
+		),
+		handleCreateGraphExportTask,
+	)
+
+	s.AddTool(
+		mcp.NewTool("getGraphImportExportTask",
+			mcp.WithDescription("List or inspect async Simulator graph import/export tasks. Completed export tasks carry details.file.fileName for download/import and details.manifest.stats.counters for review. Failed tasks carry details.errMsg."),
+			mcp.WithString("accId", mcp.Description("Workspace id. Defaults to the configured/request workspace.")),
+			mcp.WithString("name", mcp.Description("Task type: export or import. Default export.")),
+			mcp.WithNumber("taskId", mcp.Description("Optional task id to inspect directly. Uses the direct task endpoint before falling back to list lookup.")),
+			mcp.WithNumber("limit", mcp.Description("Page size. Default 15.")),
+			mcp.WithNumber("offset", mcp.Description("Page offset. Default 0.")),
+		),
+		handleGetGraphImportExportTask,
+	)
+
+	s.AddTool(
+		mcp.NewTool("importGraphArchive",
+			mcp.WithDescription("Start an async Simulator .graph import task from an uploaded fileName or a local .graph archive. This is a write operation: it can create many actors/forms/edges/accounts and, with refStrategy=reuse, update existing REF-matching objects. Normal cloning should use refStrategy=replace plus a unique refReplacePrefix. Requires confirmImport=true."),
+			mcp.WithString("accId", mcp.Description("Target workspace id. Defaults to the configured/request workspace.")),
+			mcp.WithString("fileName", mcp.Description("Already uploaded storage fileName of the .graph archive. Provide exactly one of fileName or localPath.")),
+			mcp.WithString("localPath", mcp.Description("Absolute path to a local .graph archive on the MCP server host. The file is validated as a .graph zip before upload. Provide exactly one of fileName or localPath.")),
+			mcp.WithString("title", mcp.Description("Optional import file title. Defaults to the archive basename/title.")),
+			mcp.WithString("refStrategy", mcp.Description("REF collision strategy: replace (default, creates objects with prefixed refs), reuse (updates matching existing refs; requires allowReuseImport=true), or error.")),
+			mcp.WithString("refReplacePrefix", mcp.Description("Required only with refStrategy=replace. Use a unique prefix, e.g. clone_20260724_. Omit for refStrategy=error or reuse.")),
+			mcp.WithBoolean("confirmImport", mcp.Description("Required true guard acknowledging that import writes objects into the workspace.")),
+			mcp.WithBoolean("allowReuseImport", mcp.Description("Required true only when refStrategy=reuse, because reuse can update existing REF-matching objects.")),
+			mcp.WithArray("users", mcp.Description("Optional user/group mapping array, same shape as UI: {fromId,toIds[]}.")),
+			mcp.WithArray("scripts", mcp.Description("Optional Corezoid script credential mapping array, same shape as UI import task.")),
+			mcp.WithNumber("waitSec", mcp.Description("Optional seconds to poll for completion before returning. Without it, returns the created task.")),
+		),
+		handleImportGraphArchive,
+	)
+
+	s.AddTool(
+		mcp.NewTool("cloneGraphLayer",
+			mcp.WithDescription("Clone/copy a Simulator graph layer through the official async export/import flow: export layer actor to a .graph archive, wait for completion, download, upload into the target workspace, then import with the chosen REF strategy. This does not delete the source layer. Accepts either layerId or sourceUrl; sourceUrl can be a Simulator /actors_graph/<workspace>/graph/<graphId>/layers/<layerId> link. On successful replace imports, the result tries to include target.layerId and target.url for the cloned layer. This is a convenience wrapper over cloneGraphObjects. Export can fail if the current user lacks access to any object included by layer recursion. This can create many objects; use replace with a unique refReplacePrefix for normal cloning. Requires confirmClone=true. Avoid casual use in production workspaces until manifest counters are reviewed."),
+			mcp.WithString("layerId", mcp.Description("Source layer actor UUID. Optional when sourceUrl contains /layers/<layerId>.")),
+			mcp.WithString("sourceUrl", mcp.Description("Optional Simulator graph/layer URL. For layer clone, must contain /layers/<layerId>; sourceAccId is inferred from the URL when possible.")),
+			mcp.WithString("sourceAccId", mcp.Description("Source workspace id. Defaults to the configured/request workspace.")),
+			mcp.WithString("targetAccId", mcp.Description("Target workspace id in the current Simulator environment. Defaults to sourceAccId, which itself defaults to the configured/request workspace.")),
+			mcp.WithString("maxRecursionLevel", mcp.Description("Reference recursion depth for export: \"max\" (default) or integer 1..10. Full clone/import is safest with max; low values can be incomplete.")),
+			mcp.WithBoolean("attachments", mcp.Description("Include attachments in export/import. Default false.")),
+			mcp.WithBoolean("transactions", mcp.Description("Include transactions. Default false.")),
+			mcp.WithBoolean("processes", mcp.Description("Include linked Corezoid processes/projects/stages. Default false.")),
+			mcp.WithBoolean("users", mcp.Description("Include users/groups access data. Default false; unmapped imported access can grant rights to the importing user.")),
+			mcp.WithBoolean("balances", mcp.Description("Include balances. Default false.")),
+			mcp.WithBoolean("connectorsToAccounts", mcp.Description("Include connector-to-account links. Default false.")),
+			mcp.WithBoolean("systemCounters", mcp.Description("Include system counters. Default false.")),
+			mcp.WithBoolean("accountToActors", mcp.Description("Include account-to-actor links. Default false.")),
+			mcp.WithString("refStrategy", mcp.Description("Import REF collision strategy: replace (default), reuse, or error. reuse requires allowReuseImport=true.")),
+			mcp.WithString("refReplacePrefix", mcp.Description("Required only with refStrategy=replace. Unique prefix for replace strategy, e.g. clone_20260724_. Omit for refStrategy=error or reuse; non-empty values are rejected for those strategies.")),
+			mcp.WithBoolean("confirmClone", mcp.Description("Required true guard acknowledging that clone imports objects into the target workspace.")),
+			mcp.WithBoolean("allowReuseImport", mcp.Description("Required true only when refStrategy=reuse, because reuse can update existing REF-matching objects.")),
+			mcp.WithArray("userMappings", mcp.Description("Optional import user/group mapping array, same shape as UI: {fromId,toIds[]}. If omitted and users are included in the export, access import behavior follows the backend default.")),
+			mcp.WithArray("scriptMappings", mcp.Description("Optional Corezoid script credential mapping array, same shape as UI import task.")),
+			mcp.WithNumber("waitSec", mcp.Description("Seconds to wait for each async export/import task. Default 300.")),
+		),
+		handleCloneGraphLayer,
+	)
+
+	s.AddTool(
+		mcp.NewTool("cloneGraphObjects",
+			mcp.WithDescription("Clone/copy selected Simulator graph objects through the official async export/import flow. This does not delete source objects. Pass sourceUrl, graph/layer actor UUIDs in actorIds, optional formIds, or allWorkspace=true with explicit confirmation. sourceUrl can be a Simulator /actors_graph/<workspace>/graph/<graphId>/layers/<layerId> link; sourceKind=auto clones the layer when the URL has /layers/<layerId>, otherwise the graph root. On successful replace imports, the result tries to include target.graphId/target.layerId/target.url for the cloned graph/layer. Graph root export can complete while later import is rejected by backend validation, so success means final import status=completed. Export can fail if the current user lacks access to any object included by recursion. The import target defaults to the current/source workspace in the same Simulator environment; pass targetAccId to import into another workspace. This can create many objects; use replace with a unique refReplacePrefix for normal cloning. Requires confirmClone=true."),
+			mcp.WithString("sourceUrl", mcp.Description("Optional Simulator graph/layer URL. If actorIds/formIds/allWorkspace are omitted, the tool derives actorIds from this URL and sourceKind.")),
+			mcp.WithString("sourceKind", mcp.Description("How to interpret sourceUrl when deriving actorIds: auto (default; layer URL clones layer, graph URL clones graph), layer, or graph.")),
+			mcp.WithArray("actorIds", mcp.Description("Actor UUIDs to clone. Use the graph root UUID to clone a graph, or a layer UUID to clone a layer.")),
+			mcp.WithArray("formIds", mcp.Description("Numeric form ids to clone with their referenced objects.")),
+			mcp.WithBoolean("allWorkspace", mcp.Description("Clone/export the whole workspace. Requires confirmAllWorkspaceExport=true and confirmClone=true.")),
+			mcp.WithBoolean("confirmAllWorkspaceExport", mcp.Description("Required guard for allWorkspace=true because it can export a large/sensitive archive.")),
+			mcp.WithString("sourceAccId", mcp.Description("Source workspace id. Defaults to the configured/request workspace.")),
+			mcp.WithString("targetAccId", mcp.Description("Target workspace id in the current Simulator environment. Defaults to sourceAccId, which itself defaults to the configured/request workspace.")),
+			mcp.WithString("maxRecursionLevel", mcp.Description("Reference recursion depth for export: \"max\" (default) or integer 1..10. Full clone/import is safest with max; low values can be incomplete.")),
+			mcp.WithBoolean("attachments", mcp.Description("Include attachments in export/import. Default false.")),
+			mcp.WithBoolean("transactions", mcp.Description("Include transactions. Default false.")),
+			mcp.WithBoolean("processes", mcp.Description("Include linked Corezoid processes/projects/stages. Default false.")),
+			mcp.WithBoolean("users", mcp.Description("Include users/groups access data. Default false; unmapped imported access can grant rights to the importing user.")),
+			mcp.WithBoolean("balances", mcp.Description("Include balances. Default false.")),
+			mcp.WithBoolean("connectorsToAccounts", mcp.Description("Include connector-to-account links. Default false.")),
+			mcp.WithBoolean("systemCounters", mcp.Description("Include system counters. Default false.")),
+			mcp.WithBoolean("accountToActors", mcp.Description("Include account-to-actor links. Default false.")),
+			mcp.WithString("refStrategy", mcp.Description("Import REF collision strategy: replace (default), reuse, or error. reuse requires allowReuseImport=true.")),
+			mcp.WithString("refReplacePrefix", mcp.Description("Required only with refStrategy=replace. Unique prefix for replace strategy, e.g. clone_20260724_. Omit for refStrategy=error or reuse; non-empty values are rejected for those strategies.")),
+			mcp.WithBoolean("confirmClone", mcp.Description("Required true guard acknowledging that clone imports objects into the target workspace.")),
+			mcp.WithBoolean("allowReuseImport", mcp.Description("Required true only when refStrategy=reuse, because reuse can update existing REF-matching objects.")),
+			mcp.WithArray("userMappings", mcp.Description("Optional import user/group mapping array, same shape as UI: {fromId,toIds[]}. If omitted and users are included in the export, access import behavior follows the backend default.")),
+			mcp.WithArray("scriptMappings", mcp.Description("Optional Corezoid script credential mapping array, same shape as UI import task.")),
+			mcp.WithNumber("waitSec", mcp.Description("Seconds to wait for each async export/import task. Default 300.")),
+		),
+		handleCloneGraphObjects,
+	)
+}

--- a/plugins/simulator/mcp-server/internal/engines/graph/import_export_test.go
+++ b/plugins/simulator/mcp-server/internal/engines/graph/import_export_test.go
@@ -1,0 +1,993 @@
+//nolint:goconst // Test fixtures intentionally keep API keys and sample values inline.
+package graph
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/internal/apiclient"
+	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/internal/engines/ecore"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestGraphImportExportBaseURLSelectsWebAPIForBearer(t *testing.T) {
+	ecore.Configure("https://mw.simulator.company/papi/1.0", false)
+	if got := graphImportExportBaseURL(context.Background(), "Bearer sid"); got != "https://mw.simulator.company/api/1.0" {
+		t.Fatalf("Bearer auth should use web API base, got %q", got)
+	}
+	if got := graphImportExportBaseURL(context.Background(), "Simulator jwt"); got != "https://mw.simulator.company/papi/1.0" {
+		t.Fatalf("Simulator auth should keep PAPI base, got %q", got)
+	}
+	ctx := apiclient.WithBaseURL(context.Background(), "https://tenant.example/papi/1.0")
+	if got := graphImportExportBaseURL(ctx, "Bearer sid"); got != "https://tenant.example/api/1.0" {
+		t.Fatalf("ctx base override should be transformed safely, got %q", got)
+	}
+}
+
+func TestBuildGraphExportBodyGuardsAllWorkspace(t *testing.T) {
+	if _, err := buildGraphExportBody(map[string]any{"allWorkspace": true}); err == nil {
+		t.Fatal("expected allWorkspace export to require confirmation")
+	}
+	if _, err := buildGraphExportBody(map[string]any{"actorIds": []any{"../../bad"}}); err == nil {
+		t.Fatal("expected actorIds UUID validation")
+	}
+	body, err := buildGraphExportBody(map[string]any{"allWorkspace": true, "confirmAllWorkspaceExport": true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if body["allWorkspace"] != true {
+		t.Fatalf("expected allWorkspace body, got %#v", body)
+	}
+}
+
+func TestBuildGraphExportBodyUsesEmptyArraysForOmittedSelections(t *testing.T) {
+	body, err := buildGraphExportBody(map[string]any{
+		"actorIds": []any{"11111111-1111-4111-8111-111111111111"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	text := string(raw)
+	if !strings.Contains(text, `"actors":["11111111-1111-4111-8111-111111111111"]`) || !strings.Contains(text, `"forms":[]`) {
+		t.Fatalf("expected live-compatible array selections, got %s", text)
+	}
+
+	body, err = buildGraphExportBody(map[string]any{"formIds": []any{123}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	raw, err = json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	text = string(raw)
+	if !strings.Contains(text, `"actors":[]`) || !strings.Contains(text, `"forms":[123]`) {
+		t.Fatalf("expected live-compatible array selections, got %s", text)
+	}
+}
+
+func TestBuildGraphExportBodyMirrorsUISchemaFlags(t *testing.T) {
+	body, err := buildGraphExportBody(map[string]any{
+		"actorIds":             []any{"11111111-1111-4111-8111-111111111111"},
+		"formIds":              []any{123},
+		"attachments":          true,
+		"transactions":         true,
+		"processes":            true,
+		"users":                true,
+		"balances":             true,
+		"connectorsToAccounts": true,
+		"systemCounters":       true,
+		"accountToActors":      true,
+		"maxRecursionLevel":    3,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ops := requireOpsMap(t, body)
+	for _, name := range []string{"attachments", "transactions", "processes", "users", "balances", "connectorsToAccounts", "accountToActors"} {
+		if ops[name] != true {
+			t.Fatalf("expected ops.%s=true in UI-compatible export body, got %#v", name, ops)
+		}
+	}
+	if ops["maxRecursionLevel"] != 3 {
+		t.Fatalf("expected ops.maxRecursionLevel=3, got %#v", ops)
+	}
+	for _, name := range []string{"balances", "connectorsToAccounts", "systemCounters", "accountToActors"} {
+		if body[name] != true {
+			t.Fatalf("expected top-level %s=true in UI-compatible export body, got %#v", name, body)
+		}
+	}
+}
+
+func TestBuildGraphImportBodyGuardrails(t *testing.T) {
+	base := map[string]any{"confirmImport": true, "refReplacePrefix": "clone_20260724_"}
+	if _, err := buildGraphImportBody("file.graph", "", map[string]any{"refReplacePrefix": "clone_20260724_"}); err == nil {
+		t.Fatal("expected import to require confirmation")
+	}
+	if _, err := buildGraphImportBody("file.graph", "", map[string]any{"confirmImport": true}); err == nil {
+		t.Fatal("expected replace import to require prefix")
+	}
+	if _, err := buildGraphImportBody("file.graph", "", map[string]any{"confirmImport": true, "refStrategy": "reuse"}); err == nil {
+		t.Fatal("expected reuse import to require allowReuseImport")
+	}
+	body, err := buildGraphImportBody("file.graph", "", base)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ops := requireOpsMap(t, body)
+	if ops["actorRefStrategy"] != "replace" || ops["actorRefReplacePrefix"] != "clone_20260724_" {
+		t.Fatalf("unexpected ops: %#v", ops)
+	}
+}
+
+func TestBuildGraphImportBodyStrategiesWithoutPrefix(t *testing.T) {
+	body, err := buildGraphImportBody("file.graph", "", map[string]any{
+		"confirmImport": true,
+		"refStrategy":   "error",
+	})
+	if err != nil {
+		t.Fatalf("refStrategy=error should not require a prefix: %v", err)
+	}
+	ops := requireOpsMap(t, body)
+	if ops["actorRefStrategy"] != "error" {
+		t.Fatalf("expected error strategy, got %#v", ops)
+	}
+	if _, ok := ops["actorRefReplacePrefix"]; ok {
+		t.Fatalf("error strategy should not send replace prefixes: %#v", ops)
+	}
+
+	body, err = buildGraphImportBody("file.graph", "", map[string]any{
+		"confirmImport":    true,
+		"refStrategy":      "reuse",
+		"allowReuseImport": true,
+	})
+	if err != nil {
+		t.Fatalf("refStrategy=reuse with explicit allow should not require a prefix: %v", err)
+	}
+	ops = requireOpsMap(t, body)
+	if ops["actorRefStrategy"] != "reuse" {
+		t.Fatalf("expected reuse strategy, got %#v", ops)
+	}
+	if _, ok := ops["actorRefReplacePrefix"]; ok {
+		t.Fatalf("reuse strategy should not send replace prefixes: %#v", ops)
+	}
+
+	for _, args := range []map[string]any{
+		{"confirmImport": true, "refStrategy": "error", "refReplacePrefix": "clone_20260724_"},
+		{"confirmImport": true, "refStrategy": "reuse", "allowReuseImport": true, "refReplacePrefix": "clone_20260724_"},
+	} {
+		if _, err := buildGraphImportBody("file.graph", "", args); err == nil || !strings.Contains(err.Error(), "only valid with refStrategy=replace") {
+			t.Fatalf("expected non-replace prefix rejection, got %v for %#v", err, args)
+		}
+	}
+}
+
+func requireOpsMap(t *testing.T, body map[string]any) map[string]any {
+	t.Helper()
+	ops, ok := body["ops"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected ops map, got %#v", body["ops"])
+	}
+	return ops
+}
+
+func requireAnySlice(t *testing.T, value any) []any {
+	t.Helper()
+	items := requireAnySliceValue(t, value)
+	if len(items) == 0 {
+		t.Fatalf("expected non-empty []any, got %#v", value)
+	}
+	return items
+}
+
+func requireAnySliceValue(t *testing.T, value any) []any {
+	t.Helper()
+	items, ok := value.([]any)
+	if !ok {
+		t.Fatalf("expected []any, got %#v", value)
+	}
+	return items
+}
+
+func TestGraphTaskListResponseAcceptsLiveArrayShape(t *testing.T) {
+	var resp graphTaskListResponse
+	if err := json.Unmarshal([]byte(`{"data":[{"id":1,"status":"completed","name":"export"}]}`), &resp); err != nil {
+		t.Fatalf("array data shape rejected: %v", err)
+	}
+	if len(resp.Data.Tasks) != 1 || resp.Data.Tasks[0].ID != 1 {
+		t.Fatalf("unexpected array data parse: %#v", resp.Data.Tasks)
+	}
+	if err := json.Unmarshal([]byte(`{"data":{"tasks":[{"id":2,"status":"completed","name":"export"}]}}`), &resp); err != nil {
+		t.Fatalf("object data shape rejected: %v", err)
+	}
+	if len(resp.Data.Tasks) != 1 || resp.Data.Tasks[0].ID != 2 {
+		t.Fatalf("unexpected object data parse: %#v", resp.Data.Tasks)
+	}
+}
+
+func TestGetGraphImportExportTaskByIDUsesDirectEndpoint(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/papi/1.0/tasks/source/export/101":
+			writeJSON(w, `{"data":{"id":101,"status":"completed","name":"export","accId":"source","details":"{\"file\":{\"fileName\":\"bucket/export.graph\",\"title\":\"export.graph\",\"size\":123}}"}}`)
+		case r.URL.Path == "/papi/1.0/tasks/list/source/export":
+			t.Fatalf("taskId lookup must use direct task endpoint before list fallback")
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer srv.Close()
+
+	ecore.Configure(srv.URL+"/papi/1.0", false)
+	ecore.Cfg.Authorization = "Simulator test-token"
+	t.Setenv("ACCESS_TOKEN", "test-token")
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"accId":  "source",
+		"name":   "export",
+		"taskId": 101,
+	}
+	res, err := handleGetGraphImportExportTask(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res == nil || res.IsError {
+		t.Fatalf("expected success, got %#v", res)
+	}
+	text := textResult(t, res)
+	if !strings.Contains(text, `"id":101`) || !strings.Contains(text, `"fileName":"bucket/export.graph"`) {
+		t.Fatalf("unexpected task output: %s", text)
+	}
+}
+
+func TestApplyGraphSourceURLSelection(t *testing.T) {
+	const (
+		sourceAccID = "11111111-2222-4333-8444-555555555555"
+		graphID     = "33333333-3333-4333-8333-333333333333"
+		layerID     = "22222222-2222-4222-8222-222222222222"
+	)
+	ctx := apiclient.WithWorkspaceID(context.Background(), sourceAccID)
+	args := map[string]any{
+		"sourceUrl": "https://mw.simulator.company/actors_graph/11111111/graph/" + graphID + "/layers/" + layerID,
+	}
+	info, err := applyGraphSourceURL(ctx, args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info.SourceKind != "layer" || info.GraphID != graphID || info.LayerID != layerID {
+		t.Fatalf("unexpected source info: %#v", info)
+	}
+	if got := args["sourceAccId"]; got != sourceAccID {
+		t.Fatalf("short workspace segment should resolve to current full workspace, got %#v", got)
+	}
+	if info.WorkspaceID != sourceAccID {
+		t.Fatalf("source info should keep the resolved full workspace id, got %#v", info.WorkspaceID)
+	}
+	if got := requireAnySlice(t, args["actorIds"])[0]; got != layerID {
+		t.Fatalf("auto mode should select layer from layer URL, got %#v", args["actorIds"])
+	}
+
+	args = map[string]any{
+		"sourceUrl":  "https://mw.simulator.company/actors_graph/" + sourceAccID + "/graph/" + graphID + "/layers/" + layerID,
+		"sourceKind": "graph",
+	}
+	info, err = applyGraphSourceURL(ctx, args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info.SourceKind != "graph" {
+		t.Fatalf("sourceKind=graph was not preserved: %#v", info)
+	}
+	if got := requireAnySlice(t, args["actorIds"])[0]; got != graphID {
+		t.Fatalf("graph mode should select graph root, got %#v", args["actorIds"])
+	}
+}
+
+func TestReadLocalGraphArchiveRejectsUnsafeFiles(t *testing.T) {
+	if _, _, err := readLocalGraphArchive("relative.graph"); err == nil || !strings.Contains(err.Error(), "absolute") {
+		t.Fatalf("expected absolute path error, got %v", err)
+	}
+	tmp := t.TempDir()
+	txt := tmp + "/secret.txt"
+	if err := osWriteFile(txt, []byte("secret")); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := readLocalGraphArchive(txt); err == nil || !strings.Contains(err.Error(), ".graph") {
+		t.Fatalf("expected .graph extension error, got %v", err)
+	}
+}
+
+func TestValidateGraphArchiveBytes(t *testing.T) {
+	if err := validateGraphArchiveBytes([]byte("not zip")); err == nil {
+		t.Fatal("expected invalid zip error")
+	}
+	if err := validateGraphArchiveBytes(makeGraphArchive(t, false, true, false)); err == nil || !strings.Contains(err.Error(), "GraphManifest") {
+		t.Fatalf("expected missing manifest error, got %v", err)
+	}
+	if err := validateGraphArchiveBytes(makeGraphArchive(t, true, false, false)); err == nil || !strings.Contains(err.Error(), "actor or form") {
+		t.Fatalf("expected missing actor/form error, got %v", err)
+	}
+	if err := validateGraphArchiveBytes(makeGraphArchive(t, true, true, true)); err != nil {
+		t.Fatalf("valid archive rejected: %v", err)
+	}
+}
+
+func TestCloneGraphLayerHappyPath(t *testing.T) { //nolint:gocyclo // One httptest flow documents the export/download/upload/import sequence.
+	const (
+		sourceLayerID = "11111111-1111-4111-8111-111111111111"
+		targetLayerID = "22222222-2222-4222-8222-222222222222"
+	)
+	graphBytes := makeGraphArchiveWithActors(t, map[string]string{
+		sourceLayerID: "id: " + sourceLayerID + "\nformId: 200\nref: layer_ref\ntitle: Layer\n",
+	})
+	var exportBody, importBody map[string]any
+	var uploaded bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/papi/1.0/tasks/source/export":
+			if err := json.NewDecoder(r.Body).Decode(&exportBody); err != nil {
+				t.Fatalf("decode export body: %v", err)
+			}
+			writeJSON(w, `{"data":{"id":101,"status":"created","name":"export","accId":"source"}}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/papi/1.0/tasks/source/export/101":
+			writeJSON(w, `{"data":{"id":101,"status":"completed","name":"export","accId":"source","details":"{\"file\":{\"fileName\":\"bucket/export.graph\",\"title\":\"export.graph\",\"size\":123},\"manifest\":{\"stats\":{\"counters\":{\"actors\":1,\"forms\":1,\"edges\":0}}}}"}}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/papi/1.0/tasks/list/source/export":
+			writeJSON(w, `{"data":[{"id":101,"status":"completed","name":"export","accId":"source","details":"{\"file\":{\"fileName\":\"bucket/export.graph\",\"title\":\"export.graph\",\"size\":123},\"manifest\":{\"stats\":{\"counters\":{\"actors\":1,\"forms\":1,\"edges\":0}}}}"}]}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/papi/1.0/download/bucket/export.graph":
+			_, _ = w.Write(graphBytes)
+		case r.Method == http.MethodPost && r.URL.Path == "/papi/1.0/upload/target":
+			if !strings.HasPrefix(r.Header.Get("Content-Type"), "multipart/form-data") {
+				t.Fatalf("expected multipart upload, got %q", r.Header.Get("Content-Type"))
+			}
+			if _, err := io.Copy(io.Discard, r.Body); err != nil {
+				t.Fatalf("read upload: %v", err)
+			}
+			uploaded = true
+			writeJSON(w, `{"data":{"id":201,"fileName":"bucket/import.graph","title":"import.graph","size":123,"type":"application/octet-stream"}}`)
+		case r.Method == http.MethodPost && r.URL.Path == "/papi/1.0/tasks/target/import":
+			if err := json.NewDecoder(r.Body).Decode(&importBody); err != nil {
+				t.Fatalf("decode import body: %v", err)
+			}
+			writeJSON(w, `{"data":{"id":301,"status":"created","name":"import","accId":"target"}}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/papi/1.0/tasks/target/import/301":
+			writeJSON(w, `{"data":{"id":301,"status":"completed","name":"import","accId":"target","details":"{\"manifest\":{\"stats\":{\"counters\":{\"actors\":1,\"forms\":1,\"edges\":0}}}}"}}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/papi/1.0/tasks/list/target/import":
+			writeJSON(w, `{"data":[{"id":301,"status":"completed","name":"import","accId":"target","details":"{\"manifest\":{\"stats\":{\"counters\":{\"actors\":1,\"forms\":1,\"edges\":0}}}}"}]}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/papi/1.0/actors/ref/200/clone_20260724_layer_ref":
+			writeJSON(w, `{"data":{"id":"`+targetLayerID+`","formId":200,"ref":"clone_20260724_layer_ref","title":"Layer"}}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer srv.Close()
+
+	ecore.Configure(srv.URL+"/papi/1.0", false)
+	ecore.Cfg.Authorization = "Simulator test-token"
+	t.Setenv("ACCESS_TOKEN", "test-token")
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"layerId":          sourceLayerID,
+		"sourceAccId":      "source",
+		"targetAccId":      "target",
+		"refReplacePrefix": "clone_20260724_",
+		"confirmClone":     true,
+		"users":            true,
+		"waitSec":          1,
+	}
+	res, err := handleCloneGraphLayer(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res == nil || res.IsError {
+		t.Fatalf("expected success, got %#v", res)
+	}
+	if !uploaded {
+		t.Fatal("expected graph archive upload")
+	}
+	if got := requireAnySlice(t, exportBody["actors"])[0]; got != sourceLayerID {
+		t.Fatalf("export actor mismatch: %#v", exportBody)
+	}
+	exportOps := requireOpsMap(t, exportBody)
+	if exportOps["users"] != true {
+		t.Fatalf("export users flag was not preserved: %#v", exportOps)
+	}
+	if exportOps["balances"] != false || exportOps["connectorsToAccounts"] != false || exportOps["accountToActors"] != false {
+		t.Fatalf("export relation flags must be mirrored inside ops for live backend schema: %#v", exportOps)
+	}
+	ops := requireOpsMap(t, importBody)
+	if ops["actorRefStrategy"] != "replace" || ops["actorRefReplacePrefix"] != "clone_20260724_" {
+		t.Fatalf("unexpected import ops: %#v", ops)
+	}
+	if users := requireAnySliceValue(t, importBody["users"]); len(users) != 0 {
+		t.Fatalf("export users flag leaked into import mappings: %#v", users)
+	}
+	text := textResult(t, res)
+	if !strings.Contains(text, `"exportTask"`) || !strings.Contains(text, `"importTask"`) {
+		t.Fatalf("unexpected result: %s", text)
+	}
+	if !strings.Contains(text, `"countersMatch":true`) {
+		t.Fatalf("expected matching counters in result, got %s", text)
+	}
+}
+
+func TestCloneGraphLayerReuseStrategyAllowsNoPrefix(t *testing.T) {
+	graphBytes := makeGraphArchive(t, true, true, true)
+	var importBody map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/papi/1.0/tasks/source/export":
+			writeJSON(w, `{"data":{"id":101,"status":"created","name":"export","accId":"source"}}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/papi/1.0/tasks/source/export/101":
+			writeJSON(w, `{"data":{"id":101,"status":"completed","name":"export","accId":"source","details":"{\"file\":{\"fileName\":\"bucket/export.graph\",\"title\":\"export.graph\",\"size\":123},\"manifest\":{\"stats\":{\"counters\":{\"actors\":1,\"forms\":1,\"edges\":0}}}}"}}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/papi/1.0/download/bucket/export.graph":
+			_, _ = w.Write(graphBytes)
+		case r.Method == http.MethodPost && r.URL.Path == "/papi/1.0/upload/target":
+			if _, err := io.Copy(io.Discard, r.Body); err != nil {
+				t.Fatalf("read upload: %v", err)
+			}
+			writeJSON(w, `{"data":{"id":201,"fileName":"bucket/import.graph","title":"import.graph","size":123,"type":"application/octet-stream"}}`)
+		case r.Method == http.MethodPost && r.URL.Path == "/papi/1.0/tasks/target/import":
+			if err := json.NewDecoder(r.Body).Decode(&importBody); err != nil {
+				t.Fatalf("decode import body: %v", err)
+			}
+			writeJSON(w, `{"data":{"id":301,"status":"created","name":"import","accId":"target"}}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/papi/1.0/tasks/target/import/301":
+			writeJSON(w, `{"data":{"id":301,"status":"completed","name":"import","accId":"target","details":"{\"manifest\":{\"stats\":{\"counters\":{\"actors\":1,\"forms\":1,\"edges\":0}}}}"}}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer srv.Close()
+
+	ecore.Configure(srv.URL+"/papi/1.0", false)
+	ecore.Cfg.Authorization = "Simulator test-token"
+	t.Setenv("ACCESS_TOKEN", "test-token")
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"layerId":          "11111111-1111-4111-8111-111111111111",
+		"sourceAccId":      "source",
+		"targetAccId":      "target",
+		"refStrategy":      "reuse",
+		"allowReuseImport": true,
+		"confirmClone":     true,
+		"waitSec":          1,
+	}
+	res, err := handleCloneGraphLayer(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res == nil || res.IsError {
+		t.Fatalf("expected success, got %#v", res)
+	}
+	ops := requireOpsMap(t, importBody)
+	if ops["actorRefStrategy"] != "reuse" || ops["formRefStrategy"] != "reuse" {
+		t.Fatalf("unexpected import ops: %#v", ops)
+	}
+	if _, ok := ops["actorRefReplacePrefix"]; ok {
+		t.Fatalf("reuse strategy must not send replace prefixes: %#v", ops)
+	}
+	text := textResult(t, res)
+	if !strings.Contains(text, `"importRefStrategy":"reuse"`) {
+		t.Fatalf("expected reuse strategy in result, got %s", text)
+	}
+}
+
+func TestCloneGraphObjectsDefaultsTargetToCurrentWorkspace(t *testing.T) {
+	graphBytes := makeGraphArchive(t, true, true, true)
+	var exportBody, importBody map[string]any
+	uploadedToCurrent := false
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/papi/1.0/tasks/current/export":
+			if err := json.NewDecoder(r.Body).Decode(&exportBody); err != nil {
+				t.Fatalf("decode export body: %v", err)
+			}
+			writeJSON(w, `{"data":{"id":111,"status":"created","name":"export","accId":"current"}}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/papi/1.0/tasks/current/export/111":
+			writeJSON(w, `{"data":{"id":111,"status":"completed","name":"export","accId":"current","details":"{\"file\":{\"fileName\":\"bucket/graph.graph\",\"title\":\"graph.graph\",\"size\":123},\"manifest\":{\"stats\":{\"counters\":{\"actors\":2,\"forms\":1,\"edges\":1}}}}"}}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/papi/1.0/tasks/list/current/export":
+			writeJSON(w, `{"data":[{"id":111,"status":"completed","name":"export","accId":"current","details":"{\"file\":{\"fileName\":\"bucket/graph.graph\",\"title\":\"graph.graph\",\"size\":123},\"manifest\":{\"stats\":{\"counters\":{\"actors\":2,\"forms\":1,\"edges\":1}}}}"}]}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/papi/1.0/download/bucket/graph.graph":
+			_, _ = w.Write(graphBytes)
+		case r.Method == http.MethodPost && r.URL.Path == "/papi/1.0/upload/current":
+			uploadedToCurrent = true
+			if _, err := io.Copy(io.Discard, r.Body); err != nil {
+				t.Fatalf("read upload: %v", err)
+			}
+			writeJSON(w, `{"data":{"id":222,"fileName":"bucket/import.graph","title":"import.graph","size":123,"type":"application/octet-stream"}}`)
+		case r.Method == http.MethodPost && r.URL.Path == "/papi/1.0/tasks/current/import":
+			if err := json.NewDecoder(r.Body).Decode(&importBody); err != nil {
+				t.Fatalf("decode import body: %v", err)
+			}
+			writeJSON(w, `{"data":{"id":333,"status":"created","name":"import","accId":"current"}}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/papi/1.0/tasks/current/import/333":
+			writeJSON(w, `{"data":{"id":333,"status":"completed","name":"import","accId":"current","details":"{\"manifest\":{\"stats\":{\"counters\":{\"actors\":2,\"forms\":1,\"edges\":1}}}}"}}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/papi/1.0/tasks/list/current/import":
+			writeJSON(w, `{"data":[{"id":333,"status":"completed","name":"import","accId":"current","details":"{\"manifest\":{\"stats\":{\"counters\":{\"actors\":2,\"forms\":1,\"edges\":1}}}}"}]}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer srv.Close()
+
+	ecore.Configure(srv.URL+"/papi/1.0", false)
+	ecore.Cfg.Authorization = "Simulator test-token"
+	t.Setenv("ACCESS_TOKEN", "test-token")
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"actorIds":         []any{"22222222-2222-4222-8222-222222222222"},
+		"refReplacePrefix": "clone_20260724_",
+		"confirmClone":     true,
+		"waitSec":          1,
+	}
+	ctx := apiclient.WithWorkspaceID(context.Background(), "current")
+	res, err := handleCloneGraphObjects(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res == nil || res.IsError {
+		t.Fatalf("expected success, got %#v", res)
+	}
+	if !uploadedToCurrent {
+		t.Fatal("expected upload into current workspace")
+	}
+	if got := requireAnySlice(t, exportBody["actors"])[0]; got != "22222222-2222-4222-8222-222222222222" {
+		t.Fatalf("export actor mismatch: %#v", exportBody)
+	}
+	ops := requireOpsMap(t, importBody)
+	if ops["actorRefReplacePrefix"] != "clone_20260724_" {
+		t.Fatalf("unexpected import ops: %#v", ops)
+	}
+	text := textResult(t, res)
+	if !strings.Contains(text, `"sourceAccId":"current"`) || !strings.Contains(text, `"targetAccId":"current"`) {
+		t.Fatalf("expected source/target to default to current workspace, got %s", text)
+	}
+	if !strings.Contains(text, `"countersMatch":true`) {
+		t.Fatalf("expected matching counters in result, got %s", text)
+	}
+	if !strings.Contains(text, "target workspace is the same as the source workspace") {
+		t.Fatalf("expected same-workspace warning, got %s", text)
+	}
+}
+
+func TestCloneGraphObjectsFromURLReturnsTargetLayerURL(t *testing.T) { //nolint:gocyclo // One httptest flow documents URL clone plus target resolution.
+	const (
+		sourceAccID = "11111111-2222-4333-8444-555555555555"
+		graphID     = "33333333-3333-4333-8333-333333333333"
+		layerID     = "22222222-2222-4222-8222-222222222222"
+		targetAccID = "target"
+		newGraphID  = "44444444-4444-4444-8444-444444444444"
+		newLayerID  = "55555555-5555-4555-8555-555555555555"
+	)
+	graphBytes := makeGraphArchiveWithActors(t, map[string]string{
+		graphID: "id: " + graphID + "\nformId: 100\nref: graph_ref\ntitle: Graph\n",
+		layerID: "id: " + layerID + "\nformId: 200\nref: layer_ref\ntitle: Layer\n",
+	})
+	var exportBody map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/papi/1.0/tasks/"+sourceAccID+"/export":
+			if err := json.NewDecoder(r.Body).Decode(&exportBody); err != nil {
+				t.Fatalf("decode export body: %v", err)
+			}
+			writeJSON(w, `{"data":{"id":111,"status":"created","name":"export","accId":"`+sourceAccID+`"}}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/papi/1.0/tasks/"+sourceAccID+"/export/111":
+			writeJSON(w, `{"data":{"id":111,"status":"completed","name":"export","accId":"`+sourceAccID+`","details":"{\"file\":{\"fileName\":\"bucket/source.graph\",\"title\":\"source.graph\",\"size\":123},\"manifest\":{\"stats\":{\"counters\":{\"actors\":2,\"forms\":1,\"edges\":1}}}}"}}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/papi/1.0/tasks/list/"+sourceAccID+"/export":
+			writeJSON(w, `{"data":[{"id":111,"status":"completed","name":"export","accId":"`+sourceAccID+`","details":"{\"file\":{\"fileName\":\"bucket/source.graph\",\"title\":\"source.graph\",\"size\":123},\"manifest\":{\"stats\":{\"counters\":{\"actors\":2,\"forms\":1,\"edges\":1}}}}"}]}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/papi/1.0/download/bucket/source.graph":
+			_, _ = w.Write(graphBytes)
+		case r.Method == http.MethodPost && r.URL.Path == "/papi/1.0/upload/"+targetAccID:
+			if _, err := io.Copy(io.Discard, r.Body); err != nil {
+				t.Fatalf("read upload: %v", err)
+			}
+			writeJSON(w, `{"data":{"id":222,"fileName":"bucket/import.graph","title":"import.graph","size":123,"type":"application/octet-stream"}}`)
+		case r.Method == http.MethodPost && r.URL.Path == "/papi/1.0/tasks/"+targetAccID+"/import":
+			writeJSON(w, `{"data":{"id":333,"status":"created","name":"import","accId":"`+targetAccID+`"}}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/papi/1.0/tasks/"+targetAccID+"/import/333":
+			writeJSON(w, `{"data":{"id":333,"status":"completed","name":"import","accId":"`+targetAccID+`","details":"{\"manifest\":{\"stats\":{\"counters\":{\"actors\":2,\"forms\":1,\"edges\":1}}}}"}}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/papi/1.0/tasks/list/"+targetAccID+"/import":
+			writeJSON(w, `{"data":[{"id":333,"status":"completed","name":"import","accId":"`+targetAccID+`","details":"{\"manifest\":{\"stats\":{\"counters\":{\"actors\":2,\"forms\":1,\"edges\":1}}}}"}]}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/papi/1.0/actors/ref/100/clone_20260724_graph_ref":
+			writeJSON(w, `{"data":{"id":"`+newGraphID+`","formId":100,"ref":"clone_20260724_graph_ref","title":"Graph"}}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/papi/1.0/actors/ref/200/clone_20260724_layer_ref":
+			writeJSON(w, `{"data":{"id":"`+newLayerID+`","formId":200,"ref":"clone_20260724_layer_ref","title":"Layer"}}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer srv.Close()
+
+	ecore.Configure(srv.URL+"/papi/1.0", false)
+	ecore.Cfg.Authorization = "Simulator test-token"
+	t.Setenv("ACCESS_TOKEN", "test-token")
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"sourceUrl":        "https://mw.simulator.company/actors_graph/11111111/graph/" + graphID + "/layers/" + layerID,
+		"targetAccId":      targetAccID,
+		"refReplacePrefix": "clone_20260724_",
+		"confirmClone":     true,
+		"waitSec":          1,
+	}
+	ctx := apiclient.WithWorkspaceID(context.Background(), sourceAccID)
+	ctx = apiclient.WithBaseURL(ctx, srv.URL+"/papi/1.0")
+	res, err := handleCloneGraphObjects(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res == nil || res.IsError {
+		t.Fatalf("expected success, got %#v", res)
+	}
+	if got := requireAnySlice(t, exportBody["actors"])[0]; got != layerID {
+		t.Fatalf("expected sourceUrl auto mode to clone layer, got export body %#v", exportBody)
+	}
+	text := textResult(t, res)
+	if !strings.Contains(text, `"sourceGraphId":"`+graphID+`"`) || !strings.Contains(text, `"sourceLayerId":"`+layerID+`"`) {
+		t.Fatalf("expected source URL metadata, got %s", text)
+	}
+	if !strings.Contains(text, `"graphId":"`+newGraphID+`"`) || !strings.Contains(text, `"layerId":"`+newLayerID+`"`) {
+		t.Fatalf("expected resolved target graph/layer ids, got %s", text)
+	}
+	wantURL := srv.URL + "/actors_graph/target/graph/" + newGraphID + "/layers/" + newLayerID
+	if !strings.Contains(text, `"url":"`+wantURL+`"`) {
+		t.Fatalf("expected target URL %s, got %s", wantURL, text)
+	}
+}
+
+func TestCloneGraphObjectsFromURLResolvesRefLessLayerByRecentTitle(t *testing.T) {
+	const (
+		sourceAccID = "11111111-2222-4333-8444-555555555555"
+		graphID     = "33333333-3333-4333-8333-333333333333"
+		layerID     = "22222222-2222-4222-8222-222222222222"
+		targetAccID = "target"
+		newLayerID  = "55555555-5555-4555-8555-555555555555"
+		layerTitle  = "Layer Without Ref Long Fixture"
+	)
+	graphBytes := makeGraphArchiveWithActors(t, map[string]string{
+		layerID: "id: " + layerID + "\ntitle: " + layerTitle + "\n",
+	})
+	searchCalls := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/papi/1.0/tasks/"+sourceAccID+"/export":
+			writeJSON(w, `{"data":{"id":111,"status":"created","name":"export","accId":"`+sourceAccID+`"}}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/papi/1.0/tasks/"+sourceAccID+"/export/111":
+			writeJSON(w, `{"data":{"id":111,"status":"completed","name":"export","accId":"`+sourceAccID+`","details":"{\"file\":{\"fileName\":\"bucket/source.graph\",\"title\":\"source.graph\",\"size\":123},\"manifest\":{\"stats\":{\"counters\":{\"actors\":1,\"forms\":1,\"edges\":0}}}}"}}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/papi/1.0/download/bucket/source.graph":
+			_, _ = w.Write(graphBytes)
+		case r.Method == http.MethodPost && r.URL.Path == "/papi/1.0/upload/"+targetAccID:
+			if _, err := io.Copy(io.Discard, r.Body); err != nil {
+				t.Fatalf("read upload: %v", err)
+			}
+			writeJSON(w, `{"data":{"id":222,"fileName":"bucket/import.graph","title":"import.graph","size":123,"type":"application/octet-stream"}}`)
+		case r.Method == http.MethodPost && r.URL.Path == "/papi/1.0/tasks/"+targetAccID+"/import":
+			writeJSON(w, `{"data":{"id":333,"status":"created","name":"import","accId":"`+targetAccID+`"}}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/papi/1.0/tasks/"+targetAccID+"/import/333":
+			writeJSON(w, `{"data":{"id":333,"status":"completed","name":"import","accId":"`+targetAccID+`","createdAt":2000,"timeStart":2001,"details":"{\"manifest\":{\"stats\":{\"counters\":{\"actors\":1,\"forms\":1,\"edges\":0}}}}"}}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/papi/1.0/actors/"+layerID:
+			writeJSON(w, `{"data":{"id":"`+layerID+`","title":"`+layerTitle+`","formId":26741,"createdAt":1000}}`)
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/papi/1.0/actors_filters/search/"+targetAccID+"/"):
+			if r.URL.Query().Get("formId") != "26741" {
+				t.Fatalf("expected formId search narrowing, got query %s", r.URL.RawQuery)
+			}
+			searchCalls++
+			decodedPath, _ := url.PathUnescape(r.URL.EscapedPath())
+			if strings.Contains(decodedPath, layerTitle) {
+				writeJSON(w, `{"data":{"list":[],"total":0}}`)
+				return
+			}
+			writeJSON(w, `{"data":{"list":[{"id":"`+layerID+`","title":"`+layerTitle+`","formId":26741,"createdAt":1000},{"id":"`+newLayerID+`","title":"`+layerTitle+`","formId":26741,"createdAt":2001}],"total":2}}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer srv.Close()
+
+	ecore.Configure(srv.URL+"/papi/1.0", false)
+	ecore.Cfg.Authorization = "Simulator test-token"
+	t.Setenv("ACCESS_TOKEN", "test-token")
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"sourceUrl":        "https://mw.simulator.company/actors_graph/11111111/graph/" + graphID + "/layers/" + layerID,
+		"targetAccId":      targetAccID,
+		"refReplacePrefix": "clone_20260724_",
+		"confirmClone":     true,
+		"waitSec":          1,
+	}
+	ctx := apiclient.WithWorkspaceID(context.Background(), sourceAccID)
+	ctx = apiclient.WithBaseURL(ctx, srv.URL+"/papi/1.0")
+	res, err := handleCloneGraphObjects(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res == nil || res.IsError {
+		t.Fatalf("expected success, got %#v", res)
+	}
+	if searchCalls != 2 {
+		t.Fatalf("expected exact search plus shortened fallback search, got %d calls", searchCalls)
+	}
+	text := textResult(t, res)
+	if !strings.Contains(text, `"layerId":"`+newLayerID+`"`) {
+		t.Fatalf("expected target layer id resolved by fallback, got %s", text)
+	}
+	wantURL := srv.URL + "/actors_graph/target/graph/" + newLayerID + "/layers"
+	if !strings.Contains(text, `"url":"`+wantURL+`"`) {
+		t.Fatalf("expected target URL %s, got %s", wantURL, text)
+	}
+	if !strings.Contains(text, "resolved by title/formId fallback") {
+		t.Fatalf("expected fallback warning, got %s", text)
+	}
+	if strings.Contains(text, "source actor metadata was not present in the export archive") {
+		t.Fatalf("layer clone must not warn about optional graph root metadata, got %s", text)
+	}
+}
+
+func TestImportGraphArchiveRequiresConfirmBeforeLocalUpload(t *testing.T) {
+	tmp := t.TempDir()
+	archivePath := tmp + "/sample.graph"
+	if err := os.WriteFile(archivePath, makeGraphArchive(t, true, true, true), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		t.Fatalf("import without confirm must not call backend, got %s %s", r.Method, r.URL.String())
+	}))
+	defer srv.Close()
+
+	ecore.Configure(srv.URL+"/papi/1.0", false)
+	ecore.Cfg.Authorization = "Simulator test-token"
+	t.Setenv("ACCESS_TOKEN", "test-token")
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"accId":            "target",
+		"localPath":        archivePath,
+		"refReplacePrefix": "clone_20260724_",
+	}
+	res, err := handleImportGraphArchive(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res == nil || !res.IsError {
+		t.Fatalf("expected confirm error, got %#v", res)
+	}
+	if !strings.Contains(textResult(t, res), "confirmImport") {
+		t.Fatalf("expected confirmImport error, got %s", textResult(t, res))
+	}
+}
+
+func TestCloneGraphLayerReportsFailedExport(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/papi/1.0/tasks/source/export":
+			writeJSON(w, `{"data":{"id":101,"status":"created","name":"export","accId":"source"}}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/papi/1.0/tasks/source/export/101":
+			writeJSON(w, `{"data":{"id":101,"status":"failed","name":"export","accId":"source","details":"{\"error\":true,\"errMsg\":\"Failed to get Actor\"}"}}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/papi/1.0/tasks/list/source/export":
+			writeJSON(w, `{"data":[{"id":101,"status":"failed","name":"export","accId":"source","details":"{\"error\":true,\"errMsg\":\"Failed to get Actor\"}"}]}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer srv.Close()
+
+	ecore.Configure(srv.URL+"/papi/1.0", false)
+	ecore.Cfg.Authorization = "Simulator test-token"
+	t.Setenv("ACCESS_TOKEN", "test-token")
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"layerId":          "11111111-1111-4111-8111-111111111111",
+		"sourceAccId":      "source",
+		"refReplacePrefix": "clone_20260724_",
+		"confirmClone":     true,
+		"waitSec":          1,
+	}
+	res, err := handleCloneGraphLayer(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res == nil || !res.IsError {
+		t.Fatalf("expected error result, got %#v", res)
+	}
+	if !strings.Contains(textResult(t, res), "Failed to get Actor") {
+		t.Fatalf("expected export error details, got %s", textResult(t, res))
+	}
+}
+
+func TestCloneGraphLayerReportsAccessDeniedExportHint(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/papi/1.0/tasks/source/export":
+			writeJSON(w, `{"data":{"id":101,"status":"created","name":"export","accId":"source"}}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/papi/1.0/tasks/source/export/101":
+			writeJSON(w, `{"data":{"id":101,"status":"failed","name":"export","accId":"source","details":"{\"error\":true,\"errMsg\":\"Access denied to actor on layer\"}"}}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/papi/1.0/tasks/list/source/export":
+			writeJSON(w, `{"data":[{"id":101,"status":"failed","name":"export","accId":"source","details":"{\"error\":true,\"errMsg\":\"Access denied to actor on layer\"}"}]}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer srv.Close()
+
+	ecore.Configure(srv.URL+"/papi/1.0", false)
+	ecore.Cfg.Authorization = "Simulator test-token"
+	t.Setenv("ACCESS_TOKEN", "test-token")
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"layerId":          "11111111-1111-4111-8111-111111111111",
+		"sourceAccId":      "source",
+		"refReplacePrefix": "clone_20260724_",
+		"confirmClone":     true,
+		"waitSec":          1,
+	}
+	res, err := handleCloneGraphLayer(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res == nil || !res.IsError {
+		t.Fatalf("expected error result, got %#v", res)
+	}
+	text := textResult(t, res)
+	if !strings.Contains(text, "Access denied to actor on layer") {
+		t.Fatalf("expected export error details, got %s", text)
+	}
+	if !strings.Contains(text, "Export requires access to every object") {
+		t.Fatalf("expected access failure hint, got %s", text)
+	}
+}
+
+func TestCloneGraphObjectsReportsFailedImport(t *testing.T) {
+	graphBytes := makeGraphArchive(t, true, true, true)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/papi/1.0/tasks/source/export":
+			writeJSON(w, `{"data":{"id":101,"status":"created","name":"export","accId":"source"}}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/papi/1.0/tasks/source/export/101":
+			writeJSON(w, `{"data":{"id":101,"status":"completed","name":"export","accId":"source","details":"{\"file\":{\"fileName\":\"bucket/export.graph\",\"title\":\"export.graph\",\"size\":123},\"manifest\":{\"stats\":{\"counters\":{\"actors\":1,\"forms\":1,\"edges\":0}}}}"}}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/papi/1.0/tasks/list/source/export":
+			writeJSON(w, `{"data":[{"id":101,"status":"completed","name":"export","accId":"source","details":"{\"file\":{\"fileName\":\"bucket/export.graph\",\"title\":\"export.graph\",\"size\":123},\"manifest\":{\"stats\":{\"counters\":{\"actors\":1,\"forms\":1,\"edges\":0}}}}"}]}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/papi/1.0/download/bucket/export.graph":
+			_, _ = w.Write(graphBytes)
+		case r.Method == http.MethodPost && r.URL.Path == "/papi/1.0/upload/target":
+			if _, err := io.Copy(io.Discard, r.Body); err != nil {
+				t.Fatalf("read upload: %v", err)
+			}
+			writeJSON(w, `{"data":{"id":201,"fileName":"bucket/import.graph","title":"import.graph","size":123,"type":"application/octet-stream"}}`)
+		case r.Method == http.MethodPost && r.URL.Path == "/papi/1.0/tasks/target/import":
+			writeJSON(w, `{"data":{"id":301,"status":"created","name":"import","accId":"target"}}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/papi/1.0/tasks/target/import/301":
+			writeJSON(w, `{"data":{"id":301,"status":"failed","name":"import","accId":"target","details":"{\"error\":true,\"errMsg\":\"Not unique cell id\"}"}}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/papi/1.0/tasks/list/target/import":
+			writeJSON(w, `{"data":[{"id":301,"status":"failed","name":"import","accId":"target","details":"{\"error\":true,\"errMsg\":\"Not unique cell id\"}"}]}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer srv.Close()
+
+	ecore.Configure(srv.URL+"/papi/1.0", false)
+	ecore.Cfg.Authorization = "Simulator test-token"
+	t.Setenv("ACCESS_TOKEN", "test-token")
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"actorIds":         []any{"22222222-2222-4222-8222-222222222222"},
+		"sourceAccId":      "source",
+		"targetAccId":      "target",
+		"refReplacePrefix": "clone_20260724_",
+		"confirmClone":     true,
+		"waitSec":          1,
+	}
+	res, err := handleCloneGraphObjects(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res == nil || !res.IsError {
+		t.Fatalf("expected error result, got %#v", res)
+	}
+	if !strings.Contains(textResult(t, res), "Not unique cell id") {
+		t.Fatalf("expected import error details, got %s", textResult(t, res))
+	}
+}
+
+func makeGraphArchive(t *testing.T, manifest, actor, form bool) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	add := func(name, body string) {
+		t.Helper()
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := w.Write([]byte(body)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if manifest {
+		add("GraphManifest.yaml", "version: 1.0.0\nstats:\n  counters:\n    actors: 1\n")
+	}
+	if actor {
+		add("topology/actors/11111111-1111-4111-8111-111111111111.yaml", "id: 11111111-1111-4111-8111-111111111111\n")
+	}
+	if form {
+		add("forms/123.yaml", "id: 123\n")
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func makeGraphArchiveWithActors(t *testing.T, actors map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	add := func(name, body string) {
+		t.Helper()
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := w.Write([]byte(body)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	add("GraphManifest.yaml", "version: 1.0.0\nstats:\n  counters:\n    actors: 2\n")
+	add("forms/100.yaml", "id: 100\n")
+	for id, body := range actors {
+		add("topology/actors/"+id+".yaml", body)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func writeJSON(w http.ResponseWriter, body string) {
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write([]byte(body))
+}
+
+func textResult(t *testing.T, res *mcp.CallToolResult) string {
+	t.Helper()
+	if res == nil || len(res.Content) == 0 {
+		t.Fatal("empty result")
+	}
+	tc, ok := res.Content[0].(mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected text result, got %T", res.Content[0])
+	}
+	return tc.Text
+}
+
+func osWriteFile(name string, data []byte) error {
+	return os.WriteFile(name, data, 0o600)
+}

--- a/plugins/simulator/mcp-server/internal/engines/graph/live_smoke_test.go
+++ b/plugins/simulator/mcp-server/internal/engines/graph/live_smoke_test.go
@@ -1,0 +1,109 @@
+//go:build live_smoke
+
+package graph
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/internal/engines/ecore"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestLiveCloneGraphObjectsByURL(t *testing.T) {
+	if os.Getenv("LIVE_SIMULATOR_CLONE") != "1" {
+		t.Skip("set LIVE_SIMULATOR_CLONE=1 to run the live clone smoke test")
+	}
+	// This is intentionally opt-in: it creates imported graph objects in the
+	// configured workspace. Run it only against a disposable/test workspace.
+	workDir := os.Getenv("SIMULATOR_WORK_DIR")
+	if workDir == "" {
+		t.Fatal("SIMULATOR_WORK_DIR is required")
+	}
+	loadLiveDotEnv(t, filepath.Join(workDir, ".env"))
+
+	sourceURL := os.Getenv("LIVE_SIMULATOR_SOURCE_URL")
+	if sourceURL == "" {
+		t.Fatal("LIVE_SIMULATOR_SOURCE_URL is required")
+	}
+	baseURL := os.Getenv("SIMULATOR_API_BASE_URL")
+	workspaceID := os.Getenv("WORKSPACE_ID")
+	if baseURL == "" || workspaceID == "" || os.Getenv("ACCESS_TOKEN") == "" {
+		t.Fatal("SIMULATOR_API_BASE_URL, WORKSPACE_ID and ACCESS_TOKEN must be set")
+	}
+
+	ecore.Configure(baseURL, false)
+	ecore.ResetAuth()
+
+	prefix := "codex_clone_" + time.Now().UTC().Format("20060102_150405") + "_"
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"sourceUrl":        sourceURL,
+		"refReplacePrefix": prefix,
+		"confirmClone":     true,
+		"waitSec":          360,
+	}
+	res, err := handleCloneGraphObjects(context.Background(), req)
+	if err != nil {
+		t.Fatalf("cloneGraphObjects returned error: %v", err)
+	}
+	if res == nil {
+		t.Fatal("cloneGraphObjects returned nil result")
+	}
+	text := textResult(t, res)
+	t.Logf("clone result: %s", text)
+	if res.IsError {
+		t.Fatalf("cloneGraphObjects returned tool error: %s", text)
+	}
+
+	var out map[string]any
+	if err := json.Unmarshal([]byte(text), &out); err != nil {
+		t.Fatalf("parse clone result: %v", err)
+	}
+	if out["sourceAccId"] != workspaceID || out["targetAccId"] != workspaceID {
+		t.Fatalf("expected source and target to default to current workspace %s, got source=%v target=%v", workspaceID, out["sourceAccId"], out["targetAccId"])
+	}
+	if out["sourceKind"] != "layer" {
+		t.Fatalf("expected URL auto-selection to choose layer, got sourceKind=%v", out["sourceKind"])
+	}
+	if out["countersMatch"] != true {
+		t.Fatalf("expected export/import counters to match, got %v", out["countersMatch"])
+	}
+	target, _ := out["target"].(map[string]any)
+	targetURL, _ := target["url"].(string)
+	if targetURL == "" {
+		t.Fatalf("expected target.url, got target=%v warnings=%v", target, out["warnings"])
+	}
+	if !strings.Contains(targetURL, "/actors_graph/") || !strings.Contains(targetURL, "/graph/") || !strings.Contains(targetURL, "/layers") {
+		t.Fatalf("target.url does not look like a graph layer URL: %s", targetURL)
+	}
+	fmt.Println("LIVE_CLONE_TARGET_URL=" + targetURL)
+}
+
+func loadLiveDotEnv(t *testing.T, path string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		key, val, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		key, val = strings.TrimSpace(key), strings.TrimSpace(val)
+		if _, exists := os.LookupEnv(key); !exists {
+			t.Setenv(key, val)
+		}
+	}
+}

--- a/plugins/simulator/mcp-server/internal/engines/graph/register.go
+++ b/plugins/simulator/mcp-server/internal/engines/graph/register.go
@@ -7,6 +7,8 @@ import (
 
 // Register adds all graph engine tools to the MCP server.
 func Register(s *server.MCPServer) {
+	registerGraphImportExportTools(s)
+
 	s.AddTool(
 		mcp.NewTool("pullGraphFile",
 			mcp.WithDescription("Fetch all actors and edges from a layer and write them to <layerId>.yaml in the current working directory."),

--- a/plugins/simulator/mcp-server/internal/tools/eval_test.go
+++ b/plugins/simulator/mcp-server/internal/tools/eval_test.go
@@ -38,6 +38,8 @@ func knownToolNames() map[string]bool {
 	for _, n := range []string{
 		"pullGraphFile", "pushGraphFile", "getAllLayerPlacements",
 		"compactGraphLayout", "pruneLongEdges", "createChart",
+		"createGraphExportTask", "getGraphImportExportTask",
+		"importGraphArchive", "cloneGraphLayer", "cloneGraphObjects",
 		"uploadActorPicture", "uploadActorPictureBulk",
 		"buildLink", "getBbcodeTags", "readAttachment",
 		"createSmartForm", "pullSmartForm", "pushSmartForm",

--- a/plugins/simulator/mcp-server/internal/tools/testdata/eval-scenarios.json
+++ b/plugins/simulator/mcp-server/internal/tools/testdata/eval-scenarios.json
@@ -554,6 +554,27 @@
     ]
   },
   {
+    "name": "Clone a graph layer by URL",
+    "prompt": "Clone this Simulator graph layer into the current workspace and give me the new link: https://mw.simulator.company/actors_graph/11111111/graph/33333333-3333-4333-8333-333333333333/layers/22222222-2222-4222-8222-222222222222. Preserve names and avoid updating existing objects.",
+    "tools": [
+      "cloneGraphObjects"
+    ],
+    "argChecks": [
+      {
+        "tool": "cloneGraphObjects",
+        "mustContain": [
+          "sourceUrl",
+          "confirmClone",
+          "refReplacePrefix"
+        ],
+        "mustNotContain": [
+          "\"refStrategy\":\"reuse\""
+        ]
+      }
+    ],
+    "liveOnly": true
+  },
+  {
     "name": "Chart top accounts on a layer",
     "prompt": "Create a chart (use createChart) of the top maintenance spenders on layer 14b284e0-5f77-4b40-bdde-f7058b05939f.",
     "tools": [

--- a/plugins/simulator/skills/simulator-graph/SKILL.md
+++ b/plugins/simulator/skills/simulator-graph/SKILL.md
@@ -28,7 +28,7 @@ description: >
   traversal operations, layer management, and FlowchartBlock diagram creation.
 ---
 
-> **Curated tool names (v2 server).** Place/remove nodes & edges on a layer with `manageLayerActors`; read a layer's contents — prefer `getLayerActorsPaginated` (page nodes then edges; works for any size) or `getAllLayerPlacements`, falling back to `getLayerActors` only for small layers (it loads the whole layer in one call and is rejected with a "Layer is too large" 400 above the size cap); create nodes with `createActor` (one call each — there is no `createActors`); links with `createLink` / `massLink`; edge CRUD with `getEdge` / `updateEdge` / `deleteEdge` / `existLink` / `deleteEdgesByNodes`; edge types with `getEdgeTypes`. Traverse from an actor with `getRelatedActors` (type = linked | parents | children; hierarchy link type by default; paginated/filterable/sortable), `getLinkedActors` (directly-linked actors across edge types, with `edgeTypes`/`withSystem`/`pinned` filters), and `getActorLinks` (every edge of an actor). Layer ops: `layerStats` (node/edge counts), `existLayerElement` (is a node/edge on a layer — dedup before placing), `moveActors` (move ≤10 actors between layers), `cleanGraphLayer` (wipe a layer — destructive). See `/simulator` for the full list.
+> **Curated tool names (v2 server).** Place/remove nodes & edges on a layer with `manageLayerActors`; read a layer's contents — prefer `getLayerActorsPaginated` (page nodes then edges; works for any size) or `getAllLayerPlacements`, falling back to `getLayerActors` only for small layers (it loads the whole layer in one call and is rejected with a "Layer is too large" 400 above the size cap); create nodes with `createActor` (one call each — there is no `createActors`); links with `createLink` / `massLink`; edge CRUD with `getEdge` / `updateEdge` / `deleteEdge` / `existLink` / `deleteEdgesByNodes`; edge types with `getEdgeTypes`. Traverse from an actor with `getRelatedActors` (type = linked | parents | children; hierarchy link type by default; paginated/filterable/sortable), `getLinkedActors` (directly-linked actors across edge types, with `edgeTypes`/`withSystem`/`pinned` filters), and `getActorLinks` (every edge of an actor). Layer ops: `layerStats` (node/edge counts), `existLayerElement` (is a node/edge on a layer — dedup before placing), `moveActors` (move ≤10 actors between layers), `cleanGraphLayer` (wipe a layer — destructive). Official `.graph` import/export flow: `createGraphExportTask`, `getGraphImportExportTask`, `importGraphArchive`, `cloneGraphObjects`, `cloneGraphLayer`. See `/simulator` for the full list.
 
 # Simulator.Company Graph Builder
 
@@ -53,6 +53,7 @@ Simulator.Company using the `simulator` MCP server.
 | **Graph actor** | An actor with `formName="Graphs"` — the logical container for a diagram.                             |
 | **Layer actor** | An actor with `formName="Layers"` — the visual canvas where nodes are placed at (x, y).              |
 | **Graph file**  | A YAML file named `<layerId>.yaml` in the current working directory describing the full layer state. |
+| **.graph archive** | The official Simulator import/export zip archive used by the web UI. It contains `GraphManifest.yaml`, forms, actors, edges, geometry, accounts, and optional access/scripts/files. |
 | **laId**        | Layer Actor ID. Assigned by `manageLayerActors` when an actor is placed on a layer.                        |
 
 ---
@@ -147,6 +148,206 @@ The server will:
 - **Update positions** for actors whose `position` changed
 
 After push the file is updated in place with all server UUIDs.
+
+---
+
+## Official `.graph` Export / Import / Clone
+
+Use the `.graph` import/export task tools when the user wants to clone a graph
+or layer, move a graph/layer between workspaces, preserve platform-level
+topology, or work with the same archive format as the Simulator web UI. Do not
+confuse this with
+`pullGraphFile` / `pushGraphFile`: those are convenient YAML sync tools for
+editing a single layer, while `.graph` export/import is the official async
+workspace object transfer mechanism.
+
+Treat user phrases like "move" or "transfer" as **copy/import** by default: the
+source graph/layer is not deleted. Do not delete source objects after import
+unless the user gives a separate explicit destructive confirmation.
+
+The target environment is the Simulator API/auth environment of the current MCP
+session. `targetAccId` selects a workspace inside that environment. If
+`targetAccId` is omitted, imports default to `sourceAccId`; if `sourceAccId` is
+also omitted, both default to the configured/request workspace. To import into a
+different Simulator environment, switch the MCP environment/auth first, then run
+the import there.
+
+### Export
+
+```
+createGraphExportTask(
+  actorIds=["<layerActorId>"],
+  maxRecursionLevel="max",
+  attachments=false,
+  waitSec=300
+)
+```
+
+- To export a layer, pass the **layer actor UUID** in `actorIds`.
+- To export a whole graph, pass the **graph root actor UUID** in `actorIds`.
+- For clone operations, a full Simulator URL can be passed as `sourceUrl`; the
+  tool will infer `sourceAccId`, graph id and layer id when possible.
+- `maxRecursionLevel="max"` is safest for a later import because low numeric
+  recursion can omit referenced actors. A shallow export may look valid but fail
+  during import with an `ImportReplaces.Get NotFound`-style error.
+- `max` can include much more than the visible canvas. Always inspect
+  `details.manifest.stats.counters` before production use.
+- Export requires access to every object included by recursion. If a layer
+  contains actors/forms/accounts/files/linked objects the current user cannot
+  read, the backend can fail the export; surface `details.errMsg` and ask for
+  access or a narrower export selection.
+- `allWorkspace=true` is a wide export and requires
+  `confirmAllWorkspaceExport=true`.
+
+Export settings:
+
+| Setting | Default | Meaning | Ask / require |
+|---------|---------|---------|---------------|
+| `actorIds` | `[]` | Explicit graph/layer/actor UUIDs to export. A layer clone uses the layer actor UUID. | Required unless `formIds`, `allWorkspace`, or `sourceUrl` derives it. |
+| `formIds` | `[]` | Export form templates and referenced objects for those forms. | Ask before broad form export; it can pull many records. |
+| `allWorkspace` | `false` | Export the whole workspace. | Requires `confirmAllWorkspaceExport=true`; do not use casually. |
+| `maxRecursionLevel` | backend default / `max` when omitted | How deeply referenced actors/forms/accounts are followed. Numeric `1..10` narrows recursion; `"max"`/omitted is safest for complete import. | For production, ask whether the user wants complete clone (`max`) or bounded export (`1..10`). |
+| `attachments` | `false` | Include uploaded files/attachments in the archive. | Ask explicitly; this can export private files and make archives large. |
+| `transactions` | `false` | Include transaction history. | Ask explicitly; can export financial/audit data. |
+| `processes` | `false` | Include linked Corezoid processes/projects/stages where present. | Ask explicitly; cross-system dependencies may be sensitive. |
+| `users` | `false` | Include users/groups/access mapping metadata. | Ask for user/group mapping on import if access must be preserved. |
+| `balances` | `false` | Include account balances. | Ask explicitly for finance-sensitive clones. |
+| `connectorsToAccounts` | `false` | Include connector-to-account links. | Enable only when account connector topology matters. |
+| `accountToActors` | `false` | Include account-to-actor links. | Enable only when account ownership/placement relations matter. |
+| `systemCounters` | `false` | Include system counter data. | Enable only if the target needs those counters. |
+
+Implementation detail: live PAPI expects `actors` and `forms` to be JSON arrays
+even when empty, and expects `balances`, `connectorsToAccounts`,
+`accountToActors` both in `ops` and as top-level booleans. Do not send `null`
+for omitted selections.
+
+### Import
+
+```
+importGraphArchive(
+  fileName="<uploaded .graph storage fileName>",
+  refStrategy="replace",
+  refReplacePrefix="clone_YYYYMMDD_",
+  confirmImport=true,
+  waitSec=300
+)
+```
+
+- Import is a write operation. It can create many actors/forms/edges/accounts.
+- Prefer `refStrategy="replace"` with a unique `refReplacePrefix` for cloning.
+  This creates imported refs under the prefix instead of silently colliding with
+  existing refs.
+- `refStrategy="error"` does not use a prefix. It asks the backend to fail on
+  REF collisions. Use it when the target workspace should stay untouched unless
+  every imported REF is new.
+- `refStrategy="reuse"` can update existing objects that have matching refs. Use
+  it only when the user explicitly wants a merge/update and pass
+  `allowReuseImport=true`.
+- `refReplacePrefix` is required only with `replace`. Omit it for
+  `error`/`reuse`; the MCP tool rejects a non-empty prefix for those strategies
+  to avoid ambiguous imports.
+- If access users/groups are included but not mapped, backend/UI defaults may
+  grant imported access to the importing user. Ask for mapping when access rules
+  matter.
+- Avoid casual imports in production workspaces. If the workspace is production
+  or business-critical, pause for explicit confirmation and show manifest
+  counters first.
+
+Import strategy decision table:
+
+| Strategy | Prefix | Effect | When to use |
+|----------|--------|--------|-------------|
+| `replace` | Required, unique, at least 8 chars | Creates imported refs under the prefix and avoids silent collisions. | Normal clone/copy, especially same-workspace copy or uncertain target. |
+| `error` | Must be omitted | Backend rejects existing REF collisions. | Strict import into a clean target where collisions should abort. |
+| `reuse` | Must be omitted | Reuses/updates matching REF objects in the target. | Intentional merge/update only, with `allowReuseImport=true` and explicit user confirmation. |
+
+Before calling import/clone, decide with the user:
+
+1. Source: pasted `sourceUrl`, `actorIds`, `formIds`, or `allWorkspace`.
+2. Target: same workspace by default, or explicit `targetAccId`; different
+   environment requires switching MCP environment/auth first.
+3. Export scope: attachments, transactions, processes, users/access, balances,
+   account links, recursion depth.
+4. Import strategy: `replace` with prefix for copy, `error` for collision-safe
+   strict import, or `reuse` for deliberate merge/update.
+5. Access mapping: if `users=true`, ask whether user/group mappings are needed.
+6. Production safety: show manifest counters and require explicit confirmation
+   before importing into production/business-critical workspaces.
+
+### Clone a graph or layer
+
+For normal graph/layer cloning, prefer the combined tool:
+
+```
+cloneGraphObjects(
+  sourceUrl="<Simulator graph/layer URL>",
+  sourceKind="auto",
+  targetAccId="<targetWorkspaceId>",
+  refStrategy="replace",
+  refReplacePrefix="clone_YYYYMMDD_",
+  attachments=false,
+  confirmClone=true,
+  waitSec=300
+)
+```
+
+- Use `sourceUrl` when the user pastes a Simulator graph/layer link. In
+  `sourceKind="auto"` a URL with `/layers/<layerId>` clones the layer; use
+  `sourceKind="graph"` when the user explicitly wants the graph root from that
+  same URL.
+- Use `actorIds=["<graphActorId or layerActorId>"]` when the user gives UUIDs
+  instead of a URL.
+- Pass a graph root UUID to clone a graph; pass a layer UUID to clone that layer.
+- Omit `targetAccId` to import into the current/source workspace in the current
+  environment.
+- If `targetAccId` equals `sourceAccId`, `refStrategy="replace"` creates
+  duplicates in the same workspace under `refReplacePrefix`. This is valid for
+  tests and explicit copy operations, but mention it before production use.
+- `refReplacePrefix` is required for the default `replace` clone path. It is not
+  allowed for `refStrategy="error"` or `refStrategy="reuse"`; `reuse` needs
+  `allowReuseImport=true`.
+- When both export/import manifests are available, check `countersMatch`; a
+  completed import with mismatched counters needs investigation before calling
+  the clone equivalent.
+- On successful `replace` imports the tool tries to return `target.url`,
+  `target.graphId` and/or `target.layerId` for the imported copy. It prefers
+  exact REF lookup when the archive has form/ref metadata. For no-REF graph
+  actors or layers it may fall back to exact title + formId + import-time
+  matching and emits a warning asking you to verify the resolved URL. If target
+  resolution is missing or ambiguous, the clone may still be complete; explain
+  the warning and resolve the imported actor manually from the import task or
+  by searching the target workspace.
+- A graph root can export successfully but still be rejected by the backend
+  import validator. Do not report clone success until the final import task is
+  `status="completed"`; if it fails, surface `details.errMsg` exactly and
+  suggest cloning the needed layer(s) separately when appropriate.
+- Use `cloneGraphLayer` only as a shortcut when you specifically have a
+  `layerId`.
+
+### Clone a layer shortcut
+
+When the user specifically asks for a single layer and gives a layer UUID, this
+shortcut is equivalent to `cloneGraphObjects(actorIds=["<layerId>"], ...)`:
+
+```
+cloneGraphLayer(
+  sourceUrl="<Simulator graph/layer URL>",
+  targetAccId="<targetWorkspaceId>",
+  refStrategy="replace",
+  refReplacePrefix="clone_YYYYMMDD_",
+  attachments=false,
+  confirmClone=true,
+  waitSec=300
+)
+```
+
+`layerId` can be passed instead of `sourceUrl`. If `sourceUrl` is used, it must
+contain `/layers/<layerId>`.
+
+This runs export → wait → download `.graph` → upload → import → wait. Treat a
+created task as queued, not successful; final success is only
+`status="completed"`. On `status="failed"`, read `details.errMsg` and explain it
+to the user.
 
 ---
 


### PR DESCRIPTION
## What & why

Adds official Simulator `.graph` export/import support to the graph engine tools so agents can clone graph layers or selected graph objects through the same async archive flow as the web UI.

Before this change, `pullGraphFile` / `pushGraphFile` could sync a single layer's visible nodes and edges, but the MCP server had no wrapper for the platform `.graph` transfer flow. That made clone/move requests require manual browser/API work and did not preserve the broader archive semantics: forms, links, geometry, accounts, optional users/scripts/files, backend manifest counters, and async task errors.

## Summary

- Added async `.graph` task tools:
  - `createGraphExportTask`
  - `getGraphImportExportTask`
  - `importGraphArchive`
- Added safe clone wrappers:
  - `cloneGraphObjects`
  - `cloneGraphLayer`
- Added guarded import strategies:
  - default `replace` requires a unique `refReplacePrefix`
  - `reuse` requires `allowReuseImport=true`
  - workspace-wide export requires `confirmAllWorkspaceExport=true`
- Added archive validation, 100 MiB local/download caps, manifest counter reporting, and clearer export access-denied hints.
- Added target URL/id resolution for successful `replace` imports:
  - exact REF lookup when archive metadata has `formId/ref`
  - fallback for no-REF graph/layer actors by exact title + formId + import-time filtering
- Documented the tools in `README.md`, `docs/ARCHITECTURE.md`, and `simulator-graph` skill guidance.
- Added eval coverage and unified server registration checks.

## Safety notes

- Clone/import operations are write operations and require explicit confirmation (`confirmClone=true` or `confirmImport=true`).
- `refStrategy=reuse` is blocked unless the caller explicitly passes `allowReuseImport=true`, because it can update existing REF-matching objects.
- Same-workspace clones warn that `replace` creates duplicates under the prefix.
- `allWorkspace=true` export is blocked unless `confirmAllWorkspaceExport=true` is passed.
- Local `.graph` imports require an absolute path, valid zip archive structure, `.graph` extension, and size <= 100 MiB.
- Export failures caused by incomplete access now include a hint that export recursion can include objects/forms/accounts/files the user cannot read.

## Live verification

Ran the full flow against a disposable Simulator test graph/layer:

- Created a graph/layer with three named actors and two edges.
- Exported and imported it through the async `.graph` task flow.
- Verified the imported layer retained actor names and edge counts.
- Renamed one imported actor and verified the source actor was unchanged.
- Deleted one imported actor and verified the source graph/layer was unchanged.
- Cleaned up the disposable test objects afterward.

## Validation

- `make build`
- `make vet`
- `make test`
- `make discovery && git diff --exit-code -- public/`
- `go test -race ./...`
- `go test -tags live_smoke ./internal/engines/graph -run TestLiveCloneGraphObjectsByURL -count=1 -v` (compiles; skipped unless `LIVE_SIMULATOR_CLONE=1`)
- `golangci-lint run ./internal/engines/graph ./app/mcpserver ./internal/tools --new-from-rev=origin/develop` → `0 issues`

Note: full `make lint` still reports the repository's existing advisory lint baseline, but this PR's changed/new files are clean with `--new-from-rev=origin/develop`.
