### PR TITLE
fix: address bug-finder issues #87, #88, #89

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,26 @@
 - **Graph import/export tools — `exportGraph`, `importGraph`, `uploadGraphFile`, `getTaskStatus`.** Wraps the pong-server async task API so a workspace graph (actors, edges, forms, and optionally attachments / transactions / processes / users / balances) can be exported to a `.graph` archive or re-imported, mirroring the UI's Export/Import buttons — distinct from the existing `pullGraphFile`/`pushGraphFile` developer sync tools, which edit a single layer's YAML and never touch `.graph` archives. `exportGraph` requires at least one of `actors`/`forms`/`allWorkspace`; `uploadGraphFile` accepts a `.graph` file as base64 or a public URL (capped at 100 MiB either way) and returns a storage `fileName` for `importGraph`; `getTaskStatus` polls a task by id and, for a completed export, returns a ready-to-share `downloadUrl` alongside the raw `details.file.fileName`.
 
 ### Fixed
+- **`serverInfo.version` reported `2.1.0` while every manifest was at `2.7.0` (#89).** The version
+  returned in the MCP `initialize` handshake came from two stale Go consts (`cmd/server`'s and
+  `mcpserver.defaultVersion`) that `scripts/release.sh` never bumped — it only touched the six
+  manifests. Collapsed them into one exported source of truth, `mcpserver.DefaultVersion`, which
+  `cmd/server` now reads; `release.sh` bumps it in lockstep with the manifests, and a new
+  `TestDefaultVersionMatchesManifest` fails CI if it ever drifts again. Also bumped
+  `.kiro-plugin/plugin.json`, which had fallen a release behind (`2.5.0`).
+- **`loadSysForms` cached transient failures and could serve valid data alongside a stale error
+  (#87).** The success path never cleared `sysFormsErr`, and both failure paths cached the error
+  with `sysFormsLoaded=true`; in the stateless (SSE) server, a failing and a succeeding request
+  racing on the same workspace could leave the cache permanently `{validForms, staleErr}`, after
+  which every caller (`if sysErr != nil …`) silently stopped resolving form-name→id until restart.
+  Now only successful loads are cached (a failure is retried, never poisoned), the success write
+  runs under a double-check so a concurrent winner is reused rather than clobbered, and the unused
+  `sysFormsErr` field is removed.
+- **`createEdgeLink` ignored the per-item `error` flag from `mass_links` (#88).** The response's
+  `error bool` was parsed but never checked, so an `{error:true, data:{id:…}}` item would be read
+  as a created edge and recorded as a live link — a silent ghost. The success branch is now guarded
+  on `!resp.Data[0].Error`. Defensive: the current backend strips the id from a failed item, so
+  there is no active data loss today, but the contract is now enforced.
 - **`pushSmartForm` could not see cross-file token defects, so an unresolved `[[key]]` shipped
   silently.** `cduschema.ValidateFile` is per-file by signature — it can never tell whether a
   page's `[[key]]` resolves against the locale files or whether a `{{key}}` has a viewModel default

--- a/plugins/simulator/.kiro-plugin/plugin.json
+++ b/plugins/simulator/.kiro-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simulator",
-  "version": "2.5.0",
+  "version": "2.7.0",
   "description": "Simulator.Company platform assistant. Exposes the Simulator REST API as an MCP server and provides skills for managing actors, forms, graph structures, and financial accounts.",
   "author": {
     "name": "Simulator.Company",

--- a/plugins/simulator/mcp-server/app/mcpserver/actor.go
+++ b/plugins/simulator/mcp-server/app/mcpserver/actor.go
@@ -40,7 +40,7 @@ func NewActorServer(actorID string, opts Options) (*server.MCPServer, Info, erro
 	}
 	version := opts.Version
 	if version == "" {
-		version = defaultVersion
+		version = DefaultVersion
 	}
 
 	s := server.NewMCPServer(name, version)

--- a/plugins/simulator/mcp-server/app/mcpserver/mcpserver.go
+++ b/plugins/simulator/mcp-server/app/mcpserver/mcpserver.go
@@ -25,8 +25,12 @@ import (
 )
 
 const (
-	defaultName    = "simulator"
-	defaultVersion = "2.1.0"
+	defaultName = "simulator"
+	// DefaultVersion is the single source of truth for the version reported in the
+	// MCP initialize handshake (serverInfo.version). cmd/server passes it as
+	// Options.Version; scripts/release.sh bumps it in lockstep with the plugin
+	// manifests, and TestDefaultVersionMatchesManifest guards that they agree.
+	DefaultVersion = "2.7.0"
 )
 
 // Options configures the embedded MCP server.
@@ -116,7 +120,7 @@ func New(opts Options) (*server.MCPServer, Info, error) {
 	}
 	version := opts.Version
 	if version == "" {
-		version = defaultVersion
+		version = DefaultVersion
 	}
 
 	// In stateless mode the same server serves both full-workspace and per-actor

--- a/plugins/simulator/mcp-server/app/mcpserver/version_test.go
+++ b/plugins/simulator/mcp-server/app/mcpserver/version_test.go
@@ -1,0 +1,35 @@
+package mcpserver
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+// TestDefaultVersionMatchesManifest guards against the Go server reporting a
+// serverInfo.version that has drifted from the plugin manifests (issue #89).
+// scripts/release.sh bumps DefaultVersion in lockstep with the manifests; this
+// test fails CI if a release — or a manual edit — ever leaves the const behind.
+func TestDefaultVersionMatchesManifest(t *testing.T) {
+	// Canonical version source, relative to this package dir
+	// (plugins/simulator/mcp-server/app/mcpserver).
+	const manifest = "../../../.claude-plugin/plugin.json"
+	raw, err := os.ReadFile(manifest)
+	if err != nil {
+		t.Fatalf("read %s: %v", manifest, err)
+	}
+	var m struct {
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("parse %s: %v", manifest, err)
+	}
+	if m.Version == "" {
+		t.Fatalf("%s has no version field", manifest)
+	}
+	if DefaultVersion != m.Version {
+		t.Errorf("DefaultVersion = %q but %s = %q — bump mcpserver.DefaultVersion "+
+			"(scripts/release.sh does this at release) so serverInfo.version matches the manifests",
+			DefaultVersion, manifest, m.Version)
+	}
+}

--- a/plugins/simulator/mcp-server/cmd/server/main.go
+++ b/plugins/simulator/mcp-server/cmd/server/main.go
@@ -19,7 +19,9 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 )
 
-const version = "2.1.0"
+// version is the single source of truth in mcpserver; kept in lockstep with
+// the plugin manifests by scripts/release.sh.
+const version = mcpserver.DefaultVersion
 
 // installShutdownFlush flushes buffered telemetry events before the process
 // exits on SIGINT/SIGTERM (e.g. the MCP client terminating the server). Go's

--- a/plugins/simulator/mcp-server/internal/engines/graph/edgelink_test.go
+++ b/plugins/simulator/mcp-server/internal/engines/graph/edgelink_test.go
@@ -1,0 +1,53 @@
+package graph
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// massLinkStub serves the two endpoints createEdgeLink hits: the edge-type lookup
+// (so injectMassLinkData can resolve the "hierarchy" type) and mass_links itself,
+// whose response body is the caller-supplied massLinkResp.
+func massLinkStub(t *testing.T, massLinkResp string) *GraphSyncer {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "mass_links") {
+			_, _ = w.Write([]byte(massLinkResp))
+			return
+		}
+		// edge_types lookup
+		_, _ = w.Write([]byte(`{"data":[{"id":1,"name":"hierarchy"}]}`))
+	}))
+	t.Cleanup(srv.Close)
+	return newGraphSyncer(srv.URL, "t", t.Name())
+}
+
+// TestCreateEdgeLinkRejectsErrorItem guards issue #88: a per-item error must not be
+// read as a created edge even when the backend echoes back an id, or the graph
+// records a ghost link that silently disappears.
+func TestCreateEdgeLinkRejectsErrorItem(t *testing.T) {
+	s := massLinkStub(t, `{"data":[{"error":true,"data":{"id":"ghost-id"}}]}`)
+	id, err := s.createEdgeLink(context.Background(), "src-uuid", "tgt-uuid")
+	if err == nil {
+		t.Fatalf("expected an error for an error:true item, got id=%q", id)
+	}
+	if id != "" {
+		t.Errorf("expected empty id on error, got %q", id)
+	}
+}
+
+// TestCreateEdgeLinkAcceptsSuccessItem is the positive counterpart: a clean item
+// still returns its id.
+func TestCreateEdgeLinkAcceptsSuccessItem(t *testing.T) {
+	s := massLinkStub(t, `{"data":[{"error":false,"data":{"id":"real-id"}}]}`)
+	id, err := s.createEdgeLink(context.Background(), "src-uuid", "tgt-uuid")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != "real-id" {
+		t.Errorf("id = %q, want %q", id, "real-id")
+	}
+}

--- a/plugins/simulator/mcp-server/internal/engines/graph/push.go
+++ b/plugins/simulator/mcp-server/internal/engines/graph/push.go
@@ -45,7 +45,6 @@ type workspaceCache struct {
 	mu sync.RWMutex
 
 	sysFormsLoaded bool
-	sysFormsErr    error
 	sysForms       []SysFormItem
 	formNameToID   map[string]int
 	formIDToName   map[int]string
@@ -420,20 +419,20 @@ func (s *GraphSyncer) resolveActorFormID(ctx context.Context, actorID string) in
 func (s *GraphSyncer) loadSysForms(ctx context.Context) ([]SysFormItem, error) {
 	s.cache.mu.RLock()
 	loaded := s.cache.sysFormsLoaded
-	forms, cacheErr := s.cache.sysForms, s.cache.sysFormsErr
+	forms := s.cache.sysForms
 	s.cache.mu.RUnlock()
 	if loaded {
-		return forms, cacheErr
+		// Only successful loads are cached (see the write block below), so a cache
+		// hit is always valid data — never a stale error left by a failed sibling.
+		return forms, nil
 	}
 
 	u := fmt.Sprintf("%s/forms/templates/system/%s?formTypes=system", s.baseURL, ecore.Seg(s.workspaceID))
 	data, err := s.get(ctx, u)
 	if err != nil {
-		s.cache.mu.Lock()
-		s.cache.sysFormsErr = fmt.Errorf("getSystemForms: %w", err)
-		s.cache.sysFormsLoaded = true
-		s.cache.mu.Unlock()
-		return nil, s.cache.sysFormsErr
+		// Do not cache a transient failure: leaving sysFormsLoaded false lets the
+		// next call retry, instead of poisoning the workspace until process restart.
+		return nil, fmt.Errorf("getSystemForms: %w", err)
 	}
 
 	var apiResult struct {
@@ -445,11 +444,7 @@ func (s *GraphSyncer) loadSysForms(ctx context.Context) ([]SysFormItem, error) {
 		} `json:"data"`
 	}
 	if err := json.Unmarshal(data, &apiResult); err != nil {
-		s.cache.mu.Lock()
-		s.cache.sysFormsErr = fmt.Errorf("parse system forms: %w", err)
-		s.cache.sysFormsLoaded = true
-		s.cache.mu.Unlock()
-		return nil, s.cache.sysFormsErr
+		return nil, fmt.Errorf("parse system forms: %w", err)
 	}
 
 	allowedRootTitles := map[string]bool{
@@ -474,9 +469,15 @@ func (s *GraphSyncer) loadSysForms(ctx context.Context) ([]SysFormItem, error) {
 	}
 
 	s.cache.mu.Lock()
-	s.cache.sysForms = roots
-	s.cache.sysFormsLoaded = true
-	s.buildFormNameIDCache(roots) // runs inside the write lock
+	if s.cache.sysFormsLoaded {
+		// A concurrent goroutine populated the cache first; reuse its result
+		// rather than overwriting it (and re-running buildFormNameIDCache).
+		roots = s.cache.sysForms
+	} else {
+		s.cache.sysForms = roots
+		s.cache.sysFormsLoaded = true
+		s.buildFormNameIDCache(roots) // runs inside the write lock
+	}
 	s.cache.mu.Unlock()
 	return roots, nil
 }
@@ -862,7 +863,9 @@ func (s *GraphSyncer) createEdgeLink(ctx context.Context, srcUUID, tgtUUID strin
 			} `json:"data"`
 		} `json:"data"`
 	}
-	if jsonErr := json.Unmarshal(respBytes, &resp); jsonErr == nil && len(resp.Data) > 0 && resp.Data[0].Data.ID != "" {
+	// Guard on !Error: a per-item failure must not be read as a created edge even
+	// if the backend echoes back an ID, or the graph would record a ghost link.
+	if jsonErr := json.Unmarshal(respBytes, &resp); jsonErr == nil && len(resp.Data) > 0 && !resp.Data[0].Error && resp.Data[0].Data.ID != "" {
 		return resp.Data[0].Data.ID, nil
 	}
 	return "", fmt.Errorf("massLink: no link ID in response")

--- a/plugins/simulator/mcp-server/internal/engines/graph/sysforms_test.go
+++ b/plugins/simulator/mcp-server/internal/engines/graph/sysforms_test.go
@@ -1,0 +1,42 @@
+package graph
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+// TestLoadSysFormsRetriesAfterTransientFailure guards issue #87: a transient
+// failure must not be cached (it would otherwise poison the workspace until the
+// process restarts). The first call fails; the second must retry and succeed,
+// returning valid forms with no lingering error.
+func TestLoadSysFormsRetriesAfterTransientFailure(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			http.Error(w, "boom", http.StatusInternalServerError)
+			return
+		}
+		_, _ = w.Write([]byte(`{"data":[{"id":10,"title":"Graphs","parentId":null}]}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	s := newGraphSyncer(srv.URL, "t", t.Name())
+
+	if _, err := s.loadSysForms(context.Background()); err == nil {
+		t.Fatal("expected an error on the first (failing) load")
+	}
+	// The failure must NOT have been cached — the retry hits the server again.
+	forms, err := s.loadSysForms(context.Background())
+	if err != nil {
+		t.Fatalf("retry after transient failure should succeed, got: %v", err)
+	}
+	if len(forms) == 0 {
+		t.Fatal("retry returned no forms — the failure poisoned the cache")
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Errorf("server calls = %d, want 2 (failure not cached → retried)", got)
+	}
+}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -120,6 +120,15 @@ for f in $VERSION_FILES; do
   echo "  bumped $f"
 done
 
+# 2b) The Go server reports the same version in the MCP initialize handshake via
+#     the mcpserver.DefaultVersion const (cmd/server passes it through). Keep it in
+#     lockstep with the manifests; TestDefaultVersionMatchesManifest enforces it.
+GO_VERSION_FILE="plugins/simulator/mcp-server/app/mcpserver/mcpserver.go"
+tmp="$(mktemp)"
+sed "s/DefaultVersion = \"${CURRENT_RE}\"/DefaultVersion = \"${VERSION}\"/" "$GO_VERSION_FILE" > "$tmp"
+mv "$tmp" "$GO_VERSION_FILE"
+echo "  bumped $GO_VERSION_FILE"
+
 cat <<EOF
 
 Done. Version files and CHANGELOG are at $VERSION.


### PR DESCRIPTION
Fixes #87
Fixes #88
Fixes #89

Addresses the three open Bug Finder Critic issues, each verified against the current code (and, where relevant, against pong-server / control-cdu).

### #89 — `serverInfo.version` drift (valid; the filed one-line fix was insufficient)
The version returned in the MCP `initialize` handshake actually came from **two** stale Go consts — `cmd/server/main.go` (`const version`, passed as `Options.Version`, which *overrides* the fallback) and `mcpserver.defaultVersion` — neither of which `scripts/release.sh` ever bumped (it only touches the six manifests). Fix:
- collapse both into one exported source of truth `mcpserver.DefaultVersion`, read by `cmd/server`;
- sync it to the canonical `2.7.0`;
- bump `.kiro-plugin/plugin.json`, which had silently fallen a release behind (`2.5.0`);
- teach `scripts/release.sh` to bump the Go const in lockstep;
- add `TestDefaultVersionMatchesManifest` so CI fails on any future drift.

### #87 — `loadSysForms` poisoned cache under concurrency (valid, real latent bug)
The success path never cleared `sysFormsErr` and both failure paths cached the error with `sysFormsLoaded=true`. In the stateless/SSE server a failing + succeeding request racing on the same workspace could leave the cache permanently `{validForms, staleErr}`, after which every caller (`if sysErr != nil …`) silently stopped resolving form-name→id until restart. Now **only successes are cached** (failures are retried, never poisoned), the success write runs under a **double-check**, and the now-unused `sysFormsErr` field is removed. Adds a retry-after-transient-failure test.

### #88 — `createEdgeLink` ignored `mass_links` per-item error (valid; defensive)
The parsed `error bool` was never checked, so an `{error:true, data:{id:…}}` item would be recorded as a live edge — a silent ghost. Guarded the success branch on `!resp.Data[0].Error`. Note: the current pong-server strips the id from a failed item (`ErrorRes` returns `{error:true, errMsg}` with no `data`), so there is **no active data loss today** — this enforces the contract defensively. Adds positive/negative tests.

`go build` / `go vet` / `go test ./...` all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)