### PR TITLE
fix(smart-forms): allow visibility placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,6 +199,9 @@
   partials have no `.less` extension, `lessc` cannot read a `<(…)` process-substitution path
   (`EBADF`), and the npm package is `less` — a package literally named `lessc` exists and is not the
   compiler.
+- **Smart Form visibility placeholders rejected by `pushSmartForm`.** Page configs may use a pure
+  `{{viewModelKey}}` placeholder for form, section, and rendered-item `visibility`; validation now
+  accepts that server-resolved form while still rejecting malformed or embedded placeholders.
 - **Telemetry: unsynchronized `telemetryEmail` read/write.** The opt-in email was stored in a plain
   `var string`, written by `AskForEmailOnce` (after `login`) and read by `Middleware` on every tool
   call — safe under the current single-threaded stdio transport, but a data race under `go test

--- a/plugins/simulator/docs/user-flows/cdu-page-protocol.md
+++ b/plugins/simulator/docs/user-flows/cdu-page-protocol.md
@@ -233,7 +233,7 @@ Every entry in a section's `header`/`content` is an **Item**, dispatched by its 
 | `id` | string | item id; key under which its `value` is submitted |
 | `class` | enum (see §5) | which component to render |
 | `value` | string \| object \| array | current value (type depends on component) |
-| `visibility` | `visible`\|`disabled`\|`hidden` | render state |
+| `visibility` | `visible`\|`disabled`\|`hidden` or a pure `{{viewModelKey}}` placeholder | render state after server-side resolution |
 | `required` | boolean | required for submit (drives auto-disable of submit buttons) |
 | `error` | boolean | error state (server- or client-set) |
 | `errorMsg` | string | message shown when `error` |
@@ -362,7 +362,10 @@ shape the page **before** it reaches the renderer. All are resolved server-side
 
 - **`viewModel`** — a key/value bag. The app-wide `viewModel` file is merged with the
   per-request `viewModel` returned by the Corezoid process; values fill `{{token}}`
-  placeholders in the config.
+  placeholders in the config. A form, section, or rendered item in `header`, `modalHeader`, or
+  `content` may use a pure placeholder such as `"visibility": "{{graphPreviewVisibility}}"`;
+  its resolved value must be `visible`, `disabled`, or `hidden`. This also applies to nested
+  items and items expanded from `contentLoop`.
 - **`locale`** — i18n strings keyed by language. The app `locale` and the page `locale` are
   merged and resolved for the active `language`; values fill `[[token]]` placeholders.
   (`createPageData` merges `{ ...appLocale, ...pageLocale }` and `{ ...appViewModel,
@@ -621,11 +624,13 @@ wrapper.
 > generated row wrapper. So `row:"1 my_row"` puts `.my_row` on the wrapper — the one stable hook you
 > can style a whole row by (and reuse across rows: `row:"1 my_row"` + `row:"2 my_row"` share `.my_row`).
 
-### 12.3 No client-side conditional visibility — reveal = `submitOnChange` + 200 `changes`
-`visibility` is a static enum (`visible|disabled|hidden`); there is no expression/binding language,
-so a field cannot show/hide reactively from another field's value on the client. The only way to
-"reveal B when A changes" is a server round-trip: set `submitOnChange:true` on A; the `/send` handler
-returns **200** with `changes:[{id:"B", visibility:"visible|hidden"}]` (see §7). A `submitOnChange`
+### 12.3 No client-side reactive visibility — reveal = `submitOnChange` + 200 `changes`
+The raw config may set form, section, and rendered-item `visibility` to a pure
+`{{viewModelKey}}` placeholder, but the server resolves it to `visible|disabled|hidden` before the
+page reaches the client. It is initial/server-render binding, not a client-side expression: changing
+another field does not re-evaluate the placeholder locally. To "reveal B when A changes", use a
+server round-trip: set `submitOnChange:true` on A; the `/send` handler returns **200** with
+`changes:[{id:"B", visibility:"visible|hidden"}]` (see §7). A `submitOnChange`
 event posts with `buttonId = <element id>` (not a button). **Read the new value from
 `body.data.<fieldId>`** — that is the reliable source across components. `body.buttonData.value` is
 populated **only by `select`** (and a few components); `radio`, `edit`, `check`, `toggle`, etc. send no

--- a/plugins/simulator/mcp-server/internal/cduschema/schema.go
+++ b/plugins/simulator/mcp-server/internal/cduschema/schema.go
@@ -18,7 +18,7 @@ type Rules struct {
 	// plus `row` and `draggable` (renderer-side layout wrappers absent from the swagger).
 	Classes map[string]bool
 
-	// Visibility is the set of valid visibility values (visible|disabled|hidden).
+	// Visibility is the set of valid resolved visibility values (visible|disabled|hidden).
 	Visibility map[string]bool
 
 	// SectionType is the set of valid section type values (body|block|modal|float).

--- a/plugins/simulator/mcp-server/internal/cduschema/schema_test.go
+++ b/plugins/simulator/mcp-server/internal/cduschema/schema_test.go
@@ -91,6 +91,7 @@ func TestValidatePageConfig_InvalidVisibilityPlaceholders(t *testing.T) {
 		{name: "unknown literal", visibility: "shown"},
 		{name: "embedded placeholder", visibility: "state-{{visibility}}"},
 		{name: "empty placeholder", visibility: "{{}}"},
+		{name: "placeholder with surrounding whitespace", visibility: "{{ visibility }}"},
 		{name: "multiple placeholders", visibility: "{{first}}{{second}}"},
 		{name: "nested brace", visibility: "{{nested{key}}}"},
 	}

--- a/plugins/simulator/mcp-server/internal/cduschema/schema_test.go
+++ b/plugins/simulator/mcp-server/internal/cduschema/schema_test.go
@@ -58,6 +58,74 @@ func TestValidatePageConfig_Valid(t *testing.T) {
 	}
 }
 
+func TestValidatePageConfig_VisibilityPlaceholders(t *testing.T) {
+	config := `{
+		"grid": {"type": "one_column"},
+		"forms": [{
+			"id": "main",
+			"visibility": "{{formVisibility}}",
+			"sections": [{
+				"id": "body",
+				"visibility": "{{sectionVisibility}}",
+				"header": [{"id": "heading", "class": "label", "visibility": "{{headingVisibility}}"}],
+				"modalHeader": [{"id": "close", "class": "button", "visibility": "{{closeVisibility}}"}],
+				"content": [{
+					"id": "layout",
+					"class": "row",
+					"items": [{"id": "field", "class": "edit", "visibility": "{{fieldVisibility}}"}]
+				}]
+			}]
+		}]
+	}`
+
+	if errs := ValidateFile("pages/index/config", config); len(errs) != 0 {
+		t.Errorf("expected visibility placeholders to be valid, got: %v", errs)
+	}
+}
+
+func TestValidatePageConfig_InvalidVisibilityPlaceholders(t *testing.T) {
+	tests := []struct {
+		name       string
+		visibility string
+	}{
+		{name: "unknown literal", visibility: "shown"},
+		{name: "embedded placeholder", visibility: "state-{{visibility}}"},
+		{name: "empty placeholder", visibility: "{{}}"},
+		{name: "multiple placeholders", visibility: "{{first}}{{second}}"},
+		{name: "nested brace", visibility: "{{nested{key}}}"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := `{
+				"grid": {"type": "one_column"},
+				"forms": [{"id": "main", "visibility": "` + tt.visibility + `", "sections": []}]
+			}`
+
+			if errs := ValidateFile("pages/index/config", config); len(errs) == 0 {
+				t.Errorf("expected visibility %q to be rejected", tt.visibility)
+			}
+		})
+	}
+}
+
+func TestValidatePageConfig_FooterVisibilityPlaceholder(t *testing.T) {
+	config := `{
+		"grid": {"type": "one_column"},
+		"forms": [{
+			"id": "main",
+			"sections": [{
+				"id": "body",
+				"footer": [{"id": "footer", "class": "label", "visibility": "{{footerVisibility}}"}]
+			}]
+		}]
+	}`
+
+	if errs := ValidateFile("pages/index/config", config); len(errs) == 0 {
+		t.Error("expected a footer visibility placeholder to be rejected")
+	}
+}
+
 func TestValidatePageConfig_Errors(t *testing.T) {
 	config := `{
 		"grid": {"type": "bad_type"},

--- a/plugins/simulator/mcp-server/internal/cduschema/schema_test.go
+++ b/plugins/simulator/mcp-server/internal/cduschema/schema_test.go
@@ -67,7 +67,7 @@ func TestValidatePageConfig_VisibilityPlaceholders(t *testing.T) {
 			"sections": [{
 				"id": "body",
 				"visibility": "{{sectionVisibility}}",
-				"header": [{"id": "heading", "class": "label", "visibility": "{{headingVisibility}}"}],
+				"header": [{"id": "heading", "class": "label", "value": "Heading", "visibility": "{{headingVisibility}}"}],
 				"modalHeader": [{"id": "close", "class": "button", "visibility": "{{closeVisibility}}"}],
 				"content": [{
 					"id": "layout",
@@ -80,6 +80,28 @@ func TestValidatePageConfig_VisibilityPlaceholders(t *testing.T) {
 
 	if errs := ValidateFile("pages/index/config", config); len(errs) != 0 {
 		t.Errorf("expected visibility placeholders to be valid, got: %v", errs)
+	}
+}
+
+func TestValidatePageConfig_ContentLoopVisibilityPlaceholder(t *testing.T) {
+	config := `{
+		"grid": {"type": "one_column"},
+		"forms": [{
+			"id": "main",
+			"sections": [{
+				"id": "body",
+				"contentLoop": [{"fieldVisibility": "hidden"}],
+				"content": [{
+					"id": "field",
+					"class": "edit",
+					"visibility": "{{fieldVisibility}}"
+				}]
+			}]
+		}]
+	}`
+
+	if errs := ValidateFile("pages/index/config", config); len(errs) != 0 {
+		t.Errorf("expected a contentLoop visibility placeholder to be valid, got: %v", errs)
 	}
 }
 
@@ -117,7 +139,7 @@ func TestValidatePageConfig_FooterVisibilityPlaceholder(t *testing.T) {
 			"id": "main",
 			"sections": [{
 				"id": "body",
-				"footer": [{"id": "footer", "class": "label", "visibility": "{{footerVisibility}}"}]
+				"footer": [{"id": "footer", "class": "label", "value": "Footer", "visibility": "{{footerVisibility}}"}]
 			}]
 		}]
 	}`

--- a/plugins/simulator/mcp-server/internal/cduschema/validate.go
+++ b/plugins/simulator/mcp-server/internal/cduschema/validate.go
@@ -365,5 +365,5 @@ func isViewModelPlaceholder(value string) bool {
 	}
 
 	key := value[2 : len(value)-2]
-	return strings.TrimSpace(key) != "" && !strings.ContainsAny(key, "{}")
+	return key != "" && key == strings.TrimSpace(key) && !strings.ContainsAny(key, "{}")
 }

--- a/plugins/simulator/mcp-server/internal/cduschema/validate.go
+++ b/plugins/simulator/mcp-server/internal/cduschema/validate.go
@@ -7,6 +7,11 @@ import (
 	"strings"
 )
 
+const (
+	visibilityValues            = "visible|disabled|hidden"
+	visibilityPlaceholderValues = visibilityValues + " or a {{viewModelKey}} placeholder"
+)
+
 // ValidateFile validates the source of a single Smart Form env file before push.
 // relPath is the env-relative path (e.g. "pages/index/config", "locale", "definitions/button").
 // Returns a slice of human-readable error messages; empty means valid.
@@ -101,9 +106,9 @@ func validatePageConfig(relPath, source string) []string {
 			errs = append(errs, fmt.Sprintf(`%s: %s: missing required field "id"`, relPath, fLabel))
 		}
 
-		if vis, _ := form["visibility"].(string); vis != "" && !r.Visibility[vis] {
+		if vis, _ := form["visibility"].(string); vis != "" && !validVisibility(vis, r, true) {
 			errs = append(errs, fmt.Sprintf(
-				"%s: %s: invalid visibility %q; must be visible|disabled|hidden", relPath, fLabel, vis,
+				"%s: %s: invalid visibility %q; must be %s", relPath, fLabel, vis, visibilityPlaceholderValues,
 			))
 		}
 
@@ -134,21 +139,27 @@ func validateSection(relPath, formLabel string, idx int, raw any, r *Rules) []st
 			"%s: %s: invalid type %q; must be body|block|modal|float", relPath, secLabel, secType,
 		))
 	}
-	if vis, _ := section["visibility"].(string); vis != "" && !r.Visibility[vis] {
+	if vis, _ := section["visibility"].(string); vis != "" && !validVisibility(vis, r, true) {
 		errs = append(errs, fmt.Sprintf(
-			"%s: %s: invalid visibility %q; must be visible|disabled|hidden", relPath, secLabel, vis,
+			"%s: %s: invalid visibility %q; must be %s", relPath, secLabel, vis, visibilityPlaceholderValues,
 		))
 	}
 
-	for _, slot := range []string{"header", "content", "footer", "modalHeader"} {
+	// renderPage resolves item placeholders in these section slots.
+	for _, slot := range []string{"header", "content", "modalHeader"} {
 		items, _ := section[slot].([]any)
 		slotLabel := fmt.Sprintf("%s.%s", secLabel, slot)
-		errs = append(errs, validateItems(relPath, slotLabel, items, r)...)
+		errs = append(errs, validateItems(relPath, slotLabel, items, r, true)...)
 	}
+
+	// Keep validating the legacy slot, but do not accept placeholders that the
+	// server does not resolve.
+	footer, _ := section["footer"].([]any)
+	errs = append(errs, validateItems(relPath, secLabel+".footer", footer, r, false)...)
 	return errs
 }
 
-func validateItems(relPath, path string, items []any, r *Rules) []string {
+func validateItems(relPath, path string, items []any, r *Rules, allowVisibilityPlaceholder bool) []string {
 	var errs []string
 	for i, raw := range items {
 		item, _ := raw.(map[string]any)
@@ -182,9 +193,13 @@ func validateItems(relPath, path string, items []any, r *Rules) []string {
 			errs = append(errs, fmt.Sprintf(`%s: %s: missing required field "id"`, relPath, itemLabel))
 		}
 
-		if vis, _ := item["visibility"].(string); vis != "" && !r.Visibility[vis] {
+		if vis, _ := item["visibility"].(string); vis != "" && !validVisibility(vis, r, allowVisibilityPlaceholder) {
+			expected := visibilityValues
+			if allowVisibilityPlaceholder {
+				expected = visibilityPlaceholderValues
+			}
 			errs = append(errs, fmt.Sprintf(
-				"%s: %s: invalid visibility %q; must be visible|disabled|hidden", relPath, itemLabel, vis,
+				"%s: %s: invalid visibility %q; must be %s", relPath, itemLabel, vis, expected,
 			))
 		}
 
@@ -195,7 +210,7 @@ func validateItems(relPath, path string, items []any, r *Rules) []string {
 		// Recurse into row/draggable layout wrapper children.
 		if class == "row" || class == "draggable" {
 			nested, _ := item["items"].([]any)
-			errs = append(errs, validateItems(relPath, itemLabel+".items", nested, r)...)
+			errs = append(errs, validateItems(relPath, itemLabel+".items", nested, r, allowVisibilityPlaceholder)...)
 		}
 	}
 	return errs
@@ -338,4 +353,17 @@ func validateItemKeys(relPath, itemLabel, class string, item map[string]any, r *
 		}
 	}
 	return errs
+}
+
+func validVisibility(value string, r *Rules, allowPlaceholder bool) bool {
+	return r.Visibility[value] || allowPlaceholder && isViewModelPlaceholder(value)
+}
+
+func isViewModelPlaceholder(value string) bool {
+	if !strings.HasPrefix(value, "{{") || !strings.HasSuffix(value, "}}") {
+		return false
+	}
+
+	key := value[2 : len(value)-2]
+	return strings.TrimSpace(key) != "" && !strings.ContainsAny(key, "{}")
 }

--- a/plugins/simulator/skills/simulator-smart-forms/SKILL.md
+++ b/plugins/simulator/skills/simulator-smart-forms/SKILL.md
@@ -367,18 +367,19 @@ All substitution is **server-side** — the renderer receives concrete values.
 | `contentLoop` | section array expansion | one template → N rows |
 | BBCode | `label`/`button`/`edit`/`check` titles | `[b] [i] [u] [color=#f00] [size=N] [br]`, and `[url=https://…]text[/url]` → clickable `<a target="_blank">` (inline link; `[iurl=…]` opens same-tab; renderer supports more, e.g. `[bg]`). Raw `<a>` HTML is escaped — use `[url]`. |
 
-> ⚠️ **Not every field can be templated.** `visibility` is validated against the literal
-> enum `visible|disabled|hidden` at **push** time, so `"visibility": "{{show_it}}"` is
-> rejected and **a page cannot vary visibility on `/get` at all** — only `changes[]` on
-> `/send` can. `styleClass` *can* be templated, which makes the two look symmetric when they
-> are not. To show an empty state on `/get`, drive a `label`'s **value** from the viewModel.
+> ⚠️ **Visibility may be a view-model placeholder — but nothing else about it is reactive.**
+> Form, section, and rendered-item `visibility` (in `header`, `modalHeader`, and `content`) may be
+> a **pure** view-model placeholder such as `"{{graphPreviewVisibility}}"`; the server resolves it
+> to `visible|disabled|hidden` before the page reaches the client. Malformed or embedded forms
+> (`"state-{{x}}"`, `"{{ x }}"`, a bare enum typo) are rejected at **push**, and `footer` is not
+> server-rendered so a placeholder there is rejected too. This is initial/server-render binding, not
+> a client-side expression: to reveal one field after another changes, use `submitOnChange` plus a
+> 200 `changes` response.
 >
-> ⚠️ And a `label` value may **never** be the empty string (nor an `image` an empty src) —
-> the renderer rejects both. Use a non-breaking space for a blank-looking label. For an image
-> use a **fetchable** `http(s)` placeholder URL (or an actor-attached asset): `image.value` is
-> loaded through the `/api/1.0/image?src=` proxy, which rejects a `data:` URI with
-> `400 "URL is not allowed"`. Together these rules decide how you
-> build every empty state: control the **text**, not the visibility.
+> ⚠️ A `label` value may **never** be the empty string (nor an `image` an empty src) — the renderer
+> rejects both. Use a non-breaking space for a blank-looking label. For an image use a **fetchable**
+> `http(s)` placeholder URL (or an actor-attached asset): `image.value` is loaded through the
+> `/api/1.0/image?src=` proxy, which rejects a `data:` URI with `400 "URL is not allowed"`.
 
 ### locale file format
 


### PR DESCRIPTION
## What & why

`pushSmartForm` rejected page configs that used a pure `{{viewModelKey}}` placeholder for `visibility`, although pong-server resolves that field before the page reaches the CDU renderer.

This change accepts pure visibility placeholders for forms, sections, and rendered items in `header`, `modalHeader`, and `content`, including nested and `contentLoop` items. Malformed, embedded, and multiple placeholders remain invalid. The unsupported section `footer` slot is deliberately not broadened.

The Smart Form skill and CDU protocol reference now distinguish server-side visibility binding from client-side reactive visibility.

## Type of change

- [x] Bug fix
- [ ] New MCP tool / capability
- [x] Skill behaviour
- [x] Docs
- [ ] Chore / refactor

## Checklist

- [x] `make build && make vet && make test` pass locally
- [x] No tool was added or renamed
- [x] Skill frontmatter is unchanged; `make discovery` produces no diff
- [x] Reference docs remain under `plugins/simulator/docs/`
- [x] No tokens or `.env` committed; TLS behaviour is unchanged
- [x] Added an entry under `CHANGELOG.md` → `Unreleased`

## Notes for reviewers

Verified against pong-server template rendering: form and section visibility are injected explicitly, while rendered item properties are injected recursively. Placeholder values must resolve to `visible`, `disabled`, or `hidden`.