### PR TITLE
CE-15784 docs(links): closing an actor hole keeps each link's kind

### DIFF
--- a/plugins/simulator/docs/entities/links.md
+++ b/plugins/simulator/docs/entities/links.md
@@ -103,6 +103,12 @@ in `closed_edge_holes`. The hole edge itself is **never modified or deleted** (i
 merge/revert routes have no operationId and are not curated MCP tools — same as the actor-hole
 `merge_hole`/`revert_hole` routes.)
 
+Closing an **actor** hole (`merge_hole`) never changes the KIND of its links: the closer inherits the
+hole's connections as links of the same kind — a hole link stays a hole link (`hole: true`), an
+ordinary link stays ordinary. Revert moves them back the same way. An already-existing closer link to
+that neighbor is reused as-is and keeps its own kind (only one row per
+`source`/`target`/`edgeTypeId` may exist).
+
 ## Database Structure
 
 Links are stored in the `actors_edges` table with the following structure:


### PR DESCRIPTION
Documents the behavior fixed in pong-server by [CE-15784](https://jira.corezoid.com/browse/CE-15784) (`2c311d1c2` on `develop`).

Closing an actor hole (`merge_hole`) used to drop the `hole` flag when it created the closer's backing edges, so a hole link between two holes silently became an ordinary link. The fix carries the link's kind (and its linked actor) over to the created edge in both the close and the revert direction.

`docs/entities/links.md` now states the contract, so the agent doesn't assume closing a hole materialises hole links:
- a hole link stays a hole link, an ordinary link stays ordinary;
- revert moves them back the same way;
- an already-existing closer link to that neighbor is reused as-is and keeps its own kind (only one row per `source`/`target`/`edgeTypeId` may exist).

Docs only — no tool declarations, params or operationIds changed, so the drift gate is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)