### PR TITLE
CE-15765 feat(graph): exportGraph/importGraph/uploadGraphFile/getTaskStatus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ## [Unreleased]
 
+### Added
+- **Graph import/export tools — `exportGraph`, `importGraph`, `uploadGraphFile`, `getTaskStatus`.** Wraps the pong-server async task API so a workspace graph (actors, edges, forms, and optionally attachments / transactions / processes / users / balances) can be exported to a `.graph` archive or re-imported, mirroring the UI's Export/Import buttons — distinct from the existing `pullGraphFile`/`pushGraphFile` developer sync tools, which edit a single layer's YAML and never touch `.graph` archives. `exportGraph` requires at least one of `actors`/`forms`/`allWorkspace`; `uploadGraphFile` accepts a `.graph` file as base64 or a public URL (capped at 100 MiB either way) and returns a storage `fileName` for `importGraph`; `getTaskStatus` polls a task by id and, for a completed export, returns a ready-to-share `downloadUrl` alongside the raw `details.file.fileName`.
+
 ## [2.5.0] - 2026-07-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -232,6 +232,9 @@ the actor/node items.)
 |--------------------------|------------------------------------------------------------------------------------------------------|
 | `pullGraphFile`          | Fetch all actors and edges from a layer and write them to `<layerId>.yaml` in the working directory  |
 | `pushGraphFile`          | Read `<layerId>.yaml` and sync it with the server layer: create / update / remove to match the file  |
+| `exportGraph` / `importGraph` | Export actors (by UUID, form, or whole workspace) to a `.graph` archive, or import one back — same as the UI Export/Import buttons. Async; poll with `getTaskStatus` |
+| `uploadGraphFile`        | Upload a `.graph` archive (base64 or public URL) to workspace storage, returning the `fileName` for `importGraph` |
+| `getTaskStatus`          | Poll an `exportGraph` / `importGraph` task; completed exports include a ready-to-share `downloadUrl` |
 | `getAllLayerPlacements`  | Return every actor placement on a layer in one paginated call                                        |
 | `compactGraphLayout`     | Auto-layout a layer into domain-clustered grids (replaces the pull → edit → push loop)               |
 | `pruneLongEdges`         | Delete edges longer than a distance threshold; preserves hierarchy edges                             |
@@ -261,7 +264,8 @@ Claude Code / Codex / Kiro
         ├── auth        set-environment (public config → account URL), login (OAuth2 PKCE → .env), set-workspace
         ├── tools       curated typed operations (forms, actors, accounts,
         │               transactions, graph, apps) — one tool per backend op
-        ├── engines     pullGraphFile, pushGraphFile, compactGraphLayout,
+        ├── engines     pullGraphFile, pushGraphFile, exportGraph, importGraph,
+        │               uploadGraphFile, getTaskStatus, compactGraphLayout,
         │               pruneLongEdges, getAllLayerPlacements, uploadActorPicture(Bulk), createChart, buildLink
         └── apiclient   HTTP → Simulator /papi/1.0 (local :9000 or mw gateway)
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -268,6 +268,9 @@ ported from the original implementation:
 |--------------------------|--------------------------|----------------------------------------------------------------------|
 | `pullGraphFile`          | `sync_graph.go`          | Export a layer's actors + edges to `<layerId>.yaml`                  |
 | `pushGraphFile`          | `sync_graph.go` / `push_graph.go` | Diff a local YAML against the layer and create/update/delete |
+| `exportGraph` / `importGraph` | `tasks.go`          | Create an async export/import task against the pong-server task API (actors/forms/whole workspace ↔ `.graph` archive), mirroring the UI Export/Import buttons |
+| `uploadGraphFile`        | `tasks.go`               | Upload a `.graph` archive (base64 or public URL, capped at 100 MiB) to workspace storage; returns the storage `fileName` for `importGraph` |
+| `getTaskStatus`          | `tasks.go`               | Poll an export/import task by id; unwraps the pong-server `details` TEXT blob into structured JSON and, for completed exports, adds a ready-to-use `downloadUrl` |
 | `getAllLayerPlacements`  | `get_layer_placements.go`| Return every placement on a layer in one paginated call             |
 | `compactGraphLayout`     | `compact_layout.go`      | Auto-layout a layer into domain-clustered grids                     |
 | `pruneLongEdges`         | `prune_edges.go`         | Delete edges longer than a distance threshold; preserves hierarchy  |

--- a/plugins/simulator/mcp-server/internal/engines/graph/register.go
+++ b/plugins/simulator/mcp-server/internal/engines/graph/register.go
@@ -105,4 +105,68 @@ func Register(s *server.MCPServer) {
 		),
 		handleCreateChart,
 	)
+
+	// ---- Async import/export tasks (backed by pong-server task API) ----
+	//
+	// Export flow:  exportGraph → poll getTaskStatus → completed details contain
+	//               file.fileName which can be passed to importGraph.
+	// Import flow:  uploadGraphFile (if importing an external file) → get
+	//               fileName → importGraph(fileName) → poll getTaskStatus.
+
+	s.AddTool(
+		mcp.NewTool("exportGraph",
+			mcp.WithDescription("Export selected actors (by UUID, form, or entire workspace) to a .graph archive file visible in the workspace Exports section. Before calling: 1) ask the user whether to export the entire workspace (allWorkspace:true) or a specific graph — if specific, use searchActors or getForms to find actor/form IDs; 2) ask which data to include: attachments, transactions, processes, users, balances (show defaults so the user can confirm or change). Operation is async — poll getTaskStatus until status is \"completed\"; completed details include file.fileName (pass to importGraph to re-import). Provide at least one filter: actors, forms, or allWorkspace."),
+			mcp.WithArray("actors", mcp.Description("List of actor UUIDs to export.")),
+			mcp.WithArray("forms", mcp.Description("List of numeric form IDs — all actors in these forms are exported.")),
+			mcp.WithBoolean("allWorkspace", mcp.Description("Export every actor in the workspace. Default false.")),
+			mcp.WithBoolean("attachments", mcp.Description("Include attachment files and pictures. Default true.")),
+			mcp.WithBoolean("transactions", mcp.Description("Include account transactions and transfers. Default false.")),
+			mcp.WithBoolean("processes", mcp.Description("Include Corezoid processes and API Gateway configs. Default false.")),
+			mcp.WithBoolean("users", mcp.Description("Include user access rules and permissions. Default false.")),
+			mcp.WithBoolean("balances", mcp.Description("Include account balances. Default false.")),
+			mcp.WithBoolean("connectorsToAccounts", mcp.Description("Include account connectors/integrations. Default true.")),
+			mcp.WithBoolean("accountToActors", mcp.Description("Include account-to-actor mappings. Default true.")),
+			mcp.WithBoolean("systemCounters", mcp.Description("Include system counter accounts. Default false.")),
+			mcp.WithNumber("maxRecursionLevel", mcp.Description("Max depth when traversing actor relationships. 0 = unlimited (default).")),
+		),
+		handleExportGraph,
+	)
+
+	s.AddTool(
+		mcp.NewTool("uploadGraphFile",
+			mcp.WithDescription("Upload a .graph archive to workspace storage and return the storage fileName for use with importGraph. Accepts base64-encoded content or a public URL. Not needed when re-importing a file exported in the same workspace — pass details.file.fileName from the completed exportGraph task directly to importGraph."),
+			mcp.WithString("base64", mcp.Description("Base64-encoded .graph file content (optionally with data: URI prefix). One of base64 or fileUrl is required.")),
+			mcp.WithString("fileUrl", mcp.Description("Public URL to download the .graph file from. One of base64 or fileUrl is required.")),
+			mcp.WithString("originalName", mcp.Description("Original filename (e.g. \"backup.graph\"). Default \"import.graph\".")),
+		),
+		handleUploadGraphFile,
+	)
+
+	s.AddTool(
+		mcp.NewTool("importGraph",
+			mcp.WithDescription("Import a .graph archive into the workspace, restoring actors, forms, edges, and related data. Before calling: 1) determine the file source — if re-importing from a previous export, use details.file.fileName from getTaskStatus; if importing an external file, ask the user for a URL and upload it first with uploadGraphFile to get the fileName; 2) ask the user about reference strategies — for each entity type (actors, forms, transfers, transactions, processes) choose \"reuse\" (merge with existing data) or \"replace\" (create new copies), show defaults and let the user confirm or change; 3) ask if user permission remapping is needed. Operation is async — poll getTaskStatus until done."),
+			mcp.WithString("fileName", mcp.Description("Storage fileName of the .graph file (from exportGraph details or uploadGraphFile result)."), mcp.Required()),
+			mcp.WithArray("users", mcp.Description("User ID remapping array. Each element: {fromId (number), toIds (number array)}.")),
+			mcp.WithString("actorRefStrategy", mcp.Description("Actor reference strategy: \"reuse\" (merge with existing) or \"replace\" (create new). Empty = server default.")),
+			mcp.WithString("actorRefReplacePrefix", mcp.Description("Prefix for actor references when strategy is \"replace\". Auto-generated if empty.")),
+			mcp.WithString("formRefStrategy", mcp.Description("Form reference strategy: \"reuse\" or \"replace\".")),
+			mcp.WithString("formRefReplacePrefix", mcp.Description("Prefix for form references when strategy is \"replace\". Auto-generated if empty.")),
+			mcp.WithString("transferRefStrategy", mcp.Description("Transfer reference strategy: \"reuse\" or \"replace\".")),
+			mcp.WithString("transferRefReplacePrefix", mcp.Description("Prefix for transfer references when strategy is \"replace\". Auto-generated if empty.")),
+			mcp.WithString("transactionRefStrategy", mcp.Description("Transaction reference strategy: \"reuse\" or \"replace\".")),
+			mcp.WithString("transactionRefReplacePrefix", mcp.Description("Prefix for transaction references when strategy is \"replace\". Auto-generated if empty.")),
+			mcp.WithString("processesRefStrategy", mcp.Description("Corezoid processes reference strategy: \"reuse\" (merge) or \"replace\" (reimport).")),
+			mcp.WithArray("dataReplace", mcp.Description("Data replacement rules. Each element: {from: {type, ref?, id?}, to: {title?, description?, ref?}}.")),
+		),
+		handleImportGraph,
+	)
+
+	s.AddTool(
+		mcp.NewTool("getTaskStatus",
+			mcp.WithDescription("Poll the status of an export or import task. Returns status (created, started, completed, failed, canceled) and structured details. Call repeatedly every 2-3 seconds until terminal status. For completed exports, the response includes downloadUrl (ready to share with the user) and details.file.fileName (the same file, usable with readAttachment or passed to importGraph for re-import)."),
+			mcp.WithNumber("taskId", mcp.Description("Numeric task ID returned by exportGraph or importGraph."), mcp.Required()),
+			mcp.WithString("name", mcp.Description("Task type: \"import\" or \"export\"."), mcp.Required()),
+		),
+		handleGetTaskStatus,
+	)
 }

--- a/plugins/simulator/mcp-server/internal/engines/graph/tasks.go
+++ b/plugins/simulator/mcp-server/internal/engines/graph/tasks.go
@@ -1,0 +1,403 @@
+package graph
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"strings"
+
+	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/internal/engines/ecore"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// taskResponse is the JSON envelope returned by the pong-server task API.
+type taskResponse struct {
+	Data taskData `json:"data"`
+}
+
+type taskData struct {
+	ID      int             `json:"id"`
+	Name    string          `json:"name"`
+	Status  string          `json:"status"`
+	Details json.RawMessage `json:"details,omitempty"`
+}
+
+// unwrapDetails detects whether Details is a JSON-encoded string (pong-server
+// stores it as TEXT in PostgreSQL) and, if so, replaces it with the parsed
+// JSON object so callers see structured data instead of an escaped string.
+func unwrapDetails(d json.RawMessage) json.RawMessage {
+	if len(d) == 0 || d[0] != '"' {
+		return d
+	}
+	var s string
+	if json.Unmarshal(d, &s) == nil && len(s) > 0 && (s[0] == '{' || s[0] == '[') {
+		return json.RawMessage(s)
+	}
+	return d
+}
+
+// exportedFileName extracts details.file.fileName from an unwrapped task
+// details payload, or "" if absent (e.g. the task isn't a completed export).
+func exportedFileName(details json.RawMessage) string {
+	var d struct {
+		File struct {
+			FileName string `json:"fileName"`
+		} `json:"file"`
+	}
+	if json.Unmarshal(details, &d) != nil {
+		return ""
+	}
+	return d.File.FileName
+}
+
+// encodeDownloadPath percent-escapes each path segment of a storage file name
+// while keeping the slash separators, mirroring internal/tools/download.go's
+// encodeFilePath for the same PAPI /download/{fileName} route.
+func encodeDownloadPath(fileName string) string {
+	parts := strings.Split(fileName, "/")
+	for i, p := range parts {
+		parts[i] = url.PathEscape(p)
+	}
+	return strings.Join(parts, "/")
+}
+
+// maxGraphFileBytes caps the download size for .graph files fetched by URL.
+const maxGraphFileBytes = 100 << 20 // 100 MiB
+
+// maxGraphFileBase64Chars caps the base64 source so decoded output can't
+// exceed maxGraphFileBytes (base64 expands raw bytes by 4/3).
+const maxGraphFileBase64Chars = (maxGraphFileBytes / 3) * 4
+
+// downloadGraphFileFromURL downloads a file from a public URL.
+func downloadGraphFileFromURL(ctx context.Context, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	client := ecore.APIHTTPClient()
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("download failed: HTTP %d", resp.StatusCode)
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxGraphFileBytes))
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+// handleExportGraph creates an async export task for graph actors.
+// The caller should poll getTaskStatus until the task completes.
+func handleExportGraph(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	if authResult := ecore.EnsureAuth(ctx); authResult != nil {
+		return authResult, nil
+	}
+
+	accID := ecore.WorkspaceIDForContext(ctx)
+	if accID == "" {
+		return mcp.NewToolResultError("[Error] workspace ID is not set"), nil
+	}
+
+	args := req.GetArguments()
+
+	var actors []string
+	if raw, ok := args["actors"]; ok && raw != nil {
+		if arr, ok := raw.([]any); ok {
+			for _, v := range arr {
+				if s, ok := v.(string); ok && s != "" {
+					if !ecore.IsUUID(s) {
+						return mcp.NewToolResultError(fmt.Sprintf("[Error] actors: %q is not a valid UUID", s)), nil
+					}
+					actors = append(actors, s)
+				}
+			}
+		}
+	}
+
+	var forms []int
+	if raw, ok := args["forms"]; ok && raw != nil {
+		if arr, ok := raw.([]any); ok {
+			for _, v := range arr {
+				if n := toInt(v); n != 0 {
+					forms = append(forms, n)
+				}
+			}
+		}
+	}
+
+	allWorkspace, _ := args["allWorkspace"].(bool)
+
+	if len(actors) == 0 && len(forms) == 0 && !allWorkspace {
+		return mcp.NewToolResultError("[Error] provide at least one filter: actors, forms, or allWorkspace"), nil
+	}
+
+	// Export options (control-tasks ExportTaskOps).
+	ops := map[string]interface{}{}
+	for _, key := range []string{
+		"attachments", "transactions", "processes", "users",
+		"balances", "connectorsToAccounts", "accountToActors", "systemCounters",
+	} {
+		if v, ok := args[key].(bool); ok {
+			ops[key] = v
+		}
+	}
+	if n := toInt(args["maxRecursionLevel"]); n > 0 {
+		ops["maxRecursionLevel"] = n
+	}
+
+	body := map[string]interface{}{}
+	if len(actors) > 0 {
+		body["actors"] = actors
+	}
+	if len(forms) > 0 {
+		body["forms"] = forms
+	}
+	if allWorkspace {
+		body["allWorkspace"] = true
+	}
+	if len(ops) > 0 {
+		body["ops"] = ops
+	}
+
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("[Error] marshal request: %v", err)), nil
+	}
+
+	url := fmt.Sprintf("%s/tasks/%s/export", ecore.BuildBaseURLForContext(ctx), ecore.Seg(accID))
+	respBytes, err := ecore.PapiPOST(ctx, url, bodyBytes)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("[Error] create export task: %v", err)), nil
+	}
+
+	var resp taskResponse
+	if err := json.Unmarshal(respBytes, &resp); err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("[Error] parse response: %v (body: %.200s)", err, respBytes)), nil
+	}
+
+	out, _ := json.Marshal(resp.Data)
+	return mcp.NewToolResultText(string(out)), nil
+}
+
+// handleImportGraph creates an async import task from a .graph file.
+// The caller should poll getTaskStatus until the task completes.
+func handleImportGraph(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	if authResult := ecore.EnsureAuth(ctx); authResult != nil {
+		return authResult, nil
+	}
+
+	accID := ecore.WorkspaceIDForContext(ctx)
+	if accID == "" {
+		return mcp.NewToolResultError("[Error] workspace ID is not set"), nil
+	}
+
+	args := req.GetArguments()
+
+	fileName, _ := args["fileName"].(string)
+	if fileName == "" {
+		return mcp.NewToolResultError("[Error] fileName is required"), nil
+	}
+
+	var users []map[string]interface{}
+	if raw, ok := args["users"]; ok && raw != nil {
+		if arr, ok := raw.([]any); ok {
+			for _, item := range arr {
+				if m, ok := item.(map[string]any); ok {
+					fromID := toInt(m["fromId"])
+					var toIDs []int
+					if rawTo, ok := m["toIds"].([]any); ok {
+						for _, v := range rawTo {
+							if n := toInt(v); n != 0 {
+								toIDs = append(toIDs, n)
+							}
+						}
+					}
+					if fromID != 0 || len(toIDs) > 0 {
+						users = append(users, map[string]interface{}{
+							"fromId": fromID,
+							"toIds":  toIDs,
+						})
+					}
+				}
+			}
+		}
+	}
+
+	// Import options (control-tasks ImportTaskOps).
+	ops := map[string]interface{}{}
+	for _, key := range []string{
+		"actorRefStrategy", "actorRefReplacePrefix",
+		"formRefStrategy", "formRefReplacePrefix",
+		"transferRefStrategy", "transferRefReplacePrefix",
+		"transactionRefStrategy", "transactionRefReplacePrefix",
+		"processesRefStrategy",
+	} {
+		if v, _ := args[key].(string); v != "" {
+			ops[key] = v
+		}
+	}
+
+	// dataReplace — from/to replacement rules (passed through as-is).
+	var dataReplace []interface{}
+	if raw, ok := args["dataReplace"]; ok && raw != nil {
+		if arr, ok := raw.([]any); ok {
+			dataReplace = arr
+		}
+	}
+
+	body := map[string]interface{}{
+		"fileName": fileName,
+	}
+	if len(users) > 0 {
+		body["users"] = users
+	}
+	if len(ops) > 0 {
+		body["ops"] = ops
+	}
+	if len(dataReplace) > 0 {
+		body["dataReplace"] = dataReplace
+	}
+
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("[Error] marshal request: %v", err)), nil
+	}
+
+	url := fmt.Sprintf("%s/tasks/%s/import", ecore.BuildBaseURLForContext(ctx), ecore.Seg(accID))
+	respBytes, err := ecore.PapiPOST(ctx, url, bodyBytes)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("[Error] create import task: %v", err)), nil
+	}
+
+	var resp taskResponse
+	if err := json.Unmarshal(respBytes, &resp); err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("[Error] parse response: %v (body: %.200s)", err, respBytes)), nil
+	}
+
+	out, _ := json.Marshal(resp.Data)
+	return mcp.NewToolResultText(string(out)), nil
+}
+
+// handleGetTaskStatus polls the status of an async import or export task.
+func handleGetTaskStatus(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	if authResult := ecore.EnsureAuth(ctx); authResult != nil {
+		return authResult, nil
+	}
+
+	accID := ecore.WorkspaceIDForContext(ctx)
+	if accID == "" {
+		return mcp.NewToolResultError("[Error] workspace ID is not set"), nil
+	}
+
+	args := req.GetArguments()
+
+	taskID := toInt(args["taskId"])
+	if taskID <= 0 {
+		return mcp.NewToolResultError("[Error] taskId is required and must be a positive number"), nil
+	}
+
+	name, _ := args["name"].(string)
+	if name != "import" && name != "export" {
+		return mcp.NewToolResultError("[Error] name is required and must be \"import\" or \"export\""), nil
+	}
+
+	apiURL := fmt.Sprintf("%s/tasks/%s/%s/%d", ecore.BuildBaseURLForContext(ctx), ecore.Seg(accID), ecore.Seg(name), taskID)
+	respBytes, err := ecore.PapiGET(ctx, apiURL)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("[Error] get task status: %v", err)), nil
+	}
+
+	var resp taskResponse
+	if err := json.Unmarshal(respBytes, &resp); err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("[Error] parse response: %v (body: %.200s)", err, respBytes)), nil
+	}
+
+	resp.Data.Details = unwrapDetails(resp.Data.Details)
+
+	outMap := map[string]interface{}{
+		"id":      resp.Data.ID,
+		"name":    resp.Data.Name,
+		"status":  resp.Data.Status,
+		"details": resp.Data.Details,
+	}
+	if fileName := exportedFileName(resp.Data.Details); fileName != "" {
+		outMap["downloadUrl"] = fmt.Sprintf("%s/download/%s", ecore.BuildBaseURLForContext(ctx), encodeDownloadPath(fileName))
+	}
+
+	out, _ := json.Marshal(outMap)
+	return mcp.NewToolResultText(string(out)), nil
+}
+
+// handleUploadGraphFile uploads a .graph file to the simulator storage so it
+// can be used with importGraph. Accepts the file as base64 content or as a
+// public URL. Returns the storage fileName for use as importGraph's fileName.
+func handleUploadGraphFile(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	if authResult := ecore.EnsureAuth(ctx); authResult != nil {
+		return authResult, nil
+	}
+
+	accID := ecore.WorkspaceIDForContext(ctx)
+	if accID == "" {
+		return mcp.NewToolResultError("[Error] workspace ID is not set"), nil
+	}
+
+	args := req.GetArguments()
+
+	var (
+		fileBytes []byte
+		filename  string
+	)
+
+	if b64, ok := args["base64"].(string); ok && b64 != "" {
+		// Strip optional data URI prefix.
+		if i := strings.Index(b64, "base64,"); i >= 0 {
+			b64 = b64[i+len("base64,"):]
+		}
+		if len(b64) > maxGraphFileBase64Chars {
+			return mcp.NewToolResultError(fmt.Sprintf("[Error] base64 payload too large (max %d MiB)", maxGraphFileBytes>>20)), nil
+		}
+		b, err := decodeBase64Flexible(b64)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("[Error] decode base64: %v", err)), nil
+		}
+		fileBytes = b
+	} else if u, ok := args["fileUrl"].(string); ok && u != "" {
+		b, err := downloadGraphFileFromURL(ctx, u)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("[Error] download fileUrl: %v", err)), nil
+		}
+		fileBytes = b
+		filename = filepath.Base(u)
+		if i := strings.IndexAny(filename, "?#"); i >= 0 {
+			filename = filename[:i]
+		}
+	} else {
+		return mcp.NewToolResultError("[Error] one of base64 or fileUrl is required"), nil
+	}
+
+	if fn, ok := args["originalName"].(string); ok && fn != "" {
+		filename = fn
+	}
+	if filename == "" {
+		filename = "import.graph"
+	}
+
+	storageName, err := uploadFile(ctx, accID, filename, "application/octet-stream", fileBytes)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("[Error] upload: %v", err)), nil
+	}
+
+	out, _ := json.Marshal(map[string]string{
+		"fileName": storageName,
+		"title":    filename,
+	})
+	return mcp.NewToolResultText(string(out)), nil
+}


### PR DESCRIPTION
## Summary
- Add `exportGraph` / `importGraph` engine tools wrapping the pong-server async task API (actors/forms/whole-workspace ↔ `.graph` archive), mirroring the UI's Export/Import buttons.
- Add `uploadGraphFile` (base64 or public URL, capped at 100 MiB) to stage an external `.graph` archive for `importGraph`.
- Add `getTaskStatus` to poll an export/import task by id; for a completed export it also returns a ready-to-share `downloadUrl` alongside `details.file.fileName`.
- Distinct from the existing `pullGraphFile`/`pushGraphFile` dev-sync tools, which edit a single layer's YAML and never touch `.graph` archives — their descriptions now cross-reference the new tools.
- Docs: README.md MCP-tools table, `docs/ARCHITECTURE.md` §4, `CHANGELOG.md` (`## [Unreleased]`, no version bump per release-time versioning flow).

## Test plan
- [x] `make build && make vet` clean
- [x] `go test ./...` (mcp-server module) passes
- [ ] Manual smoke test against a live workspace: `exportGraph` → poll `getTaskStatus` → verify `downloadUrl` → `importGraph` round-trip