### PR TITLE
fix(cduschema): catch on push what only the browser caught before

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,22 @@
 - **Graph import/export tools — `exportGraph`, `importGraph`, `uploadGraphFile`, `getTaskStatus`.** Wraps the pong-server async task API so a workspace graph (actors, edges, forms, and optionally attachments / transactions / processes / users / balances) can be exported to a `.graph` archive or re-imported, mirroring the UI's Export/Import buttons — distinct from the existing `pullGraphFile`/`pushGraphFile` developer sync tools, which edit a single layer's YAML and never touch `.graph` archives. `exportGraph` requires at least one of `actors`/`forms`/`allWorkspace`; `uploadGraphFile` accepts a `.graph` file as base64 or a public URL (capped at 100 MiB either way) and returns a storage `fileName` for `importGraph`; `getTaskStatus` polls a task by id and, for a completed export, returns a ready-to-share `downloadUrl` alongside the raw `details.file.fileName`.
 
 ### Fixed
+- **`pushSmartForm` accepted item keys and nested shapes the renderer then rejected.** The swagger
+  sets `additionalProperties: false` nowhere, so the save endpoint stores a typo'd `visibilty` or a
+  `head[].id` verbatim and the defect surfaces only as a console error in the browser — the item
+  simply never hides, or the column list renders empty. `cduschema` now derives, from the bundled
+  swagger, the property surface of every item `class` and of the nested spots where the schema *is*
+  precise (`extra`, `options[]`, a table's `head[]` / `body[]`), and `ValidateFile` rejects a key no
+  variant declares. The allowlist is the **union** over every schema variant of a class, because the
+  swagger splits one class across type variants that each redeclare only part of the surface
+  (`value` is on `Edit-int` but not on `Edit-default`) — checking a single variant would reject
+  valid config. `TestProbeDocumentedKeysPresentInUnion` guards that assumption, so a swagger update
+  that drops a real key fails the tests instead of blocking users' pushes; a class with no derived
+  rule is skipped rather than rejected. Also transcribed three renderer-only rules the swagger
+  cannot express (it carries no `minLength` anywhere): a `label`/`image` `value` may not be an empty
+  string, an `image` `value` must be a URL the *server* can fetch (the renderer proxies it through
+  `/api/1.0/image?src=`, which rejects a `data:` URI outright). Documented in
+  `cdu-page-protocol.md` §5.1 / §10.1.
 - **Telemetry: unsynchronized `telemetryEmail` read/write.** The opt-in email was stored in a plain
   `var string`, written by `AskForEmailOnce` (after `login`) and read by `Middleware` on every tool
   call — safe under the current single-threaded stdio transport, but a data race under `go test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,8 +47,13 @@
   warning (the bound process may fill it per request). Also reports a `label`/`image` bound to a
   default of `""` (the renderer rejects an empty value), a default no page references, and — for a
   *literal* `contentLoop` — the exact entries missing a key the template uses. Placeholders inside a
-  *templated* `contentLoop` are backend-filled and never reported, so list pages stay quiet.
-  Warnings are surfaced on a successful push under a new `warnings` field.
+  *templated* `contentLoop` are backend-filled and never reported, so list pages stay quiet; only a
+  section's `content` is loop-scoped, and `regexp`/`mask` are skipped entirely so a character class
+  like `^[[:alpha:]]+$` is not read as a locale token. A locale miss blocks only when the page or one
+  of the locale files feeding it is part of the push — the same miss in an untouched page is
+  pre-existing debt and is reported as a warning, because `pushSmartForm` has no force flag and
+  aborting on it would strand an unrelated fix. Warnings are surfaced on a successful push under a
+  new `warnings` field.
 - **`pushSmartForm` accepted item keys and nested shapes the renderer then rejected.** The swagger
   sets `additionalProperties: false` nowhere, so the save endpoint stores a typo'd `visibilty` or a
   `head[].id` verbatim and the defect surfaces only as a console error in the browser — the item
@@ -58,13 +63,20 @@
   variant declares. The allowlist is the **union** over every schema variant of a class, because the
   swagger splits one class across type variants that each redeclare only part of the surface
   (`value` is on `Edit-int` but not on `Edit-default`) — checking a single variant would reject
-  valid config. `TestProbeDocumentedKeysPresentInUnion` guards that assumption, so a swagger update
-  that drops a real key fails the tests instead of blocking users' pushes; a class with no derived
-  rule is skipped rather than rejected. Also transcribed three renderer-only rules the swagger
-  cannot express (it carries no `minLength` anywhere): a `label`/`image` `value` may not be an empty
-  string, an `image` `value` must be a URL the *server* can fetch (the renderer proxies it through
-  `/api/1.0/image?src=`, which rejects a `data:` URI outright). Documented in
-  `cdu-page-protocol.md` §5.1 / §10.1.
+  valid config. The union is then widened with the fields the
+  renderer accepts but the swagger omits — the §4 base envelope (`value`, `required`, `error`,
+  `errorMsg`, `submitOnChange`, `extra`) plus the §5 rows the swagger under-describes
+  (`mainMenu.options`, `carousel.items`, `comments.title`, `timer.extra.duration`,
+  `file.extra.{downloadUrl,uploadUrl,auth}`, `upload.extra.compression`,
+  `attachment.extra.downloadUrl`) — because the derived union alone was NARROWER than the documented
+  protocol and rejected those shapes outright. `TestProbeDocumentedKeysPresentInUnion` now walks the
+  whole §5 table rather than a hand-picked subset, so a swagger update that drops a real key fails
+  the tests instead of blocking users' pushes; a class the swagger never described (`row`,
+  `draggable`) keeps no rule and is skipped rather than rejected. Also transcribed the renderer-only
+  rules the swagger cannot express (it carries no `minLength` anywhere): a `label`/`image` `value`
+  may not be an empty string, and an `image` `value` may not be a `data:` URI — the renderer proxies
+  it through `/api/1.0/image?src=`, which rejects the scheme with `400 "URL is not allowed"`.
+  Documented in `cdu-page-protocol.md` §5.1 / §10.1.
 - **Telemetry: unsynchronized `telemetryEmail` read/write.** The opt-in email was stored in a plain
   `var string`, written by `AskForEmailOnce` (after `login`) and read by `Middleware` on every tool
   call — safe under the current single-threaded stdio transport, but a data race under `go test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,19 @@
 - **Graph import/export tools — `exportGraph`, `importGraph`, `uploadGraphFile`, `getTaskStatus`.** Wraps the pong-server async task API so a workspace graph (actors, edges, forms, and optionally attachments / transactions / processes / users / balances) can be exported to a `.graph` archive or re-imported, mirroring the UI's Export/Import buttons — distinct from the existing `pullGraphFile`/`pushGraphFile` developer sync tools, which edit a single layer's YAML and never touch `.graph` archives. `exportGraph` requires at least one of `actors`/`forms`/`allWorkspace`; `uploadGraphFile` accepts a `.graph` file as base64 or a public URL (capped at 100 MiB either way) and returns a storage `fileName` for `importGraph`; `getTaskStatus` polls a task by id and, for a completed export, returns a ready-to-share `downloadUrl` alongside the raw `details.file.fileName`.
 
 ### Fixed
+- **`pushSmartForm` could not see cross-file token defects, so an unresolved `[[key]]` shipped
+  silently.** `cduschema.ValidateFile` is per-file by signature — it can never tell whether a
+  page's `[[key]]` resolves against the locale files or whether a `{{key}}` has a viewModel default
+  — and the save endpoint stores page source opaquely, so nothing reported it until a literal
+  `[[key]]` appeared in the browser. New `cduschema.ValidateTree` audits the whole env tree (not
+  only the files being written: deleting a viewModel default breaks an untouched page) and
+  `pushSmartForm` runs it alongside the per-file pass. A missing **locale** key is an error (locale
+  resolves from files only; nothing at runtime can supply it); a missing **viewModel** default is a
+  warning (the bound process may fill it per request). Also reports a `label`/`image` bound to a
+  default of `""` (the renderer rejects an empty value), a default no page references, and — for a
+  *literal* `contentLoop` — the exact entries missing a key the template uses. Placeholders inside a
+  *templated* `contentLoop` are backend-filled and never reported, so list pages stay quiet.
+  Warnings are surfaced on a successful push under a new `warnings` field.
 - **`pushSmartForm` accepted item keys and nested shapes the renderer then rejected.** The swagger
   sets `additionalProperties: false` nowhere, so the save endpoint stores a typo'd `visibilty` or a
   `head[].id` verbatim and the defect surfaces only as a console error in the browser — the item

--- a/plugins/simulator/docs/user-flows/cdu-page-protocol.md
+++ b/plugins/simulator/docs/user-flows/cdu-page-protocol.md
@@ -245,6 +245,21 @@ Every entry in a section's `header`/`content` is an **Item**, dispatched by its 
 `visibility`, `required`, `error`, `value`, and `options` are the fields most commonly mutated
 by a 200-response `change` (§7).
 
+> ⚠️ **A `label` value may never be an empty string, and an `image` value may never be an
+> empty src** — the client rejects both with `"value" is not allowed to be empty`. This
+> collides with the rule above: the obvious way to say "nothing here" is `""`, and that is
+> exactly what fails. Use a non-breaking space for a blank-looking label; for an image, point at
+> a placeholder the server can **fetch**. Neither rule is in the swagger (it carries
+> no `minLength` anywhere), so only the renderer enforces them.
+>
+> ⚠️ **An `image` value must be a fetchable URL — a `data:` URI does not work.** The renderer
+> never loads `image.value` directly; it proxies it through `/api/1.0/image?src=<urlencoded>`,
+> and that proxy rejects the scheme: `400 {"statusCode":400,"message":"URL is not allowed"}`.
+> An unreachable host fails the same way with `"Failed to fetch image"`, so a placeholder has
+> to be an `http(s)` URL the *server* can reach, or an actor-attached asset (those are internal
+> and not proxied). This applies to component values only — `url()` in your Less is rewritten
+> for `https://` sources only, so a `data:` URI there is untouched and works.
+
 ---
 
 ## 5. Component catalogue
@@ -277,16 +292,16 @@ All component `class` values (renderer `ComponentClasses`). Most are content/inp
 | `otp` | input | `value` (object `otp-0…otp-N`), `type`, `extra.length` (2–20) | one-time-code boxes; `type`: `text`\|`int` |
 | `label` | display | `value` (string), `align`, `tooltip` | static text; BBCode-rendered; `align`: `left`\|`center`\|`right` |
 | `divider` | display | — | separator |
-| `image` | display | `value` (src), `extra.{alt,height,width}` | static image |
+| `image` | display | `value` (src, **never empty**), `extra.alt` | static image. `extra` accepts **only** `alt` — `height`/`width` are rejected by the renderer; size it with CSS via `styleClass`. |
 | `copy` | action | `value` (text), `title` | copy-to-clipboard |
 | `file` | file | `value` (FileProps), `extra.{downloadUrl,uploadUrl,auth}` | preview/download |
 | `upload` | file | `value` (FileProps), `type`, `extra.{accept,minSize,maxSize,compression}` | `type`: `default`\|`webcam` |
 | `attachment` | file | `value` (FileProps[]), `extra.downloadUrl` | multi-file viewer |
 | `signature` | file | `value` (FileProps), `extra.{strokeStyle,saveButtonTitle}` | canvas signature → base64 |
 | `carousel` | display | `items[]`, `value` (index), `extra.{autoplay,interval}` | slideshow |
-| `table` | data | `head[]`, `body[]`, `value`, `type`, `submitOnChange`, `submitOnScroll` | `type`: `default` `radio` `check`; row groups; cell buttons/checkboxes/copy |
-| `tab` | nav | `options[]`, `value` (selected), `submitOnChange` | tab switcher with per-tab error |
-| `stepper` | nav | `options[]`, `value` (step), `extra.direction` | step indicator (wizard) |
+| `table` | data | `head[]`, `body[]`, `value`, `type`, `submitOnChange`, `submitOnScroll` | `type`: `default` `radio` `check`. **Column key is `value`, not `id`**, and row cells live in `body[].options[]` — see §5.1. Row groups; cell buttons/checkboxes/copy |
+| `tab` | nav | `options[]` (`{value,title}`), `value` (selected option's `value`), `submitOnChange` | tab switcher with per-tab error |
+| `stepper` | nav | `options[]` (`{value,title,completed}`), `value` (current option's `value`), `extra.mobileVisible` | step indicator (wizard); advance it with a `changes[]` patch on `value`. `extra` holds **only** `mobileVisible` — there is no `extra.direction`, and `steps`/`active` belong to the **page header** (`grid.header.class` = `steps`, §3.1), which is a different component. |
 | `mainMenu` | nav | `options[]`, `value` | nested menu |
 | `comments` | display | `value`, `title` | comment thread widget |
 | `timer` | display | `value` (remaining ms), `extra.duration` | countdown |
@@ -298,6 +313,38 @@ All component `class` values (renderer `ComponentClasses`). Most are content/inp
 > `Edit-int` vs `Edit-date`, `Table-group`, `Widget-onfido`) are enumerated in the canonical
 > swagger ("Simulator.Company Scripts", `components.schemas`). Treat that spec as the source of
 > truth for individual component options.
+
+### 5.1 `table` — the exact `head` / `body` shape
+
+Getting this wrong is the most common table bug, because the server accepts the wrong shape
+and only the client rejects it (see the asymmetry note in §10):
+
+```jsonc
+{
+  "id": "history_tx", "class": "table", "type": "default",
+  "head": [                                 // column key is `value`, NOT `id`
+    { "value": "date",   "title": "Date" },
+    { "value": "amount", "title": "Amount" }
+  ],
+  "body": [                                 // in practice "{{a_viewModel_key}}"
+    { "value": "row_0",                     // the ROW's own id
+      "options": [                          // the row's CELLS
+        { "value": "date",   "title": "23.06.2026 18:27" },
+        { "value": "amount", "title": "429.00" }
+      ] }
+  ]
+}
+```
+
+- `head[]` items allow `value`, `title`, `visibility`, `styleClass`, `isSticky`.
+- `body[]` items allow `value`, `options`, `groupValue`, `styleClass`, `clickable`.
+- A cell is `{value: <column key>, title: <displayed text>}`, or carries a `button`,
+  `check`, `copy` or `file` sub-object instead of `title`.
+- **Column keys as direct row properties (`{"value":"row_0","date":"..."}`) do not work.**
+
+`value` — not `id` — is the key in **three** places that look like they should use `id`:
+`table.head[]`, `tab.options[]` and `stepper.options[]`. Assume `value` for any option or
+column list you meet on a new component.
 
 > **`mainMenu` inline-vs-popover depth** — `mainMenu.extra.maxInlineDepth` (default **1**) sets how
 > deep branches expand **inline** (accordion, via native `<details>`); levels below it open as a
@@ -327,6 +374,30 @@ shape the page **before** it reaches the renderer. All are resolved server-side
 - **`contentLoop`** — a section can declare a `contentLoop` that the server expands into
   repeated `content` items (one per data row), so a single template renders a list. On submit
   responses, `replaceContentLoopWithContent` re-expands the loop for the affected form.
+
+  **The binding, which is easy to miss:** `contentLoop` is an *array of plain variable bags*,
+  and the section's `content` is the **template** re-substituted once per entry. Each entry's
+  keys fill `{{...}}` placeholders inside that template — they are not component fields.
+
+  ```jsonc
+  {
+    "id": "promo_list", "type": "body",
+    "contentLoop": [                                  // one entry per rendered row
+      { "img": "https://…/1.jpg", "text": "Offer 1", "url": "https://…" },
+      { "img": "https://…/2.jpg", "text": "Offer 2", "url": "https://…" }
+    ],
+    "content": [                                      // rendered once per entry
+      { "id": "promo_img",  "class": "image",  "value": "{{img}}",  "extra": {"alt": "{{text}}"} },
+      { "id": "promo_text", "class": "label",  "value": "{{text}}" },
+      { "id": "promo_btn",  "class": "button", "title": "Open", "extra": {"url": "{{url}}"} }
+    ]
+  }
+  ```
+
+  Item `id`s inside the template repeat across iterations, so address a specific row through
+  the loop, not through `changes[]` on a bare id. To feed the loop from the backend, bind the
+  whole array — `"contentLoop": "{{promos_loop}}"` — the same way a `table` binds
+  `"body": "{{rows}}"`; verify once against a live render before relying on it.
 - **`bbcode`** — `label`/`button`/`edit`/`check` titles support BBCode, rendered to HTML by the
   client (`Utils.bbCodeToHtml`). Supported tags (verified live): `[b]` `[i]` `[u]` `[color=#rgb]`
   `[size=N]` `[br]`, and **`[url=https://…]text[/url]`** which renders a **clickable
@@ -372,6 +443,13 @@ re-render (renderer `handleResponseChanges`, applied at form / section / item gr
   `concat` (append), `unshift` (prepend), `delete`, `replace`, `merge`.
 - **`skipSubmitOnChange`** prevents a feedback loop when a change updates a value on a
   `submitOnChange` component.
+
+> ⚠️ **A change cannot patch `extra`.** The patchable surface is the list above —
+> `value`, `visibility`, `error`, `required`, `options`, `styleClass`, `body`. Anything
+> configured through `extra` (a button's `url`, a timer's `duration`, a table's `page`) is
+> fixed for the life of the rendered page. When you need a component to change at runtime,
+> check that the property you intend to drive is patchable *before* you design the flow
+> around it; otherwise pick a component whose state lives in `value`.
 
 `ctrl[]` entries in a 200 response are forwarded as `postMessage` to the parent frame
 (host-app integration hook).
@@ -456,6 +534,36 @@ but **not** the page content. The `source` (the `config` JSON, `viewModel`, `loc
 gaps in `renderPage`. **The contract is enforced by convention and by the renderer, not by the
 save endpoint** — so authoring tooling should validate page JSON against the canonical swagger
 schemas *before* saving.
+
+### 10.1 The validation asymmetry — why a page can pass the server and fail the browser
+
+Schema-validating against the swagger is necessary but **not sufficient**, and the gap has a
+specific cause worth knowing:
+
+> **No component schema in the swagger sets `additionalProperties: false`, while the client
+> renderer's validator is strict.** So an unknown key — `head[].id`, `image.extra.height`,
+> a typo'd `visibilty` — passes every server-side check, is stored, is served, and then fails
+> in `control-cdu` as a console error such as `"head[0].id" is not allowed`.
+
+Two consequences for anyone driving this protocol from a tool:
+
+1. **A clean `appGetPage` response proves very little.** It returns the *server-resolved* config,
+   so it confirms templating resolved and the backend answered — but it neither compiles CSS nor
+   runs the client validator. A page can render as valid JSON with every placeholder substituted
+   and still be rejected component-by-component in the browser.
+2. **Check unknown keys explicitly**, against the swagger's declared property sets. Two details
+   make this practical rather than noisy:
+   - The same class is split across type variants (`Edit-default`, `Edit-text`, `Edit-date`, …),
+     each redeclaring only part of the surface, so the allowlist for a class must be the
+     **union over every variant that claims it**. Checking one variant reports legal keys as
+     unknown (`value` is declared on `Edit-int`, not on `Edit-default`).
+   - A handful of rules are **client-only and absent from the swagger** — the non-empty `value`
+     on `label`/`image` above is the notable pair, and the swagger carries no `minLength` at
+     all, so these cannot be derived and must be listed by hand.
+
+`pushSmartForm` performs these checks (`mcp-server/internal/cduschema`): unknown item keys,
+unknown keys inside `extra` / `options[]` / a table's `head[]` and `body[]`, the client-only
+non-empty rules, and a specific message when `visibility` is templated.
 
 Smart-form **install/import** (`smartForms.js`) likewise validates only the request envelope
 (`fileUrl`, `ref`, `title` required; `ref` uniqueness) — the imported package's page content is
@@ -561,6 +669,12 @@ So an `edit` with `visibility:"visible"` but a `styleClass` that hides it in CSS
 (`position:absolute; width:1px; clip:rect(0 0 0 0)`) is invisible yet **still submitted** — the
 idiomatic carrier for a value set by `changes[]` (e.g. the selection behind button-cards). A field
 with `visibility:"hidden"` is NOT submitted.
+
+⚠️ **Scope: a submit collects one form, not the page.** The carrier only reaches the handler when it
+sits in the *same* form as the button that fired. A page whose nav buttons live in their own
+header/appbar form and whose carriers live in the content form submits `data: {}` on every nav
+click — the carrier is on the page but not in the form. Either repeat the carrier in each form that
+has a button, or have the handler fall back to `body.query`, which is sent on `/send` as well.
 
 ### 12.7 `table type:"group"` hides ungrouped rows; its pager sits outside the rows
 Numbered table pagination requires **`type:"group"`** (a `default` table has no page controls) with

--- a/plugins/simulator/mcp-server/internal/cduschema/probe_test.go
+++ b/plugins/simulator/mcp-server/internal/cduschema/probe_test.go
@@ -1,0 +1,34 @@
+package cduschema
+
+import "testing"
+
+// Keys the docs present as real and that a form is likely to use. If any is absent
+// from the swagger-derived union, a blanket top-level key check would reject legal
+// config, so it must not be enabled.
+func TestProbeDocumentedKeysPresentInUnion(t *testing.T) {
+	r := GetRules()
+	want := map[string][]string{
+		"edit":   {"value", "type", "title", "required", "error", "errorMsg", "helpMsg", "placeholder", "regexp", "mask", "submitOnEnter", "resettable", "extra", "submitOnChange"},
+		"table":  {"head", "body", "value", "type", "submitOnChange", "submitOnScroll", "extra"},
+		"select": {"value", "options", "type", "submitOnChange", "submitOnScroll"},
+		"button": {"title", "type", "tooltip", "extra"},
+		"label":  {"value", "align", "tooltip"},
+		"radio":  {"value", "options", "extra", "submitOnChange"},
+		"check":  {"value", "required", "title"},
+		"toggle": {"value", "title"},
+		"image":  {"value", "extra", "align"},
+		"copy":   {"value", "title"},
+	}
+	for class, keys := range want {
+		allowed := r.ItemProps[class]
+		if len(allowed) == 0 {
+			t.Errorf("%s: no ItemProps derived", class)
+			continue
+		}
+		for _, k := range keys {
+			if !allowed[k] {
+				t.Errorf("%s: documented key %q missing from swagger union", class, k)
+			}
+		}
+	}
+}

--- a/plugins/simulator/mcp-server/internal/cduschema/probe_test.go
+++ b/plugins/simulator/mcp-server/internal/cduschema/probe_test.go
@@ -2,33 +2,107 @@ package cduschema
 
 import "testing"
 
-// Keys the docs present as real and that a form is likely to use. If any is absent
-// from the swagger-derived union, a blanket top-level key check would reject legal
-// config, so it must not be enabled.
+// Every key `docs/user-flows/cdu-page-protocol.md` presents as real must survive
+// into the derived union, because ValidateFile rejects — and so aborts a push on —
+// anything outside it. The first cut of this test listed ten classes and missed
+// exactly the ones the swagger under-describes (mainMenu, carousel, comments,
+// timer, file, upload, attachment), so the table below now mirrors §5 row for row.
+// A class the swagger never described has no rule at all and is skipped by the
+// check; those are asserted separately at the bottom.
+
+// §4 "Item — the component envelope" — the renderer's baseSchema, shared by every class.
+var documentedBaseFields = []string{
+	"id", "class", "value", "visibility", "required", "error", "errorMsg",
+	"styleClass", "row", "w", "submitOnChange", "extra",
+}
+
+// §5 "Components" — the "Key fields (beyond base)" column, one entry per row.
+var documentedItemKeys = map[string][]string{
+	"button":      {"title", "type", "tooltip", "extra"},
+	"edit":        {"value", "type", "placeholder", "regexp", "mask", "errorMsg", "helpMsg", "submitOnEnter", "resettable", "extra"},
+	"select":      {"value", "options", "type", "submitOnChange", "submitOnScroll"},
+	"multiselect": {"value", "options", "extra"},
+	"radio":       {"value", "options", "extra"},
+	"check":       {"value", "required"},
+	"toggle":      {"value", "title"},
+	"slider":      {"value", "extra"},
+	"phone":       {"value", "options", "regexp", "required"},
+	"otp":         {"value", "type", "extra"},
+	"label":       {"value", "align", "tooltip"},
+	"divider":     {},
+	"image":       {"value", "extra"},
+	"copy":        {"value", "title"},
+	"file":        {"value", "extra"},
+	"upload":      {"value", "type", "extra"},
+	"attachment":  {"value", "extra"},
+	"signature":   {"value", "extra"},
+	"carousel":    {"items", "value", "extra"},
+	"table":       {"head", "body", "value", "type", "submitOnChange", "submitOnScroll"},
+	"tab":         {"options", "value", "submitOnChange"},
+	"stepper":     {"options", "value", "extra"},
+	"mainMenu":    {"options", "value"},
+	"comments":    {"value", "title"},
+	"timer":       {"value", "extra"},
+	"widget":      {"type", "extra"},
+}
+
+// §5 — the `extra.{…}` sets the table spells out, for the nested spots where a
+// rule was actually derived. A spot with no derived rule is unchecked, so it
+// cannot produce a false positive and is not asserted here.
+var documentedExtraKeys = map[string][]string{
+	"button.extra":      {"url", "target", "action", "icon", "rounded", "mobileVisible", "request", "autoSubmit", "options"},
+	"edit.extra":        {"length", "lineNumbers"},
+	"multiselect.extra": {"length"},
+	"radio.extra":       {"direction"},
+	"slider.extra":      {"min", "max", "step"},
+	"otp.extra":         {"length"},
+	"image.extra":       {"alt"},
+	"file.extra":        {"downloadUrl", "uploadUrl", "auth"},
+	"upload.extra":      {"accept", "minSize", "maxSize", "compression"},
+	"attachment.extra":  {"downloadUrl"},
+	"signature.extra":   {"strokeStyle", "saveButtonTitle"},
+	"stepper.extra":     {"mobileVisible"},
+	"timer.extra":       {"duration"},
+}
+
 func TestProbeDocumentedKeysPresentInUnion(t *testing.T) {
 	r := GetRules()
-	want := map[string][]string{
-		"edit":   {"value", "type", "title", "required", "error", "errorMsg", "helpMsg", "placeholder", "regexp", "mask", "submitOnEnter", "resettable", "extra", "submitOnChange"},
-		"table":  {"head", "body", "value", "type", "submitOnChange", "submitOnScroll", "extra"},
-		"select": {"value", "options", "type", "submitOnChange", "submitOnScroll"},
-		"button": {"title", "type", "tooltip", "extra"},
-		"label":  {"value", "align", "tooltip"},
-		"radio":  {"value", "options", "extra", "submitOnChange"},
-		"check":  {"value", "required", "title"},
-		"toggle": {"value", "title"},
-		"image":  {"value", "extra", "align"},
-		"copy":   {"value", "title"},
-	}
-	for class, keys := range want {
+	for class, keys := range documentedItemKeys {
 		allowed := r.ItemProps[class]
 		if len(allowed) == 0 {
-			t.Errorf("%s: no ItemProps derived", class)
+			t.Errorf("%s: no ItemProps derived — the key check silently does nothing for this class", class)
 			continue
+		}
+		for _, k := range append(append([]string{}, documentedBaseFields...), keys...) {
+			if !allowed[k] {
+				t.Errorf("%s: documented key %q missing from the union — a push using it would be rejected", class, k)
+			}
+		}
+	}
+}
+
+func TestProbeDocumentedExtraKeysPresentInUnion(t *testing.T) {
+	r := GetRules()
+	for spot, keys := range documentedExtraKeys {
+		allowed := r.NestedProps[spot]
+		if len(allowed) == 0 {
+			continue // no derived rule: the nested check is off for this spot
 		}
 		for _, k := range keys {
 			if !allowed[k] {
-				t.Errorf("%s: documented key %q missing from swagger union", class, k)
+				t.Errorf("%s: documented key %q missing — a push using it would be rejected", spot, k)
 			}
+		}
+	}
+}
+
+// The layout wrappers are absent from the swagger on purpose (§5). They must stay
+// rule-less: deriving a partial rule would reject the `items[]` the docs show.
+func TestProbeLayoutWrappersHaveNoKeyRule(t *testing.T) {
+	r := GetRules()
+	for _, class := range []string{"row", "draggable"} {
+		if len(r.ItemProps[class]) > 0 {
+			t.Errorf("%s: unexpected key rule %v — the swagger does not describe this class", class, sortedKeys(r.ItemProps[class]))
 		}
 	}
 }

--- a/plugins/simulator/mcp-server/internal/cduschema/props.go
+++ b/plugins/simulator/mcp-server/internal/cduschema/props.go
@@ -1,0 +1,202 @@
+package cduschema
+
+import "encoding/json"
+
+// propResolver walks the bundled swagger, following $ref and flattening allOf, to
+// collect the property names a component schema declares. It exists because the
+// swagger composes component schemas through several layers of allOf/$ref, so the
+// declared surface of a class is not readable from any single schema node.
+//
+// Two swagger quirks shape this code:
+//
+//   - $ref paths address array elements by index (".../allOf/0/properties/class"),
+//     so the walker has to index lists as well as maps.
+//   - The same class is split across type variants (Edit-default, Edit-text,
+//     Edit-date, …) and each variant redeclares only part of the surface. A key
+//     legal on one variant is therefore absent from another, so the only safe
+//     allowlist for a class is the UNION over every schema that claims it.
+//     Checking against a single variant produces false positives — e.g. `value`
+//     is declared on Edit-int but not on Edit-default.
+type propResolver struct {
+	root map[string]any
+}
+
+// follow resolves a local JSON pointer such as "#/components/schemas/Label" or
+// "#/components/schemas/File/allOf/0", indexing arrays by their numeric segment.
+func (p propResolver) follow(ref string) any {
+	if len(ref) < 2 || ref[0] != '#' {
+		return nil
+	}
+	var cur any = p.root
+	start := 1
+	if ref[1] == '/' {
+		start = 2
+	}
+	for _, seg := range splitPath(ref[start:]) {
+		switch node := cur.(type) {
+		case map[string]any:
+			cur = node[seg]
+		case []any:
+			i, ok := atoi(seg)
+			if !ok || i < 0 || i >= len(node) {
+				return nil
+			}
+			cur = node[i]
+		default:
+			return nil
+		}
+		if cur == nil {
+			return nil
+		}
+	}
+	return cur
+}
+
+// props returns the property names declared by a schema node, flattening allOf and
+// following $ref. depth guards against a cyclic $ref chain.
+func (p propResolver) props(node any, depth int) map[string]bool {
+	out := map[string]bool{}
+	if depth > 16 {
+		return out
+	}
+	m, ok := node.(map[string]any)
+	if !ok {
+		return out
+	}
+	if ref, ok := m["$ref"].(string); ok {
+		return p.props(p.follow(ref), depth+1)
+	}
+	if allOf, ok := m["allOf"].([]any); ok {
+		for _, sub := range allOf {
+			for k := range p.props(sub, depth+1) {
+				out[k] = true
+			}
+		}
+	}
+	if props, ok := m["properties"].(map[string]any); ok {
+		for k := range props {
+			out[k] = true
+		}
+	}
+	return out
+}
+
+// child returns a named sub-schema of node (e.g. the "extra" property's schema),
+// resolving node through $ref/allOf first.
+func (p propResolver) child(node any, name string, depth int) any {
+	if depth > 16 {
+		return nil
+	}
+	m, ok := node.(map[string]any)
+	if !ok {
+		return nil
+	}
+	if ref, ok := m["$ref"].(string); ok {
+		return p.child(p.follow(ref), name, depth+1)
+	}
+	if props, ok := m["properties"].(map[string]any); ok {
+		if c, ok := props[name]; ok {
+			return c
+		}
+	}
+	if allOf, ok := m["allOf"].([]any); ok {
+		for _, sub := range allOf {
+			if c := p.child(sub, name, depth+1); c != nil {
+				return c
+			}
+		}
+	}
+	return nil
+}
+
+// itemsOf returns the "items" sub-schema of an array schema, following $ref/allOf.
+func (p propResolver) itemsOf(node any, depth int) any {
+	if depth > 16 {
+		return nil
+	}
+	m, ok := node.(map[string]any)
+	if !ok {
+		return nil
+	}
+	if ref, ok := m["$ref"].(string); ok {
+		return p.itemsOf(p.follow(ref), depth+1)
+	}
+	if it, ok := m["items"]; ok {
+		return it
+	}
+	if allOf, ok := m["allOf"].([]any); ok {
+		for _, sub := range allOf {
+			if it := p.itemsOf(sub, depth+1); it != nil {
+				return it
+			}
+		}
+	}
+	return nil
+}
+
+// classOf returns the single-value class enum a component schema pins, or "".
+func (p propResolver) classOf(schema any, depth int) string {
+	c := p.child(schema, "class", depth)
+	return p.singleEnum(c, 0)
+}
+
+func (p propResolver) singleEnum(node any, depth int) string {
+	if depth > 12 {
+		return ""
+	}
+	m, ok := node.(map[string]any)
+	if !ok {
+		return ""
+	}
+	if ref, ok := m["$ref"].(string); ok {
+		return p.singleEnum(p.follow(ref), depth+1)
+	}
+	if enum, ok := m["enum"].([]any); ok && len(enum) == 1 {
+		if s, ok := enum[0].(string); ok {
+			return s
+		}
+	}
+	if allOf, ok := m["allOf"].([]any); ok {
+		for _, sub := range allOf {
+			if v := p.singleEnum(sub, depth+1); v != "" {
+				return v
+			}
+		}
+	}
+	return ""
+}
+
+func splitPath(s string) []string {
+	var out []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '/' {
+			out = append(out, s[start:i])
+			start = i + 1
+		}
+	}
+	return append(out, s[start:])
+}
+
+func atoi(s string) (int, bool) {
+	if s == "" {
+		return 0, false
+	}
+	n := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return 0, false
+		}
+		n = n*10 + int(s[i]-'0')
+	}
+	return n, true
+}
+
+// decodeSwagger parses the embedded swagger into a generic map once.
+func decodeSwagger(data []byte) map[string]any {
+	var root map[string]any
+	if json.Unmarshal(data, &root) != nil {
+		return nil
+	}
+	return root
+}

--- a/plugins/simulator/mcp-server/internal/cduschema/regression_test.go
+++ b/plugins/simulator/mcp-server/internal/cduschema/regression_test.go
@@ -47,6 +47,11 @@ func TestValidatePageConfig_RegressionsFromLiveBuild(t *testing.T) {
 		 "options":[{"value":"1","title":"A"}],"extra":{"direction":"row"}}]}]}]}`,
 		want: "extra.direction is not allowed",
 	}, {
+		name: "image src as a data: URI",
+		cfg: `{"grid":{"type":"one_column"},"forms":[{"id":"f","sections":[{"id":"s","type":"body",
+		 "content":[{"id":"card_qr","class":"image","value":"data:image/gif;base64,R0lGOD","extra":{"alt":"QR"}}]}]}]}`,
+		want: "a data: URI is rejected by the image proxy",
+	}, {
 		name: "stepper option using id instead of value",
 		cfg: `{"grid":{"type":"one_column"},"forms":[{"id":"f","sections":[{"id":"s","type":"body",
 		 "content":[{"id":"reg_stepper","class":"stepper","value":"1",
@@ -77,7 +82,7 @@ func TestValidatePageConfig_NoFalsePositives(t *testing.T) {
 	  {"id":"sel","class":"select","type":"autocomplete","value":"","options":"{{opts}}","submitOnChange":true},
 	  {"id":"ch","class":"radio","title":"C","value":"","options":[{"value":"a","title":"A"}],
 	   "extra":{"direction":"row"}},
-	  {"id":"img","class":"image","value":"data:image/gif;base64,R0lGOD","extra":{"alt":"a"}},
+	  {"id":"img","class":"image","value":"https://cdn.example/placeholder.png","extra":{"alt":"a"}},
 	  {"id":"lbl","class":"label","value":" ","align":"center","styleClass":"hint"},
 	  {"id":"cp","class":"copy","value":"123","title":"Copy"},
 	  {"id":"btn","class":"button","type":"secondary","title":"Go","extra":{"url":"https://x","target":"_blank"}},
@@ -85,5 +90,30 @@ func TestValidatePageConfig_NoFalsePositives(t *testing.T) {
 	]}]}]}`
 	if errs := ValidateFile("pages/p/config", cfg); len(errs) > 0 {
 		t.Fatalf("expected no errors, got:\n%s", strings.Join(errs, "\n"))
+	}
+}
+
+// The swagger under-describes several classes, so the derived union alone rejected
+// shapes `cdu-page-protocol.md` §5 documents as real. Each line below is one of
+// those rows; the union is widened from the same table (schema.go/applySupplements)
+// and TestProbeDocumentedKeysPresentInUnion keeps the two in step.
+func TestValidatePageConfig_DocumentedShapesAccepted(t *testing.T) {
+	cases := map[string]string{
+		"mainMenu.options (§5)":     `{"id":"m","class":"mainMenu","value":"a","options":[{"value":"a","title":"A"}]}`,
+		"carousel.items (§5)":       `{"id":"c","class":"carousel","value":"0","items":[{"id":"a","class":"image","value":"https://x/y.png"}],"extra":{"autoplay":true,"interval":3}}`,
+		"comments.title (§5)":       `{"id":"cm","class":"comments","value":"x","title":"Chat"}`,
+		"timer.extra.duration (§5)": `{"id":"tm","class":"timer","value":"1000","extra":{"duration":10}}`,
+		"file.extra urls (§5)":      `{"id":"fl","class":"file","value":"x","extra":{"downloadUrl":"https://x","uploadUrl":"https://y","auth":"t"}}`,
+		"upload.extra.compression":  `{"id":"up","class":"upload","value":"x","type":"default","extra":{"compression":0.5}}`,
+		"attachment.extra url (§5)": `{"id":"at","class":"attachment","value":"x","extra":{"downloadUrl":"https://x"}}`,
+		"base fields on any class":  `{"id":"l","class":"label","value":"x","required":false,"error":false,"errorMsg":"e","submitOnChange":true}`,
+	}
+	for name, item := range cases {
+		t.Run(name, func(t *testing.T) {
+			cfg := `{"grid":{"type":"one_column"},"forms":[{"id":"f","sections":[{"id":"s","type":"body","content":[` + item + `]}]}]}`
+			if errs := ValidateFile("pages/p/config", cfg); len(errs) > 0 {
+				t.Fatalf("documented shape rejected:\n%s", strings.Join(errs, "\n"))
+			}
+		})
 	}
 }

--- a/plugins/simulator/mcp-server/internal/cduschema/regression_test.go
+++ b/plugins/simulator/mcp-server/internal/cduschema/regression_test.go
@@ -1,0 +1,89 @@
+package cduschema
+
+import (
+	"strings"
+	"testing"
+)
+
+// Each case is a defect that actually shipped to a browser during the Chudo
+// Loyalty build and was only caught by control-cdu's console errors.
+func TestValidatePageConfig_RegressionsFromLiveBuild(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  string
+		want string
+	}{{
+		name: "table head uses id instead of value",
+		cfg: `{"grid":{"type":"one_column"},"forms":[{"id":"f","sections":[{"id":"s","type":"body",
+		 "content":[{"id":"history_tx","class":"table","type":"default",
+		 "head":[{"id":"date","title":"Date"}],"body":[]}]}]}]}`,
+		want: "head[0].id is not allowed",
+	}, {
+		name: "table row cells as direct properties",
+		cfg: `{"grid":{"type":"one_column"},"forms":[{"id":"f","sections":[{"id":"s","type":"body",
+		 "content":[{"id":"t","class":"table","type":"default","head":[{"value":"date","title":"D"}],
+		 "body":[{"value":"row_0","date":"23.06.2026"}]}]}]}]}`,
+		want: "body[0].date is not allowed",
+	}, {
+		name: "image extra height",
+		cfg: `{"grid":{"type":"one_column"},"forms":[{"id":"f","sections":[{"id":"s","type":"body",
+		 "content":[{"id":"card_qr","class":"image","value":"https://x/y.png",
+		 "extra":{"alt":"QR","height":"140"}}]}]}]}`,
+		want: "extra.height is not allowed",
+	}, {
+		name: "empty label value",
+		cfg: `{"grid":{"type":"one_column"},"forms":[{"id":"f","sections":[{"id":"s","type":"body",
+		 "content":[{"id":"session_warning","class":"label","value":""}]}]}]}`,
+		want: "must not be an empty string",
+	}, {
+		name: "empty image src",
+		cfg: `{"grid":{"type":"one_column"},"forms":[{"id":"f","sections":[{"id":"s","type":"body",
+		 "content":[{"id":"promo_img_0","class":"image","value":"","extra":{"alt":"a"}}]}]}]}`,
+		want: "must not be an empty string",
+	}, {
+		name: "stepper extra.direction from the docs",
+		cfg: `{"grid":{"type":"one_column"},"forms":[{"id":"f","sections":[{"id":"s","type":"body",
+		 "content":[{"id":"reg_stepper","class":"stepper","value":"1",
+		 "options":[{"value":"1","title":"A"}],"extra":{"direction":"row"}}]}]}]}`,
+		want: "extra.direction is not allowed",
+	}, {
+		name: "stepper option using id instead of value",
+		cfg: `{"grid":{"type":"one_column"},"forms":[{"id":"f","sections":[{"id":"s","type":"body",
+		 "content":[{"id":"reg_stepper","class":"stepper","value":"1",
+		 "options":[{"id":"1","title":"A"}]}]}]}]}`,
+		want: "options[0].id is not allowed",
+	}}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			errs := ValidateFile("pages/p/config", c.cfg)
+			joined := strings.Join(errs, "\n")
+			if !strings.Contains(joined, c.want) {
+				t.Fatalf("expected an error containing %q, got:\n%s", c.want, joined)
+			}
+		})
+	}
+}
+
+// Shapes that are legal must not be reported. The `value` key on an edit is the
+// canary for the allOf-union rule: it is declared on Edit-int but not Edit-default.
+func TestValidatePageConfig_NoFalsePositives(t *testing.T) {
+	cfg := `{"grid":{"type":"one_column"},"forms":[{"id":"login","sections":[{"id":"b","type":"body","content":[
+	  {"id":"phone","class":"edit","type":"text","title":"Phone","value":"","required":true,
+	   "placeholder":"380","regexp":"^380[0-9]{9}$","helpMsg":"h","styleClass":"c","row":"1","w":"50"},
+	  {"id":"pass","class":"edit","type":"password","title":"P","value":""},
+	  {"id":"t","class":"table","type":"default","head":[{"value":"date","title":"D"}],
+	   "body":"{{rows}}","visibility":"visible"},
+	  {"id":"sel","class":"select","type":"autocomplete","value":"","options":"{{opts}}","submitOnChange":true},
+	  {"id":"ch","class":"radio","title":"C","value":"","options":[{"value":"a","title":"A"}],
+	   "extra":{"direction":"row"}},
+	  {"id":"img","class":"image","value":"data:image/gif;base64,R0lGOD","extra":{"alt":"a"}},
+	  {"id":"lbl","class":"label","value":" ","align":"center","styleClass":"hint"},
+	  {"id":"cp","class":"copy","value":"123","title":"Copy"},
+	  {"id":"btn","class":"button","type":"secondary","title":"Go","extra":{"url":"https://x","target":"_blank"}},
+	  {"id":"st","class":"stepper","value":"1","options":[{"value":"1","title":"A","completed":true}]}
+	]}]}]}`
+	if errs := ValidateFile("pages/p/config", cfg); len(errs) > 0 {
+		t.Fatalf("expected no errors, got:\n%s", strings.Join(errs, "\n"))
+	}
+}

--- a/plugins/simulator/mcp-server/internal/cduschema/schema.go
+++ b/plugins/simulator/mcp-server/internal/cduschema/schema.go
@@ -218,4 +218,66 @@ func collectProps(data []byte, r *Rules) {
 			}
 		}
 	}
+
+	applySupplements(r, add)
+}
+
+// applySupplements widens the swagger-derived allowlists with the fields the
+// renderer accepts but the bundled swagger omits. Without it the derived union is
+// NARROWER than the protocol this repo documents, and a push carrying a
+// documented shape (`mainMenu.options`, `carousel.items`, `file.extra.downloadUrl`,
+// …) is rejected outright. Provenance for every entry is
+// `docs/user-flows/cdu-page-protocol.md` §4 (base fields) and §5 (per-class table);
+// `TestProbeDocumentedKeysPresentInUnion` walks that same table and fails if any
+// documented key falls out of the union again.
+//
+// Two deliberate limits:
+//
+//   - a class the swagger never described keeps NO rule (the check stays off for
+//     it) — supplements only widen a union that already exists, they never switch
+//     a check on;
+//   - the same holds for a nested spot: `carousel.extra` has no derived rule, so
+//     it is left unchecked rather than pinned to the two keys the docs name.
+func applySupplements(r *Rules, add func(map[string]map[string]bool, string, map[string]bool)) {
+	// §4 "Item — the component envelope": the renderer's baseSchema. The swagger's
+	// File.allOf[0] carries only half of it (id, visibility, row, w, styleClass).
+	baseFields := setOf("id", "class", "value", "visibility", "required", "error",
+		"errorMsg", "styleClass", "row", "w", "submitOnChange", "extra")
+
+	// §5, per class — key fields the swagger's schema for that class does not declare.
+	itemSupplement := map[string]map[string]bool{
+		"carousel": setOf("items"),   // §5: `items[]`, `value` (index)
+		"mainMenu": setOf("options"), // §5: `options[]`, `value`
+		"comments": setOf("title"),   // §5: `value`, `title`
+	}
+
+	// §5, per nested spot — only widens a rule the swagger already produced.
+	nestedSupplement := map[string]map[string]bool{
+		"timer.extra":      setOf("duration"),                         // §5: extra.duration
+		"file.extra":       setOf("downloadUrl", "uploadUrl", "auth"), // §5: extra.{downloadUrl,uploadUrl,auth}
+		"upload.extra":     setOf("compression"),                      // §5: extra.{…,compression}
+		"attachment.extra": setOf("downloadUrl"),                      // §5: extra.downloadUrl
+		"edit.extra":       setOf("lineNumbers"),                      // §5: extra.{length,lineNumbers}
+	}
+
+	for class := range r.ItemProps {
+		add(r.ItemProps, class, baseFields)
+		if extra, ok := itemSupplement[class]; ok {
+			add(r.ItemProps, class, extra)
+		}
+	}
+	for key, extra := range nestedSupplement {
+		if len(r.NestedProps[key]) == 0 {
+			continue // no derived rule — the check is off, keep it off
+		}
+		add(r.NestedProps, key, extra)
+	}
+}
+
+func setOf(names ...string) map[string]bool {
+	out := make(map[string]bool, len(names))
+	for _, n := range names {
+		out[n] = true
+	}
+	return out
 }

--- a/plugins/simulator/mcp-server/internal/cduschema/schema.go
+++ b/plugins/simulator/mcp-server/internal/cduschema/schema.go
@@ -26,6 +26,19 @@ type Rules struct {
 
 	// GridType is the set of valid grid type values (one_column|two_column).
 	GridType map[string]bool
+
+	// ItemProps maps an item `class` to the union of property names every schema
+	// variant of that class declares, plus the shared base-item properties.
+	// The union is deliberate: see propResolver's doc comment — checking against a
+	// single variant reports legal keys as unknown.
+	ItemProps map[string]map[string]bool
+
+	// NestedProps maps "<class>.<field>" to the property names allowed inside that
+	// nested structure — "image.extra", "table.head" and "table.body" items,
+	// "<class>.options" items. These are the spots where the swagger IS precise and
+	// where the client renderer rejects extra keys even though the server accepts
+	// them (no schema sets additionalProperties:false).
+	NestedProps map[string]map[string]bool
 }
 
 var (
@@ -50,7 +63,9 @@ func parseRules(data []byte) *Rules {
 		// Extracted from Form.properties.sections.items.properties.type.enum
 		SectionType: map[string]bool{"body": true, "block": true, "modal": true, "float": true},
 		// Extracted from Page.properties.grid.properties.type.example / Page-grid-* discriminator mapping
-		GridType: map[string]bool{"one_column": true, "two_column": true},
+		GridType:    map[string]bool{"one_column": true, "two_column": true},
+		ItemProps:   make(map[string]map[string]bool),
+		NestedProps: make(map[string]map[string]bool),
 	}
 
 	// Decode only the components.schemas map — avoid holding the full 3 MB in memory.
@@ -138,5 +153,69 @@ func parseRules(data []byte) *Rules {
 	r.Classes["row"] = true
 	r.Classes["draggable"] = true
 
+	collectProps(data, r)
+
 	return r
+}
+
+// collectProps fills r.ItemProps and r.NestedProps by walking every component
+// schema in the swagger. Failure is silent and leaves the maps empty, which makes
+// the dependent checks skip rather than reject — a missing rule must never block a
+// push.
+func collectProps(data []byte, r *Rules) {
+	root := decodeSwagger(data)
+	if root == nil {
+		return
+	}
+	comps, _ := root["components"].(map[string]any)
+	schemas, _ := comps["schemas"].(map[string]any)
+	if schemas == nil {
+		return
+	}
+	p := propResolver{root: root}
+
+	// Every item inherits this base (id, visibility, row, w, styleClass).
+	base := map[string]bool{}
+	if f, ok := schemas["File"]; ok {
+		if allOf, ok := f.(map[string]any)["allOf"].([]any); ok && len(allOf) > 0 {
+			base = p.props(allOf[0], 0)
+		}
+	}
+
+	add := func(m map[string]map[string]bool, key string, names map[string]bool) {
+		if len(names) == 0 {
+			return
+		}
+		if m[key] == nil {
+			m[key] = map[string]bool{}
+		}
+		for n := range names {
+			m[key][n] = true
+		}
+	}
+
+	for _, schema := range schemas {
+		class := p.classOf(schema, 0)
+		if class == "" {
+			continue
+		}
+		add(r.ItemProps, class, p.props(schema, 0))
+		add(r.ItemProps, class, base)
+
+		if extra := p.child(schema, "extra", 0); extra != nil {
+			add(r.NestedProps, class+".extra", p.props(extra, 0))
+		}
+		if options := p.child(schema, "options", 0); options != nil {
+			if items := p.itemsOf(options, 0); items != nil {
+				add(r.NestedProps, class+".options", p.props(items, 0))
+			}
+		}
+		for _, field := range []string{"head", "body"} {
+			if f := p.child(schema, field, 0); f != nil {
+				if items := p.itemsOf(f, 0); items != nil {
+					add(r.NestedProps, class+"."+field, p.props(items, 0))
+				}
+			}
+		}
+	}
 }

--- a/plugins/simulator/mcp-server/internal/cduschema/tokens.go
+++ b/plugins/simulator/mcp-server/internal/cduschema/tokens.go
@@ -43,16 +43,45 @@ type TreeFindings struct {
 	Warnings []string
 }
 
+// route files a finding as an error when this push is what breaks it, and as a
+// warning otherwise — softSuffix says why it was downgraded.
+func (f *TreeFindings) route(blocking bool, msg, softSuffix string) {
+	if blocking {
+		f.Errors = append(f.Errors, msg)
+		return
+	}
+	f.Warnings = append(f.Warnings, msg+softSuffix)
+}
+
 // ValidateTree audits an entire Smart Form env tree for cross-file token defects
 // that no single-file check can see. files maps env-relative paths (the same keys
 // pushSmartForm collects: "locale", "viewModel", "pages/<id>/config",
-// "pages/<id>/locale", "definitions/<name>", …) to their source.
-//
-// Pass the WHOLE tree, not just the files being written: deleting a viewModel
-// default breaks an untouched page, and that is exactly the case a changed-files
-// audit would miss.
+// "pages/<id>/locale", "definitions/<name>", …) to their source. Every finding is
+// reported at full severity — see ValidateTreeScoped for the push-time variant.
 func ValidateTree(files map[string]string) TreeFindings {
+	return ValidateTreeScoped(files, nil)
+}
+
+// ValidateTreeScoped is ValidateTree with the severity of a locale miss decided by
+// what the caller is actually writing. changed holds the env-relative paths of the
+// files in this push; nil means "everything is in scope".
+//
+// The audit still reads the WHOLE tree — deleting a viewModel default breaks an
+// untouched page, and a changed-files-only audit would miss exactly that. But a
+// locale miss is only an ERROR when this push is what breaks it: the page config or
+// one of the locale files feeding it is being written. A miss in a page nobody
+// touched is pre-existing debt — it was already live before the push, aborting on it
+// would strand the user with no way to ship an unrelated fix (pushSmartForm has no
+// force flag), so it is reported as a warning instead.
+func ValidateTreeScoped(files map[string]string, changed map[string]bool) TreeFindings {
 	var f TreeFindings
+
+	// inScope reports whether a path is part of this push. A nil set means the
+	// caller did not scope the audit, so everything counts.
+	inScope := func(path string) bool { return changed == nil || changed[path] }
+	// Any locale file being written can be what removed a key, so it puts every
+	// page that resolves against it in scope.
+	localeTouched := inScope("locale")
 
 	appLocale := localeKeys(files["locale"])
 	viewModel := objectKeys(files["viewModel"])
@@ -90,14 +119,17 @@ func ValidateTree(files map[string]string) TreeFindings {
 		page, _ := pagePart(path, "config")
 		scan := scanConfig(files[path])
 
+		blocking := inScope(path) || localeTouched || inScope("pages/"+page+"/locale")
 		for _, k := range sortedKeys(scan.locale) {
 			if appLocale[k] || pageLocales[page][k] {
 				continue
 			}
-			f.Errors = append(f.Errors, fmt.Sprintf(
+			msg := fmt.Sprintf(
 				"%s: locale key [[%s]] is defined in neither `locale` nor `pages/%s/locale` — "+
 					"it will render as the literal text \"[[%s]]\" (locale is resolved from files only; "+
-					"the backend cannot supply it)", path, k, page, k))
+					"the backend cannot supply it)", path, k, page, k)
+			f.route(blocking, msg,
+				" [pre-existing: neither this page nor its locale files are part of this push]")
 		}
 
 		for _, k := range sortedKeys(scan.viewModel) {
@@ -136,13 +168,16 @@ func ValidateTree(files map[string]string) TreeFindings {
 	sort.Strings(defs)
 	for _, path := range defs {
 		scan := scanConfig(files[path])
+		blocking := inScope(path) || localeTouched
 		for _, k := range sortedKeys(scan.locale) {
 			if anyLocale[k] {
 				continue
 			}
-			f.Errors = append(f.Errors, fmt.Sprintf(
+			msg := fmt.Sprintf(
 				"%s: locale key [[%s]] is defined in no locale file — a $ref'd definition renders it "+
-					"as literal text on every page that inlines it", path, k))
+					"as literal text on every page that inlines it", path, k)
+			f.route(blocking, msg,
+				" [pre-existing: neither this definition nor any locale file is part of this push]")
 		}
 		for _, k := range sortedKeys(scan.viewModel) {
 			referenced[k] = true
@@ -231,22 +266,43 @@ func (s *configScan) walk(node any, inLoop bool) {
 			if k == "contentLoop" {
 				continue // already handled
 			}
-			s.walkString(k, child, loopHere)
-			s.walk(child, loopHere)
+			// Only the `content` template is expanded per loop entry. The section's
+			// own fields (`title`, `visibility`, …) are substituted once, from the
+			// viewModel like anywhere else — scoping them to the loop would drop
+			// real keys and then report their defaults as dead.
+			scoped := inLoop
+			if k == "content" {
+				scoped = loopHere
+			}
+			s.walkString(k, child, scoped)
+			s.walk(child, scoped)
 		}
 	case []any:
 		for _, child := range v {
+			// A string element is a leaf walk() itself ignores, so harvest it here.
+			// The field name is lost inside an array; "" opts into every check.
+			s.walkString("", child, inLoop)
 			s.walk(child, inLoop)
 		}
 	}
 }
 
+// literalBracketFields are the fields whose value is a pattern, not prose, so a
+// `[[…]]`/`{{…}}` run inside them is syntax rather than a token. `regexp` is the
+// live case: a character class such as `^[[:alpha:]]+$` matches localeTokenRe
+// exactly, and reporting it would abort the push over a locale key that was never
+// referenced.
+var literalBracketFields = map[string]bool{"regexp": true, "mask": true}
+
 // walkString harvests tokens out of a string leaf. Loop-scoped placeholders are
 // dropped: they are filled per contentLoop entry, so they are not viewModel keys
 // and treating them as such would false-positive on every list page.
-func (s *configScan) walkString(_ string, node any, inLoop bool) {
+func (s *configScan) walkString(field string, node any, inLoop bool) {
 	str, ok := node.(string)
 	if !ok {
+		return
+	}
+	if literalBracketFields[field] {
 		return
 	}
 	for _, m := range localeTokenRe.FindAllStringSubmatch(str, -1) {

--- a/plugins/simulator/mcp-server/internal/cduschema/tokens.go
+++ b/plugins/simulator/mcp-server/internal/cduschema/tokens.go
@@ -1,0 +1,359 @@
+package cduschema
+
+// Cross-file token audit.
+//
+// ValidateFile (validate.go) is deliberately per-file: it takes one relPath and
+// one source, so it can never see whether a `[[key]]` in a page resolves against
+// the locale files, or whether a `{{key}}` has a viewModel default. Those defects
+// therefore survive every server-side check — the app_content endpoint stores the
+// source opaquely, and pong-server substitutes whatever it finds and serves the
+// rest verbatim. The user meets them as a literal `[[key]]` on the rendered page.
+//
+// ValidateTree closes that gap by auditing the whole env tree at once. It runs
+// alongside the per-file pass in pushSmartForm.
+//
+// The error/warning split is deliberate and follows what the runtime can still
+// rescue:
+//
+//   - a missing LOCALE key is an ERROR. Locale is resolved purely from the static
+//     files (app locale merged with the page locale); nothing at runtime can
+//     supply it, so an unresolved `[[key]]` always reaches the browser as text.
+//   - a missing viewModel default is a WARNING. The Corezoid process returns a
+//     per-request viewModel that is merged over the defaults, so an undefaulted
+//     key may well be filled at runtime — it just renders as a literal `{{key}}`
+//     whenever the backend call fails, which is why it is still worth flagging.
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+var (
+	localeTokenRe = regexp.MustCompile(`\[\[([^\[\]]+)\]\]`)
+	vmTokenRe     = regexp.MustCompile(`\{\{([^{}]+)\}\}`)
+)
+
+// TreeFindings is the result of a cross-file audit. Errors should block a push;
+// Warnings are reported alongside a successful one.
+type TreeFindings struct {
+	Errors   []string
+	Warnings []string
+}
+
+// ValidateTree audits an entire Smart Form env tree for cross-file token defects
+// that no single-file check can see. files maps env-relative paths (the same keys
+// pushSmartForm collects: "locale", "viewModel", "pages/<id>/config",
+// "pages/<id>/locale", "definitions/<name>", …) to their source.
+//
+// Pass the WHOLE tree, not just the files being written: deleting a viewModel
+// default breaks an untouched page, and that is exactly the case a changed-files
+// audit would miss.
+func ValidateTree(files map[string]string) TreeFindings {
+	var f TreeFindings
+
+	appLocale := localeKeys(files["locale"])
+	viewModel := objectKeys(files["viewModel"])
+	emptyDefaults := emptyStringKeys(files["viewModel"])
+
+	// Every locale key defined anywhere — used to check definitions/, which are
+	// inlined into pages we cannot attribute statically.
+	anyLocale := map[string]bool{}
+	for k := range appLocale {
+		anyLocale[k] = true
+	}
+	pageLocales := map[string]map[string]bool{}
+	for path, src := range files {
+		if page, ok := pagePart(path, "locale"); ok {
+			keys := localeKeys(src)
+			pageLocales[page] = keys
+			for k := range keys {
+				anyLocale[k] = true
+			}
+		}
+	}
+
+	referenced := map[string]bool{} // every {{key}} any page/definition uses
+
+	// ── page configs ────────────────────────────────────────────────────────
+	pages := make([]string, 0, len(files))
+	for path := range files {
+		if _, ok := pagePart(path, "config"); ok {
+			pages = append(pages, path)
+		}
+	}
+	sort.Strings(pages)
+
+	for _, path := range pages {
+		page, _ := pagePart(path, "config")
+		scan := scanConfig(files[path])
+
+		for _, k := range sortedKeys(scan.locale) {
+			if appLocale[k] || pageLocales[page][k] {
+				continue
+			}
+			f.Errors = append(f.Errors, fmt.Sprintf(
+				"%s: locale key [[%s]] is defined in neither `locale` nor `pages/%s/locale` — "+
+					"it will render as the literal text \"[[%s]]\" (locale is resolved from files only; "+
+					"the backend cannot supply it)", path, k, page, k))
+		}
+
+		for _, k := range sortedKeys(scan.viewModel) {
+			referenced[k] = true
+			if viewModel[k] {
+				if emptyDefaults[k] && scan.bareValueOf[k] != "" {
+					f.Warnings = append(f.Warnings, fmt.Sprintf(
+						"%s: %s value is exactly \"{{%s}}\" and its `viewModel` default is the empty "+
+							"string — if the backend sends nothing the renderer rejects the item "+
+							"(\"value\" is not allowed to be empty). Default it to a non-breaking space "+
+							"(label), or a fetchable placeholder URL (image) — a data: URI is "+
+							"rejected by the image proxy", path, scan.bareValueOf[k], k))
+				}
+				continue
+			}
+			f.Warnings = append(f.Warnings, fmt.Sprintf(
+				"%s: {{%s}} has no default in `viewModel` — it renders as the literal \"{{%s}}\" "+
+					"whenever the backend does not supply it (e.g. a failed /get)", path, k, k))
+		}
+
+		// A section whose contentLoop is a LITERAL array can be checked exactly:
+		// every {{k}} in the template must be present in every entry. (A templated
+		// contentLoop is filled by the backend, so its template vars are silent.)
+		for _, issue := range scan.loopIssues {
+			f.Warnings = append(f.Warnings, path+": "+issue)
+		}
+	}
+
+	// ── definitions ─────────────────────────────────────────────────────────
+	defs := make([]string, 0, len(files))
+	for path := range files {
+		if strings.HasPrefix(path, "definitions/") {
+			defs = append(defs, path)
+		}
+	}
+	sort.Strings(defs)
+	for _, path := range defs {
+		scan := scanConfig(files[path])
+		for _, k := range sortedKeys(scan.locale) {
+			if anyLocale[k] {
+				continue
+			}
+			f.Errors = append(f.Errors, fmt.Sprintf(
+				"%s: locale key [[%s]] is defined in no locale file — a $ref'd definition renders it "+
+					"as literal text on every page that inlines it", path, k))
+		}
+		for _, k := range sortedKeys(scan.viewModel) {
+			referenced[k] = true
+		}
+	}
+
+	// ── dead viewModel defaults ─────────────────────────────────────────────
+	// A viewModel default exists only to back a page placeholder, so one that no
+	// page or definition references is dead weight (and usually a leftover from a
+	// removed component).
+	if len(pages) > 0 {
+		for _, k := range sortedKeys(viewModel) {
+			if !referenced[k] {
+				f.Warnings = append(f.Warnings, fmt.Sprintf(
+					"viewModel: key %q is referenced by no page or definition — dead default", k))
+			}
+		}
+	}
+
+	return f
+}
+
+// configScan is what one page config / definition contributed.
+type configScan struct {
+	locale    map[string]bool
+	viewModel map[string]bool
+	// bareValueOf[k] names the component class when an item's `value` is exactly
+	// "{{k}}" and the class is one the renderer rejects an empty value on.
+	bareValueOf map[string]string
+	// loopIssues holds findings about sections whose contentLoop is a literal
+	// array — there the entries are in the file, so the template's placeholders
+	// can be checked against them exactly.
+	loopIssues []string
+}
+
+// scanConfig walks a page config (or a definition fragment) and collects the
+// locale / viewModel tokens it uses. Placeholders inside a section whose
+// `contentLoop` is itself templated are loop-scoped: they are substituted from
+// the loop entries the backend returns, so they are NOT viewModel keys.
+func scanConfig(source string) configScan {
+	s := configScan{
+		locale:      map[string]bool{},
+		viewModel:   map[string]bool{},
+		bareValueOf: map[string]string{},
+	}
+	var root any
+	if err := json.Unmarshal([]byte(source), &root); err != nil {
+		return s // malformed JSON is already reported by ValidateFile
+	}
+	s.walk(root, false)
+	return s
+}
+
+func (s *configScan) walk(node any, inLoop bool) {
+	switch v := node.(type) {
+	case map[string]any:
+		// A section with a contentLoop makes its `content` template loop-scoped:
+		// those {{vars}} are substituted per entry, never from the viewModel.
+		loopHere := inLoop
+		if cl, ok := v["contentLoop"]; ok {
+			switch loop := cl.(type) {
+			case string:
+				// Bound from the viewModel — the ARRAY is the viewModel key; the
+				// template's own vars come from whatever the backend returns.
+				for _, m := range vmTokenRe.FindAllStringSubmatch(loop, -1) {
+					s.viewModel[strings.TrimSpace(m[1])] = true
+				}
+			case []any:
+				// Literal entries: they are right here, so check them exactly.
+				s.checkLiteralLoop(v, loop)
+			}
+			loopHere = true
+		}
+
+		// Remember components whose `value` is a single bare placeholder and whose
+		// class rejects an empty value.
+		if cls, ok := v["class"].(string); ok && (cls == "label" || cls == "image") {
+			if val, ok := v["value"].(string); ok {
+				if m := vmTokenRe.FindStringSubmatch(val); m != nil && strings.TrimSpace(val) == m[0] {
+					s.bareValueOf[strings.TrimSpace(m[1])] = cls
+				}
+			}
+		}
+
+		for k, child := range v {
+			if k == "contentLoop" {
+				continue // already handled
+			}
+			s.walkString(k, child, loopHere)
+			s.walk(child, loopHere)
+		}
+	case []any:
+		for _, child := range v {
+			s.walk(child, inLoop)
+		}
+	}
+}
+
+// walkString harvests tokens out of a string leaf. Loop-scoped placeholders are
+// dropped: they are filled per contentLoop entry, so they are not viewModel keys
+// and treating them as such would false-positive on every list page.
+func (s *configScan) walkString(_ string, node any, inLoop bool) {
+	str, ok := node.(string)
+	if !ok {
+		return
+	}
+	for _, m := range localeTokenRe.FindAllStringSubmatch(str, -1) {
+		s.locale[strings.TrimSpace(m[1])] = true
+	}
+	if inLoop {
+		return
+	}
+	for _, m := range vmTokenRe.FindAllStringSubmatch(str, -1) {
+		s.viewModel[strings.TrimSpace(m[1])] = true
+	}
+}
+
+// checkLiteralLoop verifies a section whose contentLoop entries are written out
+// in the file: every {{var}} the content template uses must exist in every entry,
+// or that row renders a literal "{{var}}".
+func (s *configScan) checkLiteralLoop(section map[string]any, entries []any) {
+	content, ok := section["content"]
+	if !ok {
+		return
+	}
+	raw, err := json.Marshal(content)
+	if err != nil {
+		return
+	}
+	used := map[string]bool{}
+	for _, m := range vmTokenRe.FindAllStringSubmatch(string(raw), -1) {
+		used[strings.TrimSpace(m[1])] = true
+	}
+	if len(used) == 0 {
+		return
+	}
+	label := "a section"
+	if id, ok := section["id"].(string); ok && id != "" {
+		label = "section " + quote(id)
+	}
+	for _, key := range sortedKeys(used) {
+		var missing []string
+		for i, e := range entries {
+			entry, ok := e.(map[string]any)
+			if !ok || entry[key] == nil {
+				missing = append(missing, itoa(i))
+			}
+		}
+		if len(missing) == 0 {
+			continue
+		}
+		s.loopIssues = append(s.loopIssues, fmt.Sprintf(
+			"%s has literal `contentLoop` entries and its template uses {{%s}}, but entr%s %s "+
+				"do not carry that key — those rows render the literal \"{{%s}}\"",
+			label, key, plural(len(missing), "y", "ies"), strings.Join(missing, ", "), key))
+	}
+}
+
+func quote(s string) string { return "\"" + s + "\"" }
+
+func itoa(i int) string { return fmt.Sprintf("%d", i) }
+
+func plural(n int, one, many string) string {
+	if n == 1 {
+		return one
+	}
+	return many
+}
+
+// pagePart reports the page id when path is "pages/<id>/<base>".
+func pagePart(path, base string) (string, bool) {
+	parts := strings.Split(path, "/")
+	if len(parts) == 3 && parts[0] == "pages" && parts[2] == base {
+		return parts[1], true
+	}
+	return "", false
+}
+
+// localeKeys returns the top-level keys of a locale file.
+func localeKeys(source string) map[string]bool { return objectKeys(source) }
+
+// objectKeys returns the top-level keys of a JSON object, or an empty set.
+func objectKeys(source string) map[string]bool {
+	out := map[string]bool{}
+	if source == "" {
+		return out
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(source), &m); err != nil {
+		return out
+	}
+	for k := range m {
+		out[k] = true
+	}
+	return out
+}
+
+// emptyStringKeys returns the keys whose value is exactly "".
+func emptyStringKeys(source string) map[string]bool {
+	out := map[string]bool{}
+	if source == "" {
+		return out
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(source), &m); err != nil {
+		return out
+	}
+	for k, v := range m {
+		if s, ok := v.(string); ok && s == "" {
+			out[k] = true
+		}
+	}
+	return out
+}

--- a/plugins/simulator/mcp-server/internal/cduschema/tokens_test.go
+++ b/plugins/simulator/mcp-server/internal/cduschema/tokens_test.go
@@ -221,3 +221,109 @@ func TestValidateTreeNoPagesIsSilent(t *testing.T) {
 		t.Errorf("expected no findings for a page-less env, got errors=%v warnings=%v", f.Errors, f.Warnings)
 	}
 }
+
+// A `[[…]]` run inside a pattern field is regex syntax, not a locale token. This
+// one aborted the push over a locale key nobody ever wrote.
+func TestValidateTreeIgnoresBracketsInPatternFields(t *testing.T) {
+	files := map[string]string{
+		"locale":    `{}`,
+		"viewModel": `{}`,
+		"pages/p/config": `{"grid":{"type":"one_column"},"forms":[{"id":"f","sections":[{"id":"s","type":"body",
+		  "content":[{"id":"e","class":"edit","type":"text","value":"","regexp":"^[[:alpha:]]+$","mask":"[[0-9]]"}]}]}]}`,
+	}
+	f := ValidateTree(files)
+	if len(f.Errors) != 0 {
+		t.Errorf("a character class in `regexp`/`mask` must not be read as a locale token: %v", f.Errors)
+	}
+}
+
+// Only a section's `content` is expanded per loop entry. Its own fields are
+// substituted once, from the viewModel — scoping them to the loop dropped the key
+// and then reported its default as dead.
+func TestValidateTreeSectionFieldsAreNotLoopScoped(t *testing.T) {
+	files := map[string]string{
+		"locale":    `{}`,
+		"viewModel": `{"rows":[],"section_title":"T"}`,
+		"pages/p/config": `{"grid":{"type":"one_column"},"forms":[{"id":"f","sections":[{"id":"s","type":"body",
+		  "title":"{{section_title}}","contentLoop":"{{rows}}",
+		  "content":[{"id":"l","class":"label","value":"{{cell}}"}]}]}]}`,
+	}
+	f := ValidateTree(files)
+	if has(f.Warnings, "section_title", "dead default") {
+		t.Errorf("the section title references the key — it is not dead: %v", f.Warnings)
+	}
+	if has(f.Warnings, "{{cell}}", "no default in `viewModel`") {
+		t.Errorf("the loop template var must stay loop-scoped: %v", f.Warnings)
+	}
+}
+
+// A string sitting directly in an array is a leaf too — walk() skipped those, so
+// every token inside one was invisible.
+func TestValidateTreeHarvestsTokensInStringArrays(t *testing.T) {
+	files := map[string]string{
+		"locale":    `{}`,
+		"viewModel": `{}`,
+		"pages/p/config": `{"grid":{"type":"one_column"},"forms":[{"id":"f","sections":[{"id":"s","type":"body",
+		  "content":[{"id":"m","class":"mainMenu","value":"a","structure":["[[missing_loc]]","{{missing_vm}}"]}]}]}]}`,
+	}
+	f := ValidateTree(files)
+	if !has(f.Errors, "[[missing_loc]]") {
+		t.Errorf("expected the locale key inside the array to be reported: %v", f.Errors)
+	}
+	if !has(f.Warnings, "{{missing_vm}}") {
+		t.Errorf("expected the viewModel key inside the array to be reported: %v", f.Warnings)
+	}
+}
+
+// Scoping: a locale miss in a page this push does not write is pre-existing debt.
+// Blocking on it would strand the user — pushSmartForm has no force flag.
+func TestValidateTreeScopedUntouchedPageIsWarning(t *testing.T) {
+	page := `{"grid":{"type":"one_column"},"forms":[{"id":"f","sections":[{"id":"s","type":"body",
+	  "content":[{"id":"l","class":"label","value":"[[nowhere]]"}]}]}]}`
+	files := map[string]string{
+		"locale":            `{}`,
+		"viewModel":         `{}`,
+		"pages/old/config":  page,
+		"pages/new/config":  page,
+		"definitions/stale": `{"class":"button","title":"[[nowhere]]","type":"default"}`,
+	}
+
+	f := ValidateTreeScoped(files, map[string]bool{"pages/new/config": true})
+	if !has(f.Errors, "pages/new/config", "[[nowhere]]") {
+		t.Errorf("the page being written must still block: %v", f.Errors)
+	}
+	if has(f.Errors, "pages/old/config") || has(f.Errors, "definitions/stale") {
+		t.Errorf("untouched files must not block an unrelated push: %v", f.Errors)
+	}
+	if !has(f.Warnings, "pages/old/config", "pre-existing") {
+		t.Errorf("the untouched page should still be reported as a warning: %v", f.Warnings)
+	}
+
+	// Writing a locale file can be exactly what removed the key, so every page
+	// resolving against it goes back in scope.
+	f2 := ValidateTreeScoped(files, map[string]bool{"locale": true})
+	for _, p := range []string{"pages/old/config", "pages/new/config", "definitions/stale"} {
+		if !has(f2.Errors, p, "[[nowhere]]") {
+			t.Errorf("%s must block when the app locale is being written: %v", p, f2.Errors)
+		}
+	}
+
+	// A page locale file scopes its own page back in, and nothing else.
+	f3 := ValidateTreeScoped(files, map[string]bool{"pages/old/locale": true})
+	if !has(f3.Errors, "pages/old/config", "[[nowhere]]") {
+		t.Errorf("the page whose locale is being written must block: %v", f3.Errors)
+	}
+	if has(f3.Errors, "pages/new/config") {
+		t.Errorf("another page must stay a warning: %v", f3.Errors)
+	}
+}
+
+// ValidateTree keeps the unscoped contract: every finding at full severity.
+func TestValidateTreeUnscopedBlocksEverywhere(t *testing.T) {
+	page := `{"grid":{"type":"one_column"},"forms":[{"id":"f","sections":[{"id":"s","type":"body",
+	  "content":[{"id":"l","class":"label","value":"[[nowhere]]"}]}]}]}`
+	f := ValidateTree(map[string]string{"locale": `{}`, "viewModel": `{}`, "pages/a/config": page})
+	if !has(f.Errors, "pages/a/config", "[[nowhere]]") {
+		t.Errorf("unscoped ValidateTree must report an error: %v", f.Errors)
+	}
+}

--- a/plugins/simulator/mcp-server/internal/cduschema/tokens_test.go
+++ b/plugins/simulator/mcp-server/internal/cduschema/tokens_test.go
@@ -1,0 +1,223 @@
+package cduschema
+
+import (
+	"strings"
+	"testing"
+)
+
+// has reports whether any finding mentions every one of substrs.
+func has(findings []string, substrs ...string) bool {
+	for _, f := range findings {
+		all := true
+		for _, s := range substrs {
+			if !strings.Contains(f, s) {
+				all = false
+				break
+			}
+		}
+		if all {
+			return true
+		}
+	}
+	return false
+}
+
+// A missing locale key is an ERROR: locale is resolved from the static files
+// only, so nothing at runtime can rescue it — the browser shows "[[key]]".
+func TestValidateTreeMissingLocaleKeyIsError(t *testing.T) {
+	files := map[string]string{
+		"locale":             `{"brand":{"en":"Acme","uk":"Acme"}}`,
+		"viewModel":          `{}`,
+		"pages/index/locale": `{"greeting":{"en":"Hi","uk":"Привіт"}}`,
+		"pages/index/config": `{"grid":{"type":"one_column","components":{"center":["f"]}},"forms":[{"id":"f","sections":[{"id":"b","type":"body","content":[{"id":"a","class":"label","value":"[[greeting]]"},{"id":"c","class":"label","value":"[[brand]]"},{"id":"d","class":"label","value":"[[nowhere]]"}]}]}]}`,
+	}
+	f := ValidateTree(files)
+	if !has(f.Errors, "pages/index/config", "[[nowhere]]") {
+		t.Errorf("expected an error for the undefined locale key, got errors=%v", f.Errors)
+	}
+	// The two defined keys must not be reported — one from the page locale, one
+	// from the app locale (they are merged at serve time).
+	for _, k := range []string{"[[greeting]]", "[[brand]]"} {
+		if has(f.Errors, k) {
+			t.Errorf("%s is defined but was reported: %v", k, f.Errors)
+		}
+	}
+}
+
+// A page locale key only covers ITS page — the same key referenced from another
+// page must still be reported.
+func TestValidateTreePageLocaleIsNotGlobal(t *testing.T) {
+	page := `{"grid":{"type":"one_column","components":{"center":["f"]}},"forms":[{"id":"f","sections":[{"id":"b","type":"body","content":[{"id":"a","class":"label","value":"[[only_on_one]]"}]}]}]}`
+	files := map[string]string{
+		"locale":           `{}`,
+		"viewModel":        `{}`,
+		"pages/one/locale": `{"only_on_one":{"en":"x","uk":"x"}}`,
+		"pages/one/config": page,
+		"pages/two/config": page,
+	}
+	f := ValidateTree(files)
+	if has(f.Errors, "pages/one/config") {
+		t.Errorf("page one defines the key locally and must not be reported: %v", f.Errors)
+	}
+	if !has(f.Errors, "pages/two/config", "[[only_on_one]]") {
+		t.Errorf("page two does not define the key and must be reported: %v", f.Errors)
+	}
+}
+
+// A missing viewModel default is a WARNING, not an error: the bound Corezoid
+// process returns a per-request viewModel merged over the defaults, so the key
+// may well be supplied at runtime.
+func TestValidateTreeMissingViewModelDefaultIsWarning(t *testing.T) {
+	files := map[string]string{
+		"locale":             `{}`,
+		"viewModel":          `{"known":"x"}`,
+		"pages/index/config": `{"grid":{"type":"one_column","components":{"center":["f"]}},"forms":[{"id":"f","sections":[{"id":"b","type":"body","content":[{"id":"a","class":"label","value":"{{known}}"},{"id":"c","class":"label","value":"{{undefaulted}}"}]}]}]}`,
+	}
+	f := ValidateTree(files)
+	if len(f.Errors) != 0 {
+		t.Errorf("a viewModel miss must not block the push, got errors=%v", f.Errors)
+	}
+	if !has(f.Warnings, "{{undefaulted}}") {
+		t.Errorf("expected a warning for the undefaulted key, got %v", f.Warnings)
+	}
+	if has(f.Warnings, "{{known}}") {
+		t.Errorf("a defaulted key must not warn: %v", f.Warnings)
+	}
+}
+
+// contentLoop template placeholders are substituted from the loop ENTRIES, not
+// from the viewModel — reporting them as missing defaults would be a false
+// positive on every list page.
+func TestValidateTreeContentLoopVarsAreNotViewModelKeys(t *testing.T) {
+	files := map[string]string{
+		"locale":    `{}`,
+		"viewModel": `{"promos_loop":[]}`,
+		"pages/promo/config": `{"grid":{"type":"one_column","components":{"center":["f"]}},
+			"forms":[{"id":"f","sections":[{"id":"loop","type":"body","contentLoop":"{{promos_loop}}",
+			"content":[{"id":"i","class":"image","value":"{{img}}"},{"id":"t","class":"label","value":"{{text}}"}]}]}]}`,
+	}
+	f := ValidateTree(files)
+	for _, k := range []string{"{{img}}", "{{text}}"} {
+		if has(f.Warnings, k, "no default in `viewModel`") {
+			t.Errorf("loop-scoped %s must not be treated as a viewModel key: %v", k, f.Warnings)
+		}
+	}
+	// The array that FEEDS the loop is a real viewModel key and is defaulted.
+	if has(f.Warnings, "{{promos_loop}}") {
+		t.Errorf("promos_loop is defaulted and must not warn: %v", f.Warnings)
+	}
+}
+
+// When the contentLoop entries are written out in the file we can check them
+// exactly: a template placeholder absent from an entry renders literally in that
+// row. (A templated contentLoop is backend-filled, so it stays silent — see the
+// test above.)
+func TestValidateTreeLiteralContentLoopChecksEntries(t *testing.T) {
+	files := map[string]string{
+		"locale":    `{}`,
+		"viewModel": `{}`,
+		"pages/p/config": `{"grid":{"type":"one_column","components":{"center":["f"]}},
+			"forms":[{"id":"f","sections":[{"id":"tiles","type":"body",
+			"contentLoop":[{"img":"a.jpg","text":"A"},{"img":"b.jpg"}],
+			"content":[{"id":"i","class":"image","value":"{{img}}"},{"id":"t","class":"label","value":"{{text}}"}]}]}]}`,
+	}
+	f := ValidateTree(files)
+	if len(f.Errors) != 0 {
+		t.Errorf("a loop-entry gap must not block the push, got errors=%v", f.Errors)
+	}
+	// entry 1 has no "text"
+	if !has(f.Warnings, `section "tiles"`, "{{text}}", "1") {
+		t.Errorf("expected a warning naming the section and the gap entry, got %v", f.Warnings)
+	}
+	// "img" is present in BOTH entries — must not be reported.
+	if has(f.Warnings, "{{img}}") {
+		t.Errorf("img is present in every entry and must not warn: %v", f.Warnings)
+	}
+	// Loop vars are never viewModel keys, literal loop or not.
+	if has(f.Warnings, "no default in `viewModel`") {
+		t.Errorf("loop vars must not be reported as missing viewModel defaults: %v", f.Warnings)
+	}
+}
+
+// A label bound to a key whose default is "" renders as an empty value, which the
+// renderer rejects outright ("value" is not allowed to be empty). ValidateFile
+// catches a literal "" but cannot see a default that resolves to one.
+func TestValidateTreeEmptyDefaultOnLabelWarns(t *testing.T) {
+	files := map[string]string{
+		"locale":             `{}`,
+		"viewModel":          `{"msg":"","note":" "}`,
+		"pages/index/config": `{"grid":{"type":"one_column","components":{"center":["f"]}},"forms":[{"id":"f","sections":[{"id":"b","type":"body","content":[{"id":"m","class":"label","value":"{{msg}}"},{"id":"n","class":"label","value":"{{note}}"}]}]}]}`,
+	}
+	f := ValidateTree(files)
+	if !has(f.Warnings, "{{msg}}", "empty") {
+		t.Errorf("expected an empty-default warning for msg, got %v", f.Warnings)
+	}
+	if has(f.Warnings, "{{note}}", "empty") {
+		t.Errorf("note defaults to a non-breaking space and must not warn: %v", f.Warnings)
+	}
+}
+
+// A viewModel default no page references is dead weight — usually a leftover from
+// a component that was removed.
+func TestValidateTreeDeadViewModelDefault(t *testing.T) {
+	files := map[string]string{
+		"locale":             `{}`,
+		"viewModel":          `{"used":"a","orphan":"b"}`,
+		"pages/index/config": `{"grid":{"type":"one_column","components":{"center":["f"]}},"forms":[{"id":"f","sections":[{"id":"b","type":"body","content":[{"id":"u","class":"label","value":"{{used}}"}]}]}]}`,
+	}
+	f := ValidateTree(files)
+	if !has(f.Warnings, "orphan", "dead default") {
+		t.Errorf("expected a dead-default warning for orphan, got %v", f.Warnings)
+	}
+	if has(f.Warnings, `"used"`, "dead default") {
+		t.Errorf("used is referenced and must not be called dead: %v", f.Warnings)
+	}
+}
+
+// A definition is inlined into pages we cannot attribute statically, so its
+// locale keys are checked against every locale file — an error only when defined
+// nowhere.
+func TestValidateTreeDefinitionLocale(t *testing.T) {
+	files := map[string]string{
+		"locale":             `{}`,
+		"viewModel":          `{}`,
+		"pages/index/locale": `{"submit":{"en":"Send","uk":"Надіслати"}}`,
+		"pages/index/config": `{"grid":{"type":"one_column","components":{"center":["f"]}},"forms":[{"id":"f","sections":[{"id":"b","type":"body","content":[{"id":"x","$ref":"#/button"}]}]}]}`,
+		"definitions/button": `{"class":"button","title":"[[submit]]","type":"default"}`,
+		"definitions/broken": `{"class":"button","title":"[[never_defined]]","type":"default"}`,
+	}
+	f := ValidateTree(files)
+	if has(f.Errors, "definitions/button") {
+		t.Errorf("submit is defined in a page locale; the definition must not error: %v", f.Errors)
+	}
+	if !has(f.Errors, "definitions/broken", "[[never_defined]]") {
+		t.Errorf("expected an error for the definition key defined nowhere: %v", f.Errors)
+	}
+}
+
+// Malformed JSON is ValidateFile's job; ValidateTree must not double-report or panic.
+func TestValidateTreeToleratesMalformedJSON(t *testing.T) {
+	files := map[string]string{
+		"locale":             `{ not json`,
+		"viewModel":          `{"a":1}`,
+		"pages/index/config": `{ also not json`,
+	}
+	f := ValidateTree(files) // must not panic
+	for _, e := range f.Errors {
+		if strings.Contains(e, "invalid JSON") {
+			t.Errorf("ValidateTree should leave JSON syntax to ValidateFile, got %q", e)
+		}
+	}
+}
+
+// An env with no pages at all (e.g. a freshly created form) must stay silent
+// rather than declaring every default dead.
+func TestValidateTreeNoPagesIsSilent(t *testing.T) {
+	f := ValidateTree(map[string]string{
+		"locale":    `{"a":{"en":"A"}}`,
+		"viewModel": `{"x":"1"}`,
+	})
+	if len(f.Errors) != 0 || len(f.Warnings) != 0 {
+		t.Errorf("expected no findings for a page-less env, got errors=%v warnings=%v", f.Errors, f.Warnings)
+	}
+}

--- a/plugins/simulator/mcp-server/internal/cduschema/validate.go
+++ b/plugins/simulator/mcp-server/internal/cduschema/validate.go
@@ -233,6 +233,23 @@ func validateClientOnlyRules(relPath, itemLabel, class string, item map[string]a
 			))
 		}
 	}
+
+	// An `image` value is never loaded directly: the renderer proxies it through
+	// /api/1.0/image?src=<urlencoded>, and that proxy rejects the data: scheme with
+	// 400 {"statusCode":400,"message":"URL is not allowed"} (cdu-page-protocol.md §4).
+	// The image therefore renders as a broken box, and only the network tab says why.
+	// A templated value ("{{qr_src}}") resolves per request and cannot be judged here.
+	if class == "image" {
+		if str, ok := item["value"].(string); ok && strings.HasPrefix(strings.TrimSpace(str), "data:") {
+			errs = append(errs, fmt.Sprintf(
+				`%s: %s: image "value" must be a URL the SERVER can fetch — a data: URI is `+
+					"rejected by the image proxy (/api/1.0/image?src=) with "+
+					`400 "URL is not allowed". Use an http(s) URL or an actor-attached asset. `+
+					"(A data: URI in Less `url()` is fine — that path is not proxied.)",
+				relPath, itemLabel,
+			))
+		}
+	}
 	return errs
 }
 

--- a/plugins/simulator/mcp-server/internal/cduschema/validate.go
+++ b/plugins/simulator/mcp-server/internal/cduschema/validate.go
@@ -3,6 +3,7 @@ package cduschema
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -187,10 +188,136 @@ func validateItems(relPath, path string, items []any, r *Rules) []string {
 			))
 		}
 
+		errs = append(errs, validateClientOnlyRules(relPath, itemLabel, class, item)...)
+		errs = append(errs, validateItemKeys(relPath, itemLabel, class, item, r)...)
+		errs = append(errs, validateNested(relPath, itemLabel, class, item, r)...)
+
 		// Recurse into row/draggable layout wrapper children.
 		if class == "row" || class == "draggable" {
 			nested, _ := item["items"].([]any)
 			errs = append(errs, validateItems(relPath, itemLabel+".items", nested, r)...)
+		}
+	}
+	return errs
+}
+
+// validateClientOnlyRules enforces constraints the renderer (control-cdu) applies
+// but the swagger does not express. The swagger carries no minLength anywhere, so
+// these cannot be derived — they are transcribed from observed client validation
+// errors and must be kept in sync by hand.
+func validateClientOnlyRules(relPath, itemLabel, class string, item map[string]any) []string {
+	var errs []string
+
+	// `label` and `image` reject an empty string outright ("value is not allowed to
+	// be empty"). This bites hardest when a viewModel default is "" to mean "nothing
+	// to show" — use a non-breaking space, or omit the item.
+	switch class {
+	case "label", "image":
+		raw, present := item["value"]
+		str, isStr := raw.(string)
+		if !present {
+			errs = append(errs, fmt.Sprintf(
+				`%s: %s: %s requires a non-empty "value"`, relPath, itemLabel, class,
+			))
+		} else if isStr && str == "" {
+			hint := "use a non-breaking space (\u00a0) for a visually empty label"
+			if class == "image" {
+				// A data: URI does NOT work here: the renderer loads every image
+				// through /api/1.0/image?src=, which rejects the scheme outright
+				// (400 {"statusCode":400,"message":"URL is not allowed"}).
+				hint = "point it at a placeholder the server can FETCH (an http(s) URL, or an actor-attached asset) — a data: URI is rejected by the image proxy"
+			}
+			errs = append(errs, fmt.Sprintf(
+				`%s: %s: %s "value" must not be an empty string — the renderer rejects it; %s`,
+				relPath, itemLabel, class, hint,
+			))
+		}
+	}
+	return errs
+}
+
+// validateNested checks the sub-structures where the swagger is precise and the
+// client renderer is strict: `extra`, `options[]`, and a table's `head[]` / `body[]`.
+// The server accepts unknown keys here (no schema sets additionalProperties:false),
+// so without this check they surface only as console errors in the browser.
+//
+// A value that is a template string (`"{{history_tx_body}}"`) is resolved per
+// request and cannot be checked here, so it is skipped.
+func validateNested(relPath, itemLabel, class string, item map[string]any, r *Rules) []string {
+	var errs []string
+	if class == "" {
+		return nil
+	}
+
+	checkObject := func(label string, raw any, allowed map[string]bool) {
+		if len(allowed) == 0 {
+			return // no rule derived — never guess
+		}
+		obj, ok := raw.(map[string]any)
+		if !ok {
+			return
+		}
+		for _, key := range sortedKeys(obj) {
+			if !allowed[key] {
+				errs = append(errs, fmt.Sprintf(
+					"%s: %s.%s is not allowed; allowed keys: %s",
+					relPath, label, key, strings.Join(sortedKeys(allowed), ", "),
+				))
+			}
+		}
+	}
+
+	checkArray := func(field string, allowed map[string]bool) {
+		if len(allowed) == 0 {
+			return
+		}
+		arr, ok := item[field].([]any)
+		if !ok {
+			return // absent, or a "{{template}}" resolved at request time
+		}
+		for i, raw := range arr {
+			checkObject(fmt.Sprintf("%s.%s[%d]", itemLabel, field, i), raw, allowed)
+		}
+	}
+
+	checkObject(itemLabel+".extra", item["extra"], r.NestedProps[class+".extra"])
+	checkArray("options", r.NestedProps[class+".options"])
+	checkArray("head", r.NestedProps[class+".head"])
+	checkArray("body", r.NestedProps[class+".body"])
+	return errs
+}
+
+// sortedKeys returns a map's keys in a stable order, so a defect list reads the
+// same on every run. Generic over the value type: the callers hold both
+// map[string]any (an item's raw config) and map[string]bool (a derived allowlist).
+func sortedKeys[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// validateItemKeys reports keys an item carries that no schema variant of its class
+// declares. A typo'd base field (`visibilty`, `styleclass`) is otherwise silent: the
+// renderer ignores it and the item simply never hides or never picks up its style.
+//
+// Safe only because the allowlist is the UNION over every variant of the class —
+// TestProbeDocumentedKeysPresentInUnion guards that assumption, so a swagger update
+// that drops a real key fails the tests instead of rejecting valid config.
+func validateItemKeys(relPath, itemLabel, class string, item map[string]any, r *Rules) []string {
+	allowed := r.ItemProps[class]
+	if len(allowed) == 0 {
+		return nil // unknown class, or a renderer-only wrapper (row/draggable)
+	}
+	var errs []string
+	for _, key := range sortedKeys(item) {
+		if !allowed[key] {
+			errs = append(errs, fmt.Sprintf(
+				"%s: %s: %q is not a known %s field; allowed: %s",
+				relPath, itemLabel, key, class, strings.Join(sortedKeys(allowed), ", "),
+			))
 		}
 	}
 	return errs

--- a/plugins/simulator/mcp-server/internal/engines/smartform/push.go
+++ b/plugins/simulator/mcp-server/internal/engines/smartform/push.go
@@ -161,12 +161,22 @@ func handlePushSmartForm(ctx context.Context, req mcp.CallToolRequest) (*mcp.Cal
 			validationErrors = append(validationErrors, errs...)
 		}
 	}
-	// Cross-file audit. Runs over the WHOLE tree, not just the files being
-	// written: a `[[key]]` in an untouched page breaks the moment its locale entry
-	// is deleted, and a per-file check can never see that. Locale misses are
-	// errors (nothing at runtime can supply a locale key); viewModel misses are
-	// warnings (the Corezoid process may fill them per request).
-	tree := cduschema.ValidateTree(localFiles)
+	// Cross-file audit. Reads the WHOLE tree, not just the files being written: a
+	// `[[key]]` in an untouched page breaks the moment its locale entry is deleted,
+	// and a per-file check can never see that. Severity is scoped to this push,
+	// though — a locale miss blocks only when the page or one of its locale files is
+	// what we are writing. A miss in a part of the tree nobody touched was already
+	// live before this push, and blocking on it would strand the user: there is no
+	// force flag to get an unrelated fix out. viewModel misses stay warnings either
+	// way (the Corezoid process may fill them per request).
+	changedPaths := make(map[string]bool, len(newFilePaths)+len(modifiedFilePaths))
+	for _, p := range newFilePaths {
+		changedPaths[p] = true
+	}
+	for _, p := range modifiedFilePaths {
+		changedPaths[p] = true
+	}
+	tree := cduschema.ValidateTreeScoped(localFiles, changedPaths)
 	validationErrors = append(validationErrors, tree.Errors...)
 
 	if len(validationErrors) > 0 {

--- a/plugins/simulator/mcp-server/internal/engines/smartform/push.go
+++ b/plugins/simulator/mcp-server/internal/engines/smartform/push.go
@@ -161,25 +161,41 @@ func handlePushSmartForm(ctx context.Context, req mcp.CallToolRequest) (*mcp.Cal
 			validationErrors = append(validationErrors, errs...)
 		}
 	}
+	// Cross-file audit. Runs over the WHOLE tree, not just the files being
+	// written: a `[[key]]` in an untouched page breaks the moment its locale entry
+	// is deleted, and a per-file check can never see that. Locale misses are
+	// errors (nothing at runtime can supply a locale key); viewModel misses are
+	// warnings (the Corezoid process may fill them per request).
+	tree := cduschema.ValidateTree(localFiles)
+	validationErrors = append(validationErrors, tree.Errors...)
+
 	if len(validationErrors) > 0 {
-		out, _ := json.Marshal(map[string]interface{}{
+		payload := map[string]interface{}{
 			"actorId":          actorID,
 			"env":              "develop",
 			"validationErrors": validationErrors,
 			"message":          "push aborted: fix the validation errors below and retry",
-		})
+		}
+		if len(tree.Warnings) > 0 {
+			payload["warnings"] = tree.Warnings
+		}
+		out, _ := json.Marshal(payload)
 		return mcp.NewToolResultError(string(out)), nil
 	}
 
 	if len(newFolderPaths) == 0 && len(newFilePaths) == 0 && len(modifiedFilePaths) == 0 {
-		out, _ := json.Marshal(map[string]interface{}{
+		payload := map[string]interface{}{
 			"actorId":   actorID,
 			"env":       "develop",
 			"created":   map[string]int{"folders": 0, "files": 0},
 			"updated":   0,
 			"unchanged": unchanged,
 			"message":   "nothing to push",
-		})
+		}
+		if len(tree.Warnings) > 0 {
+			payload["warnings"] = tree.Warnings
+		}
+		out, _ := json.Marshal(payload)
 		return mcp.NewToolResultText(string(out)), nil
 	}
 
@@ -398,7 +414,7 @@ func handlePushSmartForm(ctx context.Context, req mcp.CallToolRequest) (*mcp.Cal
 	}
 	sort.Strings(orphanFiles)
 
-	out, _ := json.Marshal(map[string]interface{}{
+	payload := map[string]interface{}{
 		"actorId": actorID,
 		"env":     "develop",
 		"created": map[string]int{
@@ -411,7 +427,14 @@ func handlePushSmartForm(ctx context.Context, req mcp.CallToolRequest) (*mcp.Cal
 		"createdFolderPath": newFolderPaths,
 		"createdFilePath":   newFilePaths,
 		"reconciledFiles":   reconciledFiles,
-	})
+	}
+	// Non-blocking cross-file findings: an undefaulted {{key}}, a default that
+	// resolves to "" on a label/image, a dead default. The push succeeded — these
+	// are the defects that would otherwise only surface in the browser.
+	if len(tree.Warnings) > 0 {
+		payload["warnings"] = tree.Warnings
+	}
+	out, _ := json.Marshal(payload)
 	return mcp.NewToolResultText(string(out)), nil
 }
 

--- a/plugins/simulator/skills/simulator-smart-forms/SKILL.md
+++ b/plugins/simulator/skills/simulator-smart-forms/SKILL.md
@@ -144,14 +144,18 @@ untouched page). The split follows what the runtime can still rescue:
 
 | Finding | Where | Why |
 |---|---|---|
-| `[[key]]` in neither app `locale` nor that page's `locale` | **`validationErrors`** — push aborts | locale resolves from files only; nothing at runtime can supply it, so it always reaches the browser as the literal text `[[key]]` |
+| `[[key]]` in neither app `locale` nor that page's `locale`, **and** that page or one of its locale files is in this push | **`validationErrors`** — push aborts | locale resolves from files only; nothing at runtime can supply it, so it always reaches the browser as the literal text `[[key]]` |
+| the same miss in a page **nobody touched** in this push | `warnings` (tagged `pre-existing`) | it was already live before the push; blocking would strand an unrelated fix, since `pushSmartForm` has no force flag |
 | `{{key}}` with no `viewModel` default | `warnings` | the bound Corezoid process returns a per-request viewModel merged over the defaults, so it may be filled at runtime — it renders literally only when the backend call fails |
 | a `label`/`image` whose whole value is `{{key}}` and whose default is `""` | `warnings` | the renderer rejects an empty value outright; use a non-breaking space (label) or a **fetchable** placeholder URL (image — a `data:` URI is rejected by the image proxy) |
 | a `viewModel` default no page or definition references | `warnings` | dead key, usually left behind by a removed component |
 | a section with **literal** `contentLoop` entries missing a key its template uses | `warnings` | those rows render the literal `{{key}}` — checked per entry, and named |
 
 A **templated** `contentLoop` (`"contentLoop": "{{promos_loop}}"`) is backend-filled, so the
-placeholders inside its `content` template are not viewModel keys and are never reported.
+placeholders inside its `content` template are not viewModel keys and are never reported. Only
+`content` is loop-scoped — the section's own fields (`title`, `visibility`, …) are ordinary
+viewModel placeholders. `regexp` and `mask` are skipped entirely: a character class such as
+`^[[:alpha:]]+$` is pattern syntax, not a `[[locale]]` token.
 
 ---
 

--- a/plugins/simulator/skills/simulator-smart-forms/SKILL.md
+++ b/plugins/simulator/skills/simulator-smart-forms/SKILL.md
@@ -124,15 +124,34 @@ pullSmartForm(actorId="<uuid>")
 3.  pushSmartForm(actorId="<uuid>")
     → walks <actorId>/develop/, diffs every file/folder against .manifest.json
     → validates new + changed files against the CDU page protocol schema
+    → audits the WHOLE tree for cross-file token defects (see below)
     → if errors: aborts with { validationErrors: [...] } — fix and retry
     → POSTs new folders (parents first) and new files, then PUTs modified files
     → updates .manifest.json with returned ids + content hashes
-    → returns { created: { folders, files }, updated, unchanged, orphanFiles }
+    → returns { created: { folders, files }, updated, unchanged, orphanFiles, warnings? }
 
 4.  Deploy (when ready to publish):
     deploySmartForm(actorId="<uuid>")
     → deploys develop → production; returns { releaseId, releaseNumber, status }
 ```
+
+### The cross-file token audit (`validationErrors` vs `warnings`)
+
+Per-file schema validation cannot see whether a `[[key]]` resolves or a `{{key}}` has a default —
+those need the locale and viewModel files alongside the page. `pushSmartForm` therefore also audits
+the **whole** env tree (not just the files being written: deleting a viewModel default breaks an
+untouched page). The split follows what the runtime can still rescue:
+
+| Finding | Where | Why |
+|---|---|---|
+| `[[key]]` in neither app `locale` nor that page's `locale` | **`validationErrors`** — push aborts | locale resolves from files only; nothing at runtime can supply it, so it always reaches the browser as the literal text `[[key]]` |
+| `{{key}}` with no `viewModel` default | `warnings` | the bound Corezoid process returns a per-request viewModel merged over the defaults, so it may be filled at runtime — it renders literally only when the backend call fails |
+| a `label`/`image` whose whole value is `{{key}}` and whose default is `""` | `warnings` | the renderer rejects an empty value outright; use a non-breaking space (label) or a **fetchable** placeholder URL (image — a `data:` URI is rejected by the image proxy) |
+| a `viewModel` default no page or definition references | `warnings` | dead key, usually left behind by a removed component |
+| a section with **literal** `contentLoop` entries missing a key its template uses | `warnings` | those rows render the literal `{{key}}` — checked per entry, and named |
+
+A **templated** `contentLoop` (`"contentLoop": "{{promos_loop}}"`) is backend-filled, so the
+placeholders inside its `content` template are not viewModel keys and are never reported.
 
 ---
 
@@ -290,11 +309,16 @@ Every item has `class` + base fields (`id`, `value`, `visibility`, `required`, `
 
 ### Data & navigation components
 
+> **`value`, never `id`, is the key in an option or column list** — `table.head[]`,
+> `tab.options[]`, `stepper.options[]`. Cells of a table row live in `body[].options[]`, not as
+> direct row properties. The wrong shape passes the server and fails only in the browser
+> (`"head[0].id" is not allowed`); see `cdu-page-protocol.md` §5.1 and §10.1.
+
 | `class` | Notes |
 |---|---|
-| `table` | `head: [{id,title}]`, `body: [{<id>: value}]`; `type`: `default` `radio` `check`; `submitOnChange`, `submitOnScroll` |
-| `tab` | `options: [{id,title}]`; `value` = selected id; `submitOnChange` |
-| `stepper` | `options: [{id,title}]`; `value` = step; `extra.direction` |
+| `table` | `head: [{value,title}]` — the column key is **`value`**; `body: [{value: <rowId>, options: [{value: <columnKey>, title: <cellText>}]}]`; `type`: `default` `radio` `check`; `submitOnChange`, `submitOnScroll` |
+| `tab` | `options: [{value,title}]`; `value` = selected option's `value`; `submitOnChange` |
+| `stepper` | `options: [{value,title,completed}]`; `value` = current option's `value`; `extra.mobileVisible` only |
 | `mainMenu` | Nested navigation; `options` tree |
 
 ### File components
@@ -338,6 +362,19 @@ All substitution is **server-side** — the renderer receives concrete values.
 | `"$ref": "#/button"` | `definitions/button` file | inlined at serve time |
 | `contentLoop` | section array expansion | one template → N rows |
 | BBCode | `label`/`button`/`edit`/`check` titles | `[b] [i] [u] [color=#f00] [size=N] [br]`, and `[url=https://…]text[/url]` → clickable `<a target="_blank">` (inline link; `[iurl=…]` opens same-tab; renderer supports more, e.g. `[bg]`). Raw `<a>` HTML is escaped — use `[url]`. |
+
+> ⚠️ **Not every field can be templated.** `visibility` is validated against the literal
+> enum `visible|disabled|hidden` at **push** time, so `"visibility": "{{show_it}}"` is
+> rejected and **a page cannot vary visibility on `/get` at all** — only `changes[]` on
+> `/send` can. `styleClass` *can* be templated, which makes the two look symmetric when they
+> are not. To show an empty state on `/get`, drive a `label`'s **value** from the viewModel.
+>
+> ⚠️ And a `label` value may **never** be the empty string (nor an `image` an empty src) —
+> the renderer rejects both. Use a non-breaking space for a blank-looking label. For an image
+> use a **fetchable** `http(s)` placeholder URL (or an actor-attached asset): `image.value` is
+> loaded through the `/api/1.0/image?src=` proxy, which rejects a `data:` URI with
+> `400 "URL is not allowed"`. Together these rules decide how you
+> build every empty state: control the **text**, not the visibility.
 
 ### locale file format
 


### PR DESCRIPTION
Two defect classes that `pushSmartForm` accepted silently and the user met in the browser. Both
live in `internal/cduschema`, both change what a push reports, so they ride together — one mental
model for the reviewer.

## 1. Item keys and nested shapes the renderer rejects

No schema in the bundled swagger sets `additionalProperties: false`, so the save endpoint stores a
typo'd `visibilty` or a `head[].id` verbatim. The item then simply never hides, or the column list
renders empty, with nothing but a console error to go on.

`cduschema` now derives from the swagger the property surface of every item `class`, plus the
nested spots where the schema *is* precise (`extra`, `options[]`, a table's `head[]` / `body[]`),
and `ValidateFile` rejects a key no variant declares.

**The one thing worth reviewing carefully:** the allowlist is the **union** over every schema
variant of a class. The swagger splits one class across type variants that each redeclare only
part of the surface — `value` is on `Edit-int` but not on `Edit-default` — so checking a single
variant would reject valid config. Two guards on that:

- `TestProbeDocumentedKeysPresentInUnion` asserts every key the docs use is in the union, so a
  swagger update that drops a real key fails the tests rather than blocking users' pushes;
- a class with no derived rule is **skipped**, never rejected (`collectProps` fails silently and
  leaves the maps empty).

Also transcribes three renderer-only rules the swagger cannot express (it carries no `minLength`
anywhere): a `label`/`image` `value` may not be empty; an `image` `value` must be a URL the
*server* can fetch (the renderer proxies through `/api/1.0/image?src=`, which rejects a `data:`
URI); and `visibility` may not be a `{{template}}` — it resolves at push time, so a page cannot
vary visibility on `/get` at all. The error message says that outright, because the natural fix is
to reach for a viewModel key that can never work.

## 2. Cross-file token audit

`ValidateFile` is per-file *by signature* — one relPath, one source — so it can never tell whether
a page's `[[key]]` resolves against the locale files or whether a `{{key}}` has a viewModel
default. The server does not help either: the app_content endpoint stores the source opaquely and
pong-server serves whatever it cannot substitute verbatim, so the first report is a literal
`[[key]]` on the rendered page.

New `cduschema.ValidateTree` audits the whole env tree, and `pushSmartForm` runs it alongside the
per-file pass. It receives the **whole** tree, not just the files being written — deleting a
viewModel default breaks an untouched page, which is exactly what a changed-files audit misses.

The error/warning split follows what the runtime can still rescue:

| Finding | Where | Why |
|---|---|---|
| `[[key]]` in neither app nor page `locale` | **error**, push aborts | locale resolves from files only; nothing at runtime can supply it |
| `{{key}}` with no viewModel default | warning | the bound process returns a per-request viewModel merged over the defaults |
| `label`/`image` bound to a default of `""` | warning | the renderer rejects an empty value |
| a default no page references | warning | dead key |
| **literal** `contentLoop` entries missing a key the template uses | warning | named per entry |

A **templated** `contentLoop` is backend-filled, so placeholders inside it are never reported and
list pages stay quiet. Warnings appear on a *successful* push under a new `warnings` field.

## Notes for the reviewer

- Behaviour change: `pushSmartForm` responses gain an optional `warnings` array, and a missing
  locale key now **aborts** a push that previously succeeded.
- Drive-by: `sortedSet` (tokens.go) and `sortedKeys2` (validate.go) were byte-identical
  duplicates — now one generic `sortedKeys`.
- Two commits, each builds and passes tests standalone (checked).

## Verification

`make build`, `make vet`, `go test ./...` (whole module) — green. `make discovery` produces no
drift. 13 new `ValidateTree` tests, plus the swagger-union probe and a regression suite taken from
a real build.