### PR TITLE
feat(auth): authenticate with a workspace API key via SIMULATOR_API_SECRET

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,5 +179,8 @@ For a multi-call/computational tool, add it under `internal/engines/` and regist
 
 ## Security
 
-This repo touches OAuth tokens (stored in `.env`, mode `0600`). Never log token values,
-never commit a `.env`, and keep TLS verification on by default.
+This repo touches OAuth tokens (stored in `.env`, mode `0600`) and user-supplied API keys
+(`SIMULATOR_API_SECRET`, read-only to the plugin). Never log token or key values, never write
+`SIMULATOR_API_SECRET` to `.env`, never commit a `.env`, and keep TLS verification on by
+default. Auth-mode logging reports the mode name only — never a value, length, prefix or
+fingerprint.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,15 +63,18 @@
   environment) — `loadDotEnv` never overrides a value already in the environment, so a key exported
   in a developer's shell can outrank the project's `.env` while the base URL still comes from that
   file, and nothing in the log used to say so. Sources only; never the value.
-- **A `.env` line the loader could read but the writers could not find.** `loadDotEnv` accepts
-  `export KEY=value` and indented lines; `updateEnvFileMulti` / `removeEnvKey` matched a bare `KEY=`
-  prefix. So a rewrite of a key already present in one of those shapes **appended a second line** —
-  and the loader takes the FIRST occurrence, so `login`, `set-workspace` and `set-environment`
-  silently lost their new value on the next start, while `auth.Delete` left an `export ACCESS_TOKEN=`
-  line in place and the "cleared" token came straight back. Both sides now normalise through one
-  `auth.ParseEnvLine`, matching whole keys and preserving an existing `export` keyword on rewrite
-  (the user may be sourcing the file). A cross-package test drives loader and writers against each
-  other so the two cannot drift apart again.
+- **A `.env` line the loader could read but the writers could not find (pre-existing).**
+  `loadDotEnv` trims a line before splitting it, so it has always read `  KEY=value` and
+  `KEY = value`; `updateEnvFileMulti` / `removeEnvKey` matched a bare `KEY=` prefix and did not. So
+  a rewrite of a key already present in one of those shapes **appended a second line** — and the
+  loader takes the FIRST occurrence, so `login`, `set-workspace` and `set-environment` silently lost
+  their new value on the next start, while `auth.Delete` left the line in place and the "cleared"
+  token came straight back. This predates the API-key work and affected `ACCESS_TOKEN` /
+  `WORKSPACE_ID` on any indented `.env`. Both sides now normalise through one `auth.ParseEnvLine`,
+  matching whole keys and preserving the file's BOM and the author's indentation on rewrite. A
+  cross-package test drives loader and writers against each other so the two cannot drift apart
+  again. `.env` is not a shell script, so `export KEY=value` is deliberately NOT an assignment —
+  both sides skip it alike.
 - **`simulator-app-generator` skill.** Generates a complete multi-page Smart Form app from a set
   of existing Corezoid process ids plus a product description: pulls every process, derives its
   real input/output contract from its `api_rpc_reply` nodes (declared `params` drift and are only
@@ -99,10 +102,11 @@
   `API returned 401: …` with no clue whether the key, `WORKSPACE_ID` or the environment was wrong.
   Both HTTP stacks now append a mode-aware remediation hint (never containing credential material,
   and suppressed in stateless mode, where the credential came from the caller).
-- **`.env` parser silently mangled hand-written values.** Quoted values became part of the
-  Authorization header (`Bearer "abc"`), while an `export ` prefix or a UTF-8 BOM (Notepad /
-  PowerShell) left the variable unset with no explanation. Machine-written keys never hit these,
-  but `SIMULATOR_API_SECRET` is pasted by hand. Inline `#` is still treated as part of the value.
+- **`.env` parser silently mangled hand-written values (pre-existing).** Quoted values became part
+  of the Authorization header (`Bearer "abc"`), and a UTF-8 BOM (Notepad / PowerShell) left the
+  first line's variable unset with no explanation. Machine-written keys never hit these, but a
+  hand-pasted `ACCESS_TOKEN` already could, and `SIMULATOR_API_SECRET` always is. Inline `#` is
+  still treated as part of the value.
 - **`ecore.EnsureAuth` never cleared its cached Authorization header.** It only overwrote the
   process-global cache on success, so a removed or revoked credential would keep being sent by
   engine tools while the curated tools reported "not authenticated". The cache is now authoritative.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,20 @@
 ## [Unreleased]
 
 ### Added
+- **API-key authentication (`SIMULATOR_API_SECRET`).** A second, non-interactive auth mode for CI,
+  headless runs and service integrations: set a workspace access key in `.env` and every request is
+  sent as `Authorization: Bearer <key>` instead of the OAuth `Simulator <jwt>`. The key takes
+  precedence over `ACCESS_TOKEN` and saved OAuth credentials, and the OAuth flow is disabled end to
+  end — `login` returns an explanation instead of opening a browser (so the telemetry-email
+  elicitation never fires), `auth.Save` refuses to write a token, and `set-environment` refuses to
+  re-point the gateway, since a key is scoped to one workspace on one gateway and switching would
+  send it to a host it was not issued for. The plugin only ever reads the key: it is never written
+  back to `.env`, logged, or included in telemetry. Because a key is long-lived, the server refuses
+  to start when the API base URL would send it over plaintext HTTP to a non-local host
+  (`SIMULATOR_ALLOW_INSECURE_API_SECRET=1` overrides), and stateless/SSE construction rejects the
+  mode outright as incompatible with per-request multi-tenant auth. Implemented as a single branch
+  in `auth.Load` plus the existing per-credential `TokenType`, so no header call site changed; the
+  `app/auth` package gets its first tests.
 - **`simulator-app-generator` skill.** Generates a complete multi-page Smart Form app from a set
   of existing Corezoid process ids plus a product description: pulls every process, derives its
   real input/output contract from its `api_rpc_reply` nodes (declared `params` drift and are only
@@ -66,6 +80,17 @@
 - **Graph import/export tools — `exportGraph`, `importGraph`, `uploadGraphFile`, `getTaskStatus`.** Wraps the pong-server async task API so a workspace graph (actors, edges, forms, and optionally attachments / transactions / processes / users / balances) can be exported to a `.graph` archive or re-imported, mirroring the UI's Export/Import buttons — distinct from the existing `pullGraphFile`/`pushGraphFile` developer sync tools, which edit a single layer's YAML and never touch `.graph` archives. `exportGraph` requires at least one of `actors`/`forms`/`allWorkspace`; `uploadGraphFile` accepts a `.graph` file as base64 or a public URL (capped at 100 MiB either way) and returns a storage `fileName` for `importGraph`; `getTaskStatus` polls a task by id and, for a completed export, returns a ready-to-share `downloadUrl` alongside the raw `details.file.fileName`.
 
 ### Fixed
+- **Actionable 401/403 errors.** A rejected credential used to surface as a bare
+  `API returned 401: …` with no clue whether the key, `WORKSPACE_ID` or the environment was wrong.
+  Both HTTP stacks now append a mode-aware remediation hint (never containing credential material,
+  and suppressed in stateless mode, where the credential came from the caller).
+- **`.env` parser silently mangled hand-written values.** Quoted values became part of the
+  Authorization header (`Bearer "abc"`), while an `export ` prefix or a UTF-8 BOM (Notepad /
+  PowerShell) left the variable unset with no explanation. Machine-written keys never hit these,
+  but `SIMULATOR_API_SECRET` is pasted by hand. Inline `#` is still treated as part of the value.
+- **`ecore.EnsureAuth` never cleared its cached Authorization header.** It only overwrote the
+  process-global cache on success, so a removed or revoked credential would keep being sent by
+  engine tools while the curated tools reported "not authenticated". The cache is now authoritative.
 - **`serverInfo.version` reported `2.1.0` while every manifest was at `2.7.0` (#89).** The version
   returned in the MCP `initialize` handshake came from two stale Go consts (`cmd/server`'s and
   `mcpserver.defaultVersion`) that `scripts/release.sh` never bumped — it only touched the six

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,11 +52,26 @@
   re-point the gateway, since a key is scoped to one workspace on one gateway and switching would
   send it to a host it was not issued for. The plugin only ever reads the key: it is never written
   back to `.env`, logged, or included in telemetry. Because a key is long-lived, the server refuses
-  to start when the API base URL would send it over plaintext HTTP to a non-local host
-  (`SIMULATOR_ALLOW_INSECURE_API_SECRET=1` overrides), and stateless/SSE construction rejects the
-  mode outright as incompatible with per-request multi-tenant auth. Implemented as a single branch
-  in `auth.Load` plus the existing per-credential `TokenType`, so no header call site changed; the
-  `app/auth` package gets its first tests.
+  to start when the API base URL would send it over plaintext HTTP to a non-local host, and
+  stateless/SSE construction rejects the mode outright as incompatible with per-request multi-tenant
+  auth. That plaintext override (`SIMULATOR_ALLOW_INSECURE_API_SECRET`) is parsed as a **boolean**
+  rather than the repo's usual "set to anything" convention: the natural way to turn a switch off is
+  `=0`, and under a non-empty test that would have DISABLED the guard protecting the one credential
+  that never expires. Implemented as a single branch in `auth.Load` plus the existing per-credential
+  `TokenType`, so no header call site changed; the `app/auth` package gets its first tests. In
+  API-key mode the startup line now also names where each half came from (`.env` vs the process
+  environment) — `loadDotEnv` never overrides a value already in the environment, so a key exported
+  in a developer's shell can outrank the project's `.env` while the base URL still comes from that
+  file, and nothing in the log used to say so. Sources only; never the value.
+- **A `.env` line the loader could read but the writers could not find.** `loadDotEnv` accepts
+  `export KEY=value` and indented lines; `updateEnvFileMulti` / `removeEnvKey` matched a bare `KEY=`
+  prefix. So a rewrite of a key already present in one of those shapes **appended a second line** —
+  and the loader takes the FIRST occurrence, so `login`, `set-workspace` and `set-environment`
+  silently lost their new value on the next start, while `auth.Delete` left an `export ACCESS_TOKEN=`
+  line in place and the "cleared" token came straight back. Both sides now normalise through one
+  `auth.ParseEnvLine`, matching whole keys and preserving an existing `export` keyword on rewrite
+  (the user may be sourcing the file). A cross-package test drives loader and writers against each
+  other so the two cannot drift apart again.
 - **`simulator-app-generator` skill.** Generates a complete multi-page Smart Form app from a set
   of existing Corezoid process ids plus a product description: pulls every process, derives its
   real input/output contract from its `api_rpc_reply` nodes (declared `params` drift and are only

--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ Restart Claude Code / Codex after updating to apply the new version. For AWS Kir
 
 ## Authentication
 
+There are two ways to authenticate. The interactive OAuth2 flow below is the default. If you
+already hold a **workspace API key**, put it in `.env` as `SIMULATOR_API_SECRET` and skip
+straight to [API key](#api-key-non-interactive) — the rest of this section does not apply.
+
 Simulator runs on many environments (cloud, on-prem, local dev), so the first step is to
 **choose one**. The `set-environment` tool takes a cloud preset — `mw.simulator.company`
 (default) or `sim.simulator.company` — or a custom/local URL (host or full URL; `/papi/1.0`
@@ -133,21 +137,50 @@ You can also trigger login manually at any time:
 log in to Simulator
 ```
 
+### API key (non-interactive)
+
+For CI, headless runs and service integrations, authenticate with a pre-issued **workspace
+access key** instead of a browser sign-in. Create one at `account.corezoid.com` → workspace,
+then put it in `.env` alongside the gateway and the workspace it belongs to:
+
+```bash
+SIMULATOR_API_BASE_URL=https://mw.simulator.company/papi/1.0
+SIMULATOR_API_SECRET=your_workspace_key
+WORKSPACE_ID=the_key_s_workspace_accId
+```
+
+Every request is then sent as `Authorization: Bearer <key>`, and the OAuth flow is disabled
+end to end: `login` explains itself instead of opening a browser, no token is written to
+`.env`, and `set-environment` refuses (the key is scoped to **one workspace on one gateway**,
+so switching environments at runtime would send it to a host it was not issued for — change
+`.env` and restart instead).
+
+The plugin only ever *reads* `SIMULATOR_API_SECRET`; it never writes it back to `.env`, logs
+it, or sends it in telemetry. `.env` is read once at startup, so a restart is required after
+editing it. Because the key is long-lived, the server refuses to start if the API base URL
+would send it over plaintext HTTP to a non-local host — override with
+`SIMULATOR_ALLOW_INSECURE_API_SECRET=1` only on a trusted network.
+
+If you get a 401, the error names all three suspects: the key itself, `WORKSPACE_ID`, and
+whether the key belongs to the environment in `SIMULATOR_API_BASE_URL`.
+
 ### Static token (optional)
 
-If you prefer to manage the token yourself, set it in `.env` or export it before starting Claude Code, Codex or Kiro:
+If you prefer to manage the OAuth token yourself, set it in `.env` or export it before starting Claude Code, Codex or Kiro:
 
 ```bash
 export ACCESS_TOKEN=your_token_here
 ```
 
-The static token takes priority over saved credentials.
+Precedence is `SIMULATOR_API_SECRET` > `ACCESS_TOKEN` > saved OAuth credentials. A static
+token is sent as `Simulator <jwt>`; it is ignored entirely when `SIMULATOR_API_SECRET` is set.
 
 ## Configuration
 
 | Environment variable          | Required | Description                                                                 |
 |-------------------------------|----------|-----------------------------------------------------------------------------|
-| `ACCESS_TOKEN`                | No       | Static token — overrides OAuth2 saved credentials                           |
+| `SIMULATOR_API_SECRET`        | No       | Workspace API key. When set, every request uses `Authorization: Bearer <key>`; it overrides `ACCESS_TOKEN` and saved OAuth credentials, and disables `login` / `set-environment`. Never written to `.env` by the plugin |
+| `ACCESS_TOKEN`                | No       | Static OAuth token, sent as `Simulator <jwt>` — overrides saved OAuth credentials; ignored when `SIMULATOR_API_SECRET` is set |
 | `ACCESS_TOKEN_EXPIRES_AT`     | No       | Token expiry timestamp (RFC 3339) — written automatically after OAuth login |
 | `ACCOUNT_URL`                 | No       | OAuth account (SA) URL — set automatically by `set-environment` (derived from the gateway's public config); overrides the default `https://account.corezoid.com` |
 | `WORKSPACE_ID`                | No       | Default workspace ID (`accId`) — set automatically after `set-workspace`    |
@@ -155,11 +188,12 @@ The static token takes priority over saved credentials.
 | `SIMULATOR_API_BASE_URL`      | No       | API base URL — set automatically by `set-environment`; overrides the profile (e.g. `http://localhost:9000/papi/1.0`) |
 | `SIMULATOR_ACCOUNT_URL`       | No       | Override the profile's OAuth account (SA) URL                                |
 | `SIMULATOR_OAUTH_CLIENT_ID`   | No       | OAuth2 client ID — on-prem deployments with a custom authorization server should set this to their own client ID; cloud (account.corezoid.com) users do not need it |
+| `SIMULATOR_ALLOW_INSECURE_API_SECRET` | No | Allow `SIMULATOR_API_SECRET` to be sent over plaintext HTTP to a non-local host. Without it the server refuses to start in that configuration (loopback is always exempt) |
 | `SIMULATOR_ANALYTICS_DISABLED` | No      | Set to any non-empty value to opt out of anonymous tool-call telemetry     |
 | `SIMULATOR_ANALYTICS_ENDPOINT` | No      | Override the telemetry ingest endpoint (built-in default: the Corezoid team's public analytics process) |
 | `SIMULATOR_ANALYTICS_CONV_ID`  | No      | Override the telemetry `conv_id` (default `1852976`)                       |
 
-All values are read from a `.env` file in the current working directory at startup, and the `login` / `set-workspace` tools persist their results back to that file.
+All values are read from a `.env` file in the current working directory at startup, and the `login` / `set-workspace` tools persist their results back to that file — except `SIMULATOR_API_SECRET`, which the plugin only ever reads. Because `.env` is read once at startup, editing it requires a restart.
 
 ## Telemetry
 
@@ -443,7 +477,8 @@ two things for development:
   hidden, so end users are only offered the cloud gateways (`mw` / `sim`) and a custom URL.
 
 `login` / `set-workspace` (and `set-environment`) write `ACCESS_TOKEN` / `WORKSPACE_ID` /
-`SIMULATOR_API_BASE_URL` / `ACCOUNT_URL` back into this same file.
+`SIMULATOR_API_BASE_URL` / `ACCOUNT_URL` back into this same file. `SIMULATOR_API_SECRET` is
+never written — it is yours to manage.
 
 ### 2. Connect it in Claude Code
 
@@ -497,6 +532,10 @@ log in to Simulator          # OAuth in the browser → token saved to .env
 which workspaces do I have?  # getWorkspaces → list by name
 work in <workspace name>     # set-workspace(name=…) → saves WORKSPACE_ID
 ```
+
+Already have a workspace API key? Put `SIMULATOR_API_SECRET=…` in `.env` instead, skip
+`login` entirely, and go straight to `set-workspace` (see
+[API key](#api-key-non-interactive)).
 
 ### 4. Restart after you change the plugin
 

--- a/README.md
+++ b/README.md
@@ -166,11 +166,21 @@ whether the key belongs to the environment in `SIMULATOR_API_BASE_URL`.
 
 ### Static token (optional)
 
-If you prefer to manage the OAuth token yourself, set it in `.env` or export it before starting Claude Code, Codex or Kiro:
+If you prefer to manage the OAuth token yourself, put it in `.env`:
+
+```
+ACCESS_TOKEN=your_token_here
+```
+
+…or export it in your shell before starting Claude Code, Codex or Kiro:
 
 ```bash
 export ACCESS_TOKEN=your_token_here
 ```
+
+`.env` is not a shell script, so the `export` keyword belongs only in the second form — a
+line like `export ACCESS_TOKEN=…` inside `.env` is not an assignment and is skipped. The
+same applies to `SIMULATOR_API_SECRET`.
 
 Precedence is `SIMULATOR_API_SECRET` > `ACCESS_TOKEN` > saved OAuth credentials. A static
 token is sent as `Simulator <jwt>`; it is ignored entirely when `SIMULATOR_API_SECRET` is set.

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ token is sent as `Simulator <jwt>`; it is ignored entirely when `SIMULATOR_API_S
 | `SIMULATOR_API_BASE_URL`      | No       | API base URL — set automatically by `set-environment`; overrides the profile (e.g. `http://localhost:9000/papi/1.0`) |
 | `SIMULATOR_ACCOUNT_URL`       | No       | Override the profile's OAuth account (SA) URL                                |
 | `SIMULATOR_OAUTH_CLIENT_ID`   | No       | OAuth2 client ID — on-prem deployments with a custom authorization server should set this to their own client ID; cloud (account.corezoid.com) users do not need it |
-| `SIMULATOR_ALLOW_INSECURE_API_SECRET` | No | Allow `SIMULATOR_API_SECRET` to be sent over plaintext HTTP to a non-local host. Without it the server refuses to start in that configuration (loopback is always exempt) |
+| `SIMULATOR_ALLOW_INSECURE_API_SECRET` | No | Allow `SIMULATOR_API_SECRET` to be sent over plaintext HTTP to a non-local host. Without it the server refuses to start in that configuration (loopback is always exempt). Parsed as a **boolean** — `1`/`true` opens it, `0`/`false`/anything unparseable keeps the guard closed |
 | `SIMULATOR_ANALYTICS_DISABLED` | No      | Set to any non-empty value to opt out of anonymous tool-call telemetry     |
 | `SIMULATOR_ANALYTICS_ENDPOINT` | No      | Override the telemetry ingest endpoint (built-in default: the Corezoid team's public analytics process) |
 | `SIMULATOR_ANALYTICS_CONV_ID`  | No      | Override the telemetry `conv_id` (default `1852976`)                       |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,7 +27,7 @@ In scope:
 - the Go MCP server (`plugins/simulator/mcp-server/`) — auth handling, the API client, and the
   engine tools that touch the filesystem (`pullGraphFile`/`pushGraphFile`,
   `uploadActorPicture(Bulk)`),
-- handling of credentials, tokens, and `.env` material.
+- handling of credentials, tokens, API keys (`SIMULATOR_API_SECRET`), and `.env` material.
 
 Out of scope:
 
@@ -38,9 +38,13 @@ Out of scope:
 ## Handling of secrets
 
 - TLS verification is on by default; the server warns when it would send a token over plaintext
-  HTTP to a non-local host.
+  HTTP to a non-local host, and **refuses to start** when that credential is a long-lived
+  `SIMULATOR_API_SECRET` (loopback exempt; `SIMULATOR_ALLOW_INSECURE_API_SECRET=1` overrides).
 - Tokens and `.env` are never logged or committed. If you find a path where they leak, that is
   in scope — please report it.
+- `SIMULATOR_API_SECRET` is read-only to the plugin: it is never written back to `.env`, never
+  logged (only the *fact* that API-key mode is active), and never included in telemetry — the
+  one-time email opt-in runs from `login`, which is disabled in that mode.
 
 ## Telemetry
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -44,7 +44,7 @@ files and the [entity docs](../plugins/simulator/docs/entities/README.md).
 │   app/auth          ── OAuth2 PKCE login + .env credential storage    │
 │      │                                                                │
 │      ▼                                                                │
-│   internal/apiclient ── HTTP: base URL · Bearer · accId · timeouts ─▶ │
+│   internal/apiclient ── HTTP: base URL · Auth · accId · timeouts ─▶   │
 └───────────────────────────────────────┬─────────────────────────────┘
                                          │ HTTPS (Authorization, accId path/query)
                                          ▼
@@ -207,13 +207,18 @@ Conventions baked into the registry:
 ### 3.4 Workspace & auth context
 
 Every API call needs an `Authorization` header and a workspace id (`accId`). Both come from
-`.env`: the token is written by `login`; `WORKSPACE_ID` is written by `set-workspace`. The
+`.env`: the token is written by `login`; `WORKSPACE_ID` is written by `set-workspace`. When
+`SIMULATOR_API_SECRET` is set, `auth.Load` short-circuits and returns that key instead (see
+§5) — read live per request, like the token, but never written by the plugin, and `WORKSPACE_ID`
+must be set by hand to the workspace the key was issued for. The
 `apiclient` injects `accId` into path/query params that need it, and guards the live base URL
 and workspace value with an `RWMutex` — `set-environment` mutates the base URL and clears the
 workspace, `set-workspace` mutates the workspace, while tool calls read them. Switching
 environment with `set-environment` clears the token + workspace (workspaces are per-
 environment) and updates both the `apiclient` and engine base URLs in place, so it takes
-effect without a restart and forces a fresh `login`.
+effect without a restart and forces a fresh `login`. In API-key mode `set-environment`
+refuses outright: the key is bound to one gateway, so re-pointing the server would send it
+to a host it was not issued for.
 
 For embedded/SSE deployments, per-request overrides arrive on `ctx` (wired from headers by
 the transport): `WithAuthorization`, `WithBaseURL`, `WithWorkspaceID`, `WithActorID`, and
@@ -299,6 +304,38 @@ handles cascading deletes; its form name→id cache is per-workspace under a `sy
 
 ## 5. Authentication (`app/auth`)
 
+### Auth modes
+
+`auth.Load` resolves the active credential in precedence order, and `Credentials.TokenType`
+— assembled into a header by the single `AuthorizationHeader()` method — selects the scheme:
+
+| Precedence | Source                  | Header               | Written by the plugin? |
+|-----------:|-------------------------|----------------------|------------------------|
+| 1          | `SIMULATOR_API_SECRET`  | `Bearer <key>`       | Never — user-managed   |
+| 2          | `ACCESS_TOKEN`          | `Simulator <jwt>`    | Yes, by `login`        |
+| 3          | (none)                  | —                    | —                      |
+
+Both HTTP stacks are scheme-agnostic: they forward whatever opaque string that method
+returns, so API-key mode needed no change at any of the ~20 header call sites.
+
+API-key credentials carry a **zero `ExpiresAt`** — a key has no client-visible lifetime, so
+`IsExpired` reports false forever and revocation can only surface as a 401. `Load` returns
+before parsing `ACCESS_TOKEN_EXPIRES_AT`, so a stale expiry line from an earlier `login`
+cannot be applied to the key.
+
+In API-key mode the OAuth flow is disabled end to end: `login` returns an explanation instead
+of opening a browser (so the one-time telemetry-email elicitation never fires either), `Save`
+refuses to write a token, and `set-environment` refuses to re-point the gateway. The mode is
+fixed at startup — `.env` is read once — so both the `login` notice and the startup log say a
+restart is required. Stateless/SSE construction rejects the combination outright: a key is
+process-global and cannot serve per-request, multi-tenant auth.
+
+A 401/403 gets an actionable hint naming the three suspects (key, `WORKSPACE_ID`,
+environment) via `Client.AuthHint` in `apiclient` and `ecore.HTTPStatusError` in the engines;
+the hint never carries credential material and is suppressed in stateless mode.
+
+### OAuth2 PKCE flow
+
 ```
 login tool
   │
@@ -315,14 +352,18 @@ login tool
 config) and falls back to the resolved profile's account URL when it is unset.
 
 - **Storage**: plaintext `.env` in the working directory, mode `0600`. Writes are serialised
-  under a mutex and token + expiry are written in a single pass.
+  under a mutex and token + expiry are written in a single pass. `SIMULATOR_API_SECRET` is
+  read-only to the plugin: no writer touches that key, `Delete` matches on the exact
+  `ACCESS_TOKEN=` prefix, and the mode is never logged with any part of the value.
 - **Account URL** is derived per environment by `set-environment` (gateway public config →
   `saUrl`) and saved as `ACCOUNT_URL`; absent that, it comes from the resolved profile
   (`account.corezoid.com` for prod, `account.pre.corezoid.com` for local). The OAuth client id
   is overridable via `SIMULATOR_OAUTH_CLIENT_ID`. Local mirrors production — same PKCE flow,
   different SA.
 - **TLS**: certificate verification is **on by default**; `--insecure` is for self-signed
-  on-prem gateways.
+  on-prem gateways. In API-key mode the plaintext-HTTP warning is escalated to a startup
+  refusal (loopback exempt), because a long-lived key leaked on the wire is a durable
+  compromise rather than a 12h one; `SIMULATOR_ALLOW_INSECURE_API_SECRET=1` overrides.
 
 ---
 

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -318,7 +318,14 @@ replaces the 3k-line `server.go`: simple CRUD is generated from the curated spec
 Both profiles use the **same OAuth2-PKCE flow**; only `accountUrl` (SA) and `apiBaseUrl`
 differ. Local prerequisite: the local `pong-server` must trust the same SA the plugin logs
 into (`account.pre.corezoid.com`) — i.e. its `auth.saSecretKey` / registered OAuth `control`
-client point at that SA. No static-token path is required for normal use.
+client point at that SA. For normal interactive use the PKCE path is enough.
+
+A non-interactive path also exists: set `SIMULATOR_API_SECRET` and the plugin sends
+`Authorization: Bearer <key>` on every request, skipping OAuth entirely. That is the
+`ApiToken` scheme the dumped spec already declares
+(`internal/tools/testdata/papi-openapi.json` → `components.securitySchemes`), and it relies on
+`checkPublicApiAuth.js` accepting both schemes (§1). The key is workspace-scoped, so
+`WORKSPACE_ID` must name the workspace it was issued for.
 
 ## 9. pong-server changes — operationId at source
 

--- a/plugins/simulator/docs/user-flows/README.md
+++ b/plugins/simulator/docs/user-flows/README.md
@@ -44,13 +44,15 @@ For detailed information about the entities used in these user flows, please ref
 
 ## Authentication
 
-All API requests require a Bearer token:
+All API requests carry an `Authorization` header. Which scheme depends on the credential:
 
 ```
-Authorization: Simulator <your_token>
+Authorization: Simulator <jwt>    # OAuth2 login — token in ACCESS_TOKEN
+Authorization: Bearer <key>       # workspace API key — in SIMULATOR_API_SECRET
 ```
 
-The token is set via the `ACCESS_TOKEN` environment variable and passed automatically by the MCP server.
+Both are set from environment variables and applied automatically by the MCP server; you never
+build this header yourself. `SIMULATOR_API_SECRET` takes precedence over `ACCESS_TOKEN`.
 
 ## API Documentation
 

--- a/plugins/simulator/mcp-server/README.md
+++ b/plugins/simulator/mcp-server/README.md
@@ -23,7 +23,7 @@ go run ./cmd/server --profile local   # dev pong-server on :9000, pre SA
 go run ./cmd/server --profile prod    # public gateway (default)
 ```
 
-The server reads `ACCESS_TOKEN`, `WORKSPACE_ID`, etc. from a `.env` file in the **current
+The server reads `SIMULATOR_API_SECRET`, `ACCESS_TOKEN`, `WORKSPACE_ID`, etc. from a `.env` file in the **current
 working directory**. The `login` and `set-workspace` tools write back to it. See the root
 [`README.md`](../../../README.md#configuration) for the full env-var table.
 
@@ -57,7 +57,7 @@ This runs `npx @modelcontextprotocol/inspector go run ./cmd/server --profile $(P
 in this module dir, so the server picks up `.env` from here exactly as the `run-*` targets
 do. The command prints a `http://localhost:6274` URL with a session token — open it, then
 **Connect** → **Tools** / **Resources**. Tool calls hit the real backend, so authenticate
-first (run the `login` tool, or have a valid `ACCESS_TOKEN`/`WORKSPACE_ID` in `.env`).
+first (run the `login` tool, or have a valid `SIMULATOR_API_SECRET` / `ACCESS_TOKEN` plus `WORKSPACE_ID` in `.env`).
 
 For scripted/CI use, the Inspector also has a headless CLI mode — handy for diffing the
 tool surface without the UI:

--- a/plugins/simulator/mcp-server/app/auth/credentials.go
+++ b/plugins/simulator/mcp-server/app/auth/credentials.go
@@ -55,17 +55,22 @@ func updateEnvFileMulti(path string, kv [][2]string) error {
 		}
 	}
 	for _, pair := range kv {
-		prefix := pair[0] + "="
 		found := false
 		for i, line := range lines {
-			if strings.HasPrefix(line, prefix) {
-				lines[i] = prefix + pair[1]
-				found = true
-				break
+			// Match on the parsed key, not a "KEY=" prefix: the loader also reads
+			// `export KEY=…` and indented lines, and matching only the bare shape
+			// appended a duplicate the loader then ignored in favour of the stale
+			// first occurrence. The line's own prefix is preserved on rewrite.
+			linePrefix, ok := envLineAssigns(line, pair[0])
+			if !ok {
+				continue
 			}
+			lines[i] = linePrefix + pair[0] + "=" + pair[1]
+			found = true
+			break
 		}
 		if !found {
-			lines = append(lines, prefix+pair[1])
+			lines = append(lines, pair[0]+"="+pair[1])
 		}
 	}
 	return os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0600)
@@ -87,10 +92,11 @@ func removeEnvKey(path, key string) error {
 		return err
 	}
 
-	prefix := key + "="
 	var kept []string
 	for _, line := range strings.Split(string(data), "\n") {
-		if !strings.HasPrefix(line, prefix) {
+		// Same normalisation as the loader — an `export ACCESS_TOKEN=…` line used
+		// to survive a logout, and the token came back on the next start.
+		if _, assigns := envLineAssigns(line, key); !assigns {
 			kept = append(kept, line)
 		}
 	}
@@ -178,7 +184,7 @@ func Save(creds *Credentials) error {
 // from the .env file and from the in-process environment.
 //
 // SIMULATOR_API_SECRET is never touched: it is user-managed, and removeEnvKey
-// matches on the exact "ACCESS_TOKEN=" prefix. Clearing a leftover OAuth token
+// matches whole keys, so only ACCESS_TOKEN lines go. Clearing a leftover OAuth token
 // is still correct hygiene in API-key mode, so this is not gated on the mode.
 func Delete() error {
 	envMu.Lock()

--- a/plugins/simulator/mcp-server/app/auth/credentials.go
+++ b/plugins/simulator/mcp-server/app/auth/credentials.go
@@ -57,10 +57,11 @@ func updateEnvFileMulti(path string, kv [][2]string) error {
 	for _, pair := range kv {
 		found := false
 		for i, line := range lines {
-			// Match on the parsed key, not a "KEY=" prefix: the loader also reads
-			// `export KEY=…` and indented lines, and matching only the bare shape
-			// appended a duplicate the loader then ignored in favour of the stale
-			// first occurrence. The line's own prefix is preserved on rewrite.
+			// Match on the parsed key, not a "KEY=" prefix: the loader trims a line
+			// before splitting it, so it reads `  KEY=…`, `KEY = …` and a BOM'd
+			// first line that the bare-prefix match missed — and a miss appended a
+			// duplicate the loader then ignored in favour of the stale first
+			// occurrence. The line's own prefix is preserved on rewrite.
 			linePrefix, ok := envLineAssigns(line, pair[0])
 			if !ok {
 				continue
@@ -94,8 +95,8 @@ func removeEnvKey(path, key string) error {
 
 	var kept []string
 	for _, line := range strings.Split(string(data), "\n") {
-		// Same normalisation as the loader — an `export ACCESS_TOKEN=…` line used
-		// to survive a logout, and the token came back on the next start.
+		// Same normalisation as the loader — an indented or BOM'd ACCESS_TOKEN
+		// line used to survive a logout, and the token came back on the next start.
 		if _, assigns := envLineAssigns(line, key); !assigns {
 			kept = append(kept, line)
 		}

--- a/plugins/simulator/mcp-server/app/auth/credentials.go
+++ b/plugins/simulator/mcp-server/app/auth/credentials.go
@@ -14,18 +14,19 @@ import (
 // several mutations); the exported functions below acquire it.
 var envMu sync.Mutex
 
-// Credentials holds the Simulator JWT token.
+// Credentials holds the active Simulator credential — either an OAuth JWT or a
+// user-supplied workspace API key. TokenType selects the header scheme.
 type Credentials struct {
 	AccessToken string    `json:"access_token"`
 	ExpiresAt   time.Time `json:"expires_at"`
-	TokenType   string    `json:"token_type"` // always "Simulator"
+	TokenType   string    `json:"token_type"` // TokenTypeSimulator (OAuth) or TokenTypeBearer (API key)
 }
 
 // AuthorizationHeader returns the value to use for the Authorization header.
 func (c *Credentials) AuthorizationHeader() string {
 	tokenType := c.TokenType
 	if tokenType == "" {
-		tokenType = "Simulator"
+		tokenType = TokenTypeSimulator
 	}
 	return tokenType + " " + c.AccessToken
 }
@@ -105,17 +106,33 @@ func removeEnvKey(path, key string) error {
 	return os.WriteFile(path, []byte(content), 0600)
 }
 
-// Load reads credentials from environment variables.
-// The env vars are populated from .env by FindAndLoadDotEnv() at startup.
-// Returns nil, nil if ACCESS_TOKEN is not set.
+// Load returns the active credentials, in precedence order:
+//
+//  1. SIMULATOR_API_SECRET — a user-managed workspace API key, sent as
+//     "Bearer <key>". It wins over everything and disables the OAuth flow.
+//  2. ACCESS_TOKEN — a Simulator JWT (written by `login`, or set by hand),
+//     sent as "Simulator <jwt>".
+//
+// Returns nil, nil when neither is set. The env vars are populated from .env by
+// cmd/server's loadDotEnv at startup, so an external edit needs a restart.
+// Never returns a non-nil error; the signature is kept for callers.
 func Load() (*Credentials, error) {
+	if secret := APISecret(); secret != "" {
+		// ExpiresAt is deliberately left zero: an API key has no client-visible
+		// lifetime, so IsExpired reports false forever and EnsureAuth never
+		// treats it as stale. The backend is the only authority on revocation,
+		// and it surfaces that as a 401. Returning here (rather than falling
+		// through) also keeps a stale ACCESS_TOKEN_EXPIRES_AT line left over
+		// from a previous `login` from being applied to the key.
+		return &Credentials{AccessToken: secret, TokenType: TokenTypeBearer}, nil
+	}
 	token := os.Getenv("ACCESS_TOKEN")
 	if token == "" {
 		return nil, nil
 	}
 	creds := &Credentials{
 		AccessToken: token,
-		TokenType:   "Simulator",
+		TokenType:   TokenTypeSimulator,
 	}
 	if expiryStr := os.Getenv("ACCESS_TOKEN_EXPIRES_AT"); expiryStr != "" {
 		if t, err := time.Parse(time.RFC3339, expiryStr); err == nil {
@@ -127,7 +144,17 @@ func Load() (*Credentials, error) {
 
 // Save writes ACCESS_TOKEN (and optionally ACCESS_TOKEN_EXPIRES_AT)
 // to the .env file in the current working directory, and updates the in-process env vars.
+//
+// It refuses in API-key mode: an OAuth token saved there would be dead weight
+// on disk (Load never reaches it) while telling the user they are authenticated
+// by a credential that is not in use. The guard lives here, rather than only in
+// the `login` tool, so the invariant holds for any caller.
 func Save(creds *Credentials) error {
+	if IsAPIKeyMode() {
+		return fmt.Errorf("%s is set — refusing to write ACCESS_TOKEN to .env (unset %s to use OAuth login)",
+			APISecretEnv, APISecretEnv)
+	}
+
 	envMu.Lock()
 	defer envMu.Unlock()
 
@@ -149,6 +176,10 @@ func Save(creds *Credentials) error {
 
 // Delete removes ACCESS_TOKEN and ACCESS_TOKEN_EXPIRES_AT
 // from the .env file and from the in-process environment.
+//
+// SIMULATOR_API_SECRET is never touched: it is user-managed, and removeEnvKey
+// matches on the exact "ACCESS_TOKEN=" prefix. Clearing a leftover OAuth token
+// is still correct hygiene in API-key mode, so this is not gated on the mode.
 func Delete() error {
 	envMu.Lock()
 	defer envMu.Unlock()
@@ -220,6 +251,10 @@ func SaveWorkspaceID(accID string) error {
 }
 
 // IsExpired reports whether the credentials are expired.
+//
+// A zero ExpiresAt means "no known expiry" and reports false. API-key
+// credentials always land in that branch: the key has no client-visible
+// lifetime, so revocation can only surface as a 401 from the backend.
 func IsExpired(creds *Credentials) bool {
 	if creds == nil || creds.AccessToken == "" {
 		return true

--- a/plugins/simulator/mcp-server/app/auth/credentials_test.go
+++ b/plugins/simulator/mcp-server/app/auth/credentials_test.go
@@ -1,0 +1,197 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// isolateEnv points .env at a temp dir and clears every credential var, so a
+// developer with SIMULATOR_API_SECRET exported doesn't silently take a different
+// branch through Load().
+func isolateEnv(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("SIMULATOR_WORK_DIR", dir)
+	t.Setenv(APISecretEnv, "")
+	t.Setenv("ACCESS_TOKEN", "")
+	t.Setenv("ACCESS_TOKEN_EXPIRES_AT", "")
+	return dir
+}
+
+func TestLoadPrecedenceAPISecretWins(t *testing.T) {
+	isolateEnv(t)
+	t.Setenv(APISecretEnv, "wsk_key")
+	t.Setenv("ACCESS_TOKEN", "jwt_token")
+
+	creds, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if creds == nil {
+		t.Fatal("Load() = nil, want API-key credentials")
+	}
+	if creds.AccessToken != "wsk_key" {
+		t.Errorf("AccessToken = %q, want the API key", creds.AccessToken)
+	}
+	if creds.TokenType != TokenTypeBearer {
+		t.Errorf("TokenType = %q, want %q", creds.TokenType, TokenTypeBearer)
+	}
+	if !creds.ExpiresAt.IsZero() {
+		t.Errorf("ExpiresAt = %v, want zero", creds.ExpiresAt)
+	}
+	if got := creds.AuthorizationHeader(); got != "Bearer wsk_key" {
+		t.Errorf("AuthorizationHeader() = %q, want %q", got, "Bearer wsk_key")
+	}
+}
+
+func TestLoadOAuthWhenNoAPISecret(t *testing.T) {
+	isolateEnv(t)
+	t.Setenv("ACCESS_TOKEN", "jwt_token")
+
+	creds, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if creds == nil {
+		t.Fatal("Load() = nil, want OAuth credentials")
+	}
+	if creds.TokenType != TokenTypeSimulator {
+		t.Errorf("TokenType = %q, want %q", creds.TokenType, TokenTypeSimulator)
+	}
+	if got := creds.AuthorizationHeader(); got != "Simulator jwt_token" {
+		t.Errorf("AuthorizationHeader() = %q, want %q", got, "Simulator jwt_token")
+	}
+}
+
+func TestLoadNilWhenNeitherSet(t *testing.T) {
+	isolateEnv(t)
+
+	creds, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if creds != nil {
+		t.Fatalf("Load() = %+v, want nil", creds)
+	}
+}
+
+// AuthorizationHeader is the single point where the scheme is chosen for ~20
+// header call sites across both HTTP stacks; the empty-TokenType default must
+// keep meaning "Simulator".
+func TestAuthorizationHeaderScheme(t *testing.T) {
+	cases := []struct {
+		name  string
+		creds Credentials
+		want  string
+	}{
+		{"bearer", Credentials{AccessToken: "k", TokenType: TokenTypeBearer}, "Bearer k"},
+		{"simulator", Credentials{AccessToken: "j", TokenType: TokenTypeSimulator}, "Simulator j"},
+		{"empty token type defaults to simulator", Credentials{AccessToken: "j"}, "Simulator j"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.creds.AuthorizationHeader(); got != tc.want {
+				t.Errorf("AuthorizationHeader() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// A stale ACCESS_TOKEN_EXPIRES_AT left in .env by a previous login must not be
+// applied to API-key credentials — otherwise the engine stack would report "not
+// authenticated" while the curated stack (which never checks expiry) kept working.
+func TestIsExpiredAPIKeyIgnoresStaleExpiry(t *testing.T) {
+	isolateEnv(t)
+	t.Setenv(APISecretEnv, "wsk_key")
+	t.Setenv("ACCESS_TOKEN_EXPIRES_AT", time.Now().Add(-24*time.Hour).Format(time.RFC3339))
+
+	creds, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if !creds.ExpiresAt.IsZero() {
+		t.Errorf("ExpiresAt = %v, want zero (stale expiry must not bleed onto the key)", creds.ExpiresAt)
+	}
+	if IsExpired(creds) {
+		t.Error("IsExpired() = true for API-key credentials, want false")
+	}
+}
+
+func TestIsExpired(t *testing.T) {
+	cases := []struct {
+		name  string
+		creds *Credentials
+		want  bool
+	}{
+		{"nil", nil, true},
+		{"empty token", &Credentials{}, true},
+		{"zero expiry never expires", &Credentials{AccessToken: "t"}, false},
+		{"past", &Credentials{AccessToken: "t", ExpiresAt: time.Now().Add(-time.Hour)}, true},
+		{"future", &Credentials{AccessToken: "t", ExpiresAt: time.Now().Add(time.Hour)}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsExpired(tc.creds); got != tc.want {
+				t.Errorf("IsExpired() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSaveRefusesInAPIKeyMode(t *testing.T) {
+	dir := isolateEnv(t)
+	t.Setenv(APISecretEnv, "wsk_key")
+
+	err := Save(&Credentials{AccessToken: "jwt", TokenType: TokenTypeSimulator})
+	if err == nil {
+		t.Fatal("Save() error = nil, want a refusal in API-key mode")
+	}
+	if !strings.Contains(err.Error(), APISecretEnv) {
+		t.Errorf("Save() error = %q, should name %s", err, APISecretEnv)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, ".env")); !os.IsNotExist(statErr) {
+		t.Errorf(".env was created despite the refusal (stat err = %v)", statErr)
+	}
+	if os.Getenv("ACCESS_TOKEN") != "" {
+		t.Error("Save() set ACCESS_TOKEN in the process env despite refusing")
+	}
+}
+
+// set-environment calls Delete(); a user-managed API key must survive it.
+func TestDeleteKeepsAPISecret(t *testing.T) {
+	dir := isolateEnv(t)
+	envPath := filepath.Join(dir, ".env")
+	original := APISecretEnv + "=wsk_key\nACCESS_TOKEN=jwt\nACCESS_TOKEN_EXPIRES_AT=2026-01-01T00:00:00Z\nWORKSPACE_ID=ws1\n"
+	if err := os.WriteFile(envPath, []byte(original), 0o600); err != nil {
+		t.Fatalf("seed .env: %v", err)
+	}
+
+	if err := Delete(); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+
+	data, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatalf("read .env: %v", err)
+	}
+	got := string(data)
+	if !strings.Contains(got, APISecretEnv+"=wsk_key") {
+		t.Errorf("Delete() removed the API key; .env = %q", got)
+	}
+	if !strings.Contains(got, "WORKSPACE_ID=ws1") {
+		t.Errorf("Delete() removed WORKSPACE_ID; .env = %q", got)
+	}
+	if strings.Contains(got, "ACCESS_TOKEN") {
+		t.Errorf("Delete() left an ACCESS_TOKEN line; .env = %q", got)
+	}
+}
+
+func TestEnvFilePathUsesWorkDir(t *testing.T) {
+	dir := isolateEnv(t)
+	if got, want := envFilePath(), filepath.Join(dir, ".env"); got != want {
+		t.Errorf("envFilePath() = %q, want %q", got, want)
+	}
+}

--- a/plugins/simulator/mcp-server/app/auth/envline.go
+++ b/plugins/simulator/mcp-server/app/auth/envline.go
@@ -2,6 +2,10 @@ package auth
 
 import "strings"
 
+// bomPrefix is the UTF-8 byte order mark that Notepad and PowerShell's
+// output redirection put at the start of a file.
+const bomPrefix = "\uFEFF"
+
 // ParseEnvLine normalises one .env line into the key/value pair a reader sees.
 //
 // It is the single source of truth for what a line MEANS, because the loader
@@ -24,6 +28,13 @@ import "strings"
 // Inline comments are NOT stripped: `#` is legal inside a secret, and treating it
 // as a delimiter would corrupt the value.
 func ParseEnvLine(line string) (key, value string, ok bool) {
+	// The BOM belongs here rather than in the file readers: it is part of what a
+	// line MEANS, and leaving it to the loader alone put the readers and the
+	// writers back out of step on exactly the first line of a Notepad /
+	// PowerShell .env — the writers saw a key of "\uFEFFACCESS_TOKEN", missed the
+	// existing assignment, and appended a duplicate the loader then lost to.
+	// TrimSpace does not cover it: U+FEFF is not in unicode.IsSpace.
+	line = strings.TrimPrefix(line, bomPrefix)
 	line = strings.TrimSpace(line) // also drops a CRLF \r
 	if line == "" || strings.HasPrefix(line, "#") {
 		return "", "", false
@@ -75,7 +86,17 @@ func envLineAssigns(line, key string) (prefix string, ok bool) {
 	if !parsed || lineKey != key {
 		return "", false
 	}
-	if i := strings.Index(line, key); i >= 0 {
+	// Search only the assignment's left-hand side, and take the LAST hit: the key
+	// is the final token before "=". strings.Index over the whole raw line finds
+	// the first substring match instead, so `export port=1` keyed on "port" hit
+	// the "port" inside "export" and rewrote the line as `export=2` — renaming
+	// the variable. No current key can trigger that (all are UPPER_SNAKE), but
+	// this helper reads as general-purpose, so it should be.
+	eq := strings.Index(line, "=")
+	if eq < 0 {
+		return "", true // unreachable: ParseEnvLine already required an "="
+	}
+	if i := strings.LastIndex(line[:eq], key); i >= 0 {
 		return line[:i], true
 	}
 	return "", true

--- a/plugins/simulator/mcp-server/app/auth/envline.go
+++ b/plugins/simulator/mcp-server/app/auth/envline.go
@@ -10,17 +10,21 @@ const bomPrefix = "\uFEFF"
 //
 // It is the single source of truth for what a line MEANS, because the loader
 // (cmd/server.loadDotEnv) and the writers in this file have to agree on it. When
-// they did not, the damage was silent and one-directional: the loader accepted
-// `export ACCESS_TOKEN=…` and a leading-indented `  WORKSPACE_ID=…`, while the
-// writers matched a bare `KEY=` prefix, so a rewrite appended a SECOND line for a
-// key that was already there — and the loader takes the FIRST occurrence, so the
-// stale value won again on the next start. `Delete` had the same blind spot:
-// an `export ACCESS_TOKEN=` line survived a logout.
+// they did not, the damage was silent and one-directional: the loader trimmed a
+// line before splitting it, so it read `  WORKSPACE_ID=…` and `KEY = value`,
+// while the writers matched a bare `KEY=` prefix and did not. A rewrite then
+// appended a SECOND line for a key that was already there — and the loader takes
+// the FIRST occurrence, so the stale value won again on the next start. `Delete`
+// had the same blind spot and left the line in place.
 //
 // Accepted shapes (all of them arrive from a human editing .env by hand):
 //
-//	KEY=value            export KEY=value          KEY = value
-//	KEY="value"          KEY='value'               "  KEY=value" (indented)
+//	KEY=value            KEY = value               "  KEY=value" (indented)
+//	KEY="value"          KEY='value'               a leading UTF-8 BOM
+//
+// `.env` is not a shell script, so `export KEY=value` is NOT an assignment here:
+// the key comes out as "export KEY", which contains whitespace, and the line is
+// skipped by both sides alike.
 //
 // ok is false for a blank line, a `#` comment, a line with no `=`, and a key
 // containing whitespace (`foo bar=baz` is not a shell assignment either).
@@ -43,24 +47,11 @@ func ParseEnvLine(line string) (key, value string, ok bool) {
 	if !found {
 		return "", "", false
 	}
-	key = strings.TrimSpace(trimExportPrefix(strings.TrimSpace(rawKey)))
+	key = strings.TrimSpace(rawKey)
 	if key == "" || strings.ContainsAny(key, " \t") {
 		return "", "", false
 	}
 	return key, trimMatchingQuotes(strings.TrimSpace(rawVal)), true
-}
-
-// trimExportPrefix drops a leading `export` keyword. Only a real keyword counts —
-// `exportKEY=1` is a variable named exportKEY.
-func trimExportPrefix(key string) string {
-	const kw = "export"
-	if !strings.HasPrefix(key, kw) || len(key) == len(kw) {
-		return key
-	}
-	if c := key[len(kw)]; c != ' ' && c != '\t' {
-		return key
-	}
-	return strings.TrimSpace(key[len(kw):])
 }
 
 // trimMatchingQuotes removes one matching pair of surrounding single or double
@@ -79,25 +70,16 @@ func trimMatchingQuotes(val string) string {
 
 // envLineAssigns reports whether line is an assignment to key, whatever shape it
 // was written in, and returns the verbatim text before the key so a rewrite can
-// preserve it — a user who wrote `export FOO=…` may be sourcing the file, and
-// silently dropping the keyword would stop it exporting.
+// preserve it — the BOM belongs to the file and an indent is the author's.
+//
+// The prefix is computed structurally rather than by searching for the key: a
+// substring search finds the first match anywhere in the line, which is not
+// necessarily where the key starts.
 func envLineAssigns(line, key string) (prefix string, ok bool) {
 	lineKey, _, parsed := ParseEnvLine(line)
 	if !parsed || lineKey != key {
 		return "", false
 	}
-	// Search only the assignment's left-hand side, and take the LAST hit: the key
-	// is the final token before "=". strings.Index over the whole raw line finds
-	// the first substring match instead, so `export port=1` keyed on "port" hit
-	// the "port" inside "export" and rewrote the line as `export=2` — renaming
-	// the variable. No current key can trigger that (all are UPPER_SNAKE), but
-	// this helper reads as general-purpose, so it should be.
-	eq := strings.Index(line, "=")
-	if eq < 0 {
-		return "", true // unreachable: ParseEnvLine already required an "="
-	}
-	if i := strings.LastIndex(line[:eq], key); i >= 0 {
-		return line[:i], true
-	}
-	return "", true
+	body := strings.TrimLeft(strings.TrimPrefix(line, bomPrefix), " \t")
+	return line[:len(line)-len(body)], true
 }

--- a/plugins/simulator/mcp-server/app/auth/envline.go
+++ b/plugins/simulator/mcp-server/app/auth/envline.go
@@ -1,0 +1,82 @@
+package auth
+
+import "strings"
+
+// ParseEnvLine normalises one .env line into the key/value pair a reader sees.
+//
+// It is the single source of truth for what a line MEANS, because the loader
+// (cmd/server.loadDotEnv) and the writers in this file have to agree on it. When
+// they did not, the damage was silent and one-directional: the loader accepted
+// `export ACCESS_TOKEN=…` and a leading-indented `  WORKSPACE_ID=…`, while the
+// writers matched a bare `KEY=` prefix, so a rewrite appended a SECOND line for a
+// key that was already there — and the loader takes the FIRST occurrence, so the
+// stale value won again on the next start. `Delete` had the same blind spot:
+// an `export ACCESS_TOKEN=` line survived a logout.
+//
+// Accepted shapes (all of them arrive from a human editing .env by hand):
+//
+//	KEY=value            export KEY=value          KEY = value
+//	KEY="value"          KEY='value'               "  KEY=value" (indented)
+//
+// ok is false for a blank line, a `#` comment, a line with no `=`, and a key
+// containing whitespace (`foo bar=baz` is not a shell assignment either).
+//
+// Inline comments are NOT stripped: `#` is legal inside a secret, and treating it
+// as a delimiter would corrupt the value.
+func ParseEnvLine(line string) (key, value string, ok bool) {
+	line = strings.TrimSpace(line) // also drops a CRLF \r
+	if line == "" || strings.HasPrefix(line, "#") {
+		return "", "", false
+	}
+	rawKey, rawVal, found := strings.Cut(line, "=")
+	if !found {
+		return "", "", false
+	}
+	key = strings.TrimSpace(trimExportPrefix(strings.TrimSpace(rawKey)))
+	if key == "" || strings.ContainsAny(key, " \t") {
+		return "", "", false
+	}
+	return key, trimMatchingQuotes(strings.TrimSpace(rawVal)), true
+}
+
+// trimExportPrefix drops a leading `export` keyword. Only a real keyword counts —
+// `exportKEY=1` is a variable named exportKEY.
+func trimExportPrefix(key string) string {
+	const kw = "export"
+	if !strings.HasPrefix(key, kw) || len(key) == len(kw) {
+		return key
+	}
+	if c := key[len(kw)]; c != ' ' && c != '\t' {
+		return key
+	}
+	return strings.TrimSpace(key[len(kw):])
+}
+
+// trimMatchingQuotes removes one matching pair of surrounding single or double
+// quotes. A value that is quoted on one side only is left alone — that is more
+// likely to be part of the secret than a typo we should silently repair.
+func trimMatchingQuotes(val string) string {
+	if len(val) < 2 {
+		return val
+	}
+	first, last := val[0], val[len(val)-1]
+	if first == last && (first == '"' || first == '\'') {
+		return val[1 : len(val)-1]
+	}
+	return val
+}
+
+// envLineAssigns reports whether line is an assignment to key, whatever shape it
+// was written in, and returns the verbatim text before the key so a rewrite can
+// preserve it — a user who wrote `export FOO=…` may be sourcing the file, and
+// silently dropping the keyword would stop it exporting.
+func envLineAssigns(line, key string) (prefix string, ok bool) {
+	lineKey, _, parsed := ParseEnvLine(line)
+	if !parsed || lineKey != key {
+		return "", false
+	}
+	if i := strings.Index(line, key); i >= 0 {
+		return line[:i], true
+	}
+	return "", true
+}

--- a/plugins/simulator/mcp-server/app/auth/envline_prefix_test.go
+++ b/plugins/simulator/mcp-server/app/auth/envline_prefix_test.go
@@ -1,0 +1,49 @@
+package auth
+
+import "testing"
+
+// envLineAssigns returns the verbatim text before the key so a rewrite can
+// preserve it. Getting that offset from the first substring match in the raw
+// line renames the variable when the key also occurs inside the prefix.
+func TestEnvLineAssignsPrefix(t *testing.T) {
+	bom := string([]byte{0xEF, 0xBB, 0xBF})
+	cases := []struct {
+		name, line, key, wantPrefix string
+		wantOK                      bool
+	}{
+		{"bare", "ACCESS_TOKEN=old", "ACCESS_TOKEN", "", true},
+		{"export", "export ACCESS_TOKEN=old", "ACCESS_TOKEN", "export ", true},
+		{"export tab", "export\tACCESS_TOKEN=old", "ACCESS_TOKEN", "export\t", true},
+		{"indented export", "  export ACCESS_TOKEN=old", "ACCESS_TOKEN", "  export ", true},
+		{"spaced equals", "ACCESS_TOKEN = old", "ACCESS_TOKEN", "", true},
+		{"bom keeps the mark", bom + "ACCESS_TOKEN=old", "ACCESS_TOKEN", bom, true},
+		// The key occurs inside the "export" keyword itself. Taking the first
+		// substring hit yielded prefix "ex", rewriting the line as "export=2".
+		{"key is a substring of the prefix", "export port=1", "port", "export ", true},
+		{"value looks like the key", "export FOO=FOO", "FOO", "export ", true},
+		{"different key", "WORKSPACE_ID=w1", "ACCESS_TOKEN", "", false},
+		{"comment", "# ACCESS_TOKEN=old", "ACCESS_TOKEN", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			prefix, ok := envLineAssigns(tc.line, tc.key)
+			if ok != tc.wantOK {
+				t.Fatalf("envLineAssigns(%q, %q) ok = %v, want %v", tc.line, tc.key, ok, tc.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if prefix != tc.wantPrefix {
+				t.Errorf("prefix = %q, want %q", prefix, tc.wantPrefix)
+			}
+			// The whole point of the prefix: the rewritten line must still assign
+			// the same key, in the same shape.
+			rewritten := prefix + tc.key + "=NEW"
+			gotKey, gotVal, parsed := ParseEnvLine(rewritten)
+			if !parsed || gotKey != tc.key || gotVal != "NEW" {
+				t.Errorf("rewrite %q parses as (%q, %q, %v), want (%q, %q, true)",
+					rewritten, gotKey, gotVal, parsed, tc.key, "NEW")
+			}
+		})
+	}
+}

--- a/plugins/simulator/mcp-server/app/auth/envline_prefix_test.go
+++ b/plugins/simulator/mcp-server/app/auth/envline_prefix_test.go
@@ -3,8 +3,7 @@ package auth
 import "testing"
 
 // envLineAssigns returns the verbatim text before the key so a rewrite can
-// preserve it. Getting that offset from the first substring match in the raw
-// line renames the variable when the key also occurs inside the prefix.
+// preserve the file's BOM and the author's indentation.
 func TestEnvLineAssignsPrefix(t *testing.T) {
 	bom := string([]byte{0xEF, 0xBB, 0xBF})
 	cases := []struct {
@@ -12,15 +11,16 @@ func TestEnvLineAssignsPrefix(t *testing.T) {
 		wantOK                      bool
 	}{
 		{"bare", "ACCESS_TOKEN=old", "ACCESS_TOKEN", "", true},
-		{"export", "export ACCESS_TOKEN=old", "ACCESS_TOKEN", "export ", true},
-		{"export tab", "export\tACCESS_TOKEN=old", "ACCESS_TOKEN", "export\t", true},
-		{"indented export", "  export ACCESS_TOKEN=old", "ACCESS_TOKEN", "  export ", true},
+		{"indented", "  ACCESS_TOKEN=old", "ACCESS_TOKEN", "  ", true},
+		{"tab indented", "\tACCESS_TOKEN=old", "ACCESS_TOKEN", "\t", true},
 		{"spaced equals", "ACCESS_TOKEN = old", "ACCESS_TOKEN", "", true},
 		{"bom keeps the mark", bom + "ACCESS_TOKEN=old", "ACCESS_TOKEN", bom, true},
-		// The key occurs inside the "export" keyword itself. Taking the first
-		// substring hit yielded prefix "ex", rewriting the line as "export=2".
-		{"key is a substring of the prefix", "export port=1", "port", "export ", true},
-		{"value looks like the key", "export FOO=FOO", "FOO", "export ", true},
+		{"bom and indent", bom + "  ACCESS_TOKEN=old", "ACCESS_TOKEN", bom + "  ", true},
+		{"value looks like the key", "FOO=FOO", "FOO", "", true},
+		// .env is not a shell script: `export KEY=v` parses as the key
+		// "export KEY", which has whitespace, so neither side treats it as an
+		// assignment to KEY.
+		{"export is not supported", "export ACCESS_TOKEN=old", "ACCESS_TOKEN", "", false},
 		{"different key", "WORKSPACE_ID=w1", "ACCESS_TOKEN", "", false},
 		{"comment", "# ACCESS_TOKEN=old", "ACCESS_TOKEN", "", false},
 	}

--- a/plugins/simulator/mcp-server/app/auth/envline_test.go
+++ b/plugins/simulator/mcp-server/app/auth/envline_test.go
@@ -3,8 +3,12 @@ package auth
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
+
+// bom is the UTF-8 byte order mark a Notepad / PowerShell .env starts with.
+var bom = string([]byte{0xEF, 0xBB, 0xBF})
 
 func TestParseEnvLine(t *testing.T) {
 	cases := []struct {
@@ -13,8 +17,9 @@ func TestParseEnvLine(t *testing.T) {
 		ok       bool
 	}{
 		{`ACCESS_TOKEN=abc`, "ACCESS_TOKEN", "abc", true},
-		{`export ACCESS_TOKEN=abc`, "ACCESS_TOKEN", "abc", true},
-		{"export\tACCESS_TOKEN=abc", "ACCESS_TOKEN", "abc", true},
+		// .env is not a shell script — `export` makes the key "export ACCESS_TOKEN".
+		{`export ACCESS_TOKEN=abc`, "", "", false},
+		{"export\tACCESS_TOKEN=abc", "", "", false},
 		{`   ACCESS_TOKEN = abc `, "ACCESS_TOKEN", "abc", true},
 		{`ACCESS_TOKEN="abc"`, "ACCESS_TOKEN", "abc", true},
 		{`ACCESS_TOKEN='abc'`, "ACCESS_TOKEN", "abc", true},
@@ -44,13 +49,14 @@ func TestParseEnvLine(t *testing.T) {
 
 // A rewrite must land on the line that is already there, whatever shape it was
 // written in — appending a second assignment leaves the loader reading the stale
-// first one. And `export` is preserved: the user may be sourcing the file.
+// first one. The file's BOM and the author's indentation survive the rewrite.
 func TestEnvWritersMatchEveryReadableShape(t *testing.T) {
 	for _, shape := range []string{
-		"export ACCESS_TOKEN=old",
 		"  ACCESS_TOKEN=old",
+		"\tACCESS_TOKEN=old",
+		"ACCESS_TOKEN = old",
 		`ACCESS_TOKEN="old"`,
-		"export\tACCESS_TOKEN=old",
+		bom + "ACCESS_TOKEN=old",
 	} {
 		t.Run(shape, func(t *testing.T) {
 			path := filepath.Join(t.TempDir(), ".env")
@@ -67,9 +73,9 @@ func TestEnvWritersMatchEveryReadableShape(t *testing.T) {
 			if _, val, _ := ParseEnvLine(firstAssignment(string(body), "ACCESS_TOKEN")); val != "new" {
 				t.Errorf("value not updated in place:\n%s", body)
 			}
-			if wantExport := shape[:len("export")] == "export"; wantExport {
-				if line := firstAssignment(string(body), "ACCESS_TOKEN"); line[:len("export")] != "export" {
-					t.Errorf("the `export` keyword must survive a rewrite, got %q", line)
+			if strings.HasPrefix(shape, bom) {
+				if line := firstAssignment(string(body), "ACCESS_TOKEN"); !strings.HasPrefix(line, bom) {
+					t.Errorf("the file's BOM must survive a rewrite, got %q", line)
 				}
 			}
 

--- a/plugins/simulator/mcp-server/app/auth/envline_test.go
+++ b/plugins/simulator/mcp-server/app/auth/envline_test.go
@@ -1,0 +1,119 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseEnvLine(t *testing.T) {
+	cases := []struct {
+		line     string
+		key, val string
+		ok       bool
+	}{
+		{`ACCESS_TOKEN=abc`, "ACCESS_TOKEN", "abc", true},
+		{`export ACCESS_TOKEN=abc`, "ACCESS_TOKEN", "abc", true},
+		{"export\tACCESS_TOKEN=abc", "ACCESS_TOKEN", "abc", true},
+		{`   ACCESS_TOKEN = abc `, "ACCESS_TOKEN", "abc", true},
+		{`ACCESS_TOKEN="abc"`, "ACCESS_TOKEN", "abc", true},
+		{`ACCESS_TOKEN='abc'`, "ACCESS_TOKEN", "abc", true},
+		{`ACCESS_TOKEN="abc`, "ACCESS_TOKEN", `"abc`, true}, // one-sided quote is part of the value
+		{`ACCESS_TOKEN=abc"`, "ACCESS_TOKEN", `abc"`, true},
+		{`ACCESS_TOKEN=""`, "ACCESS_TOKEN", "", true},
+		{`ACCESS_TOKEN=ey=J0`, "ACCESS_TOKEN", "ey=J0", true},     // only the first = splits
+		{`ACCESS_TOKEN=wsk#abc`, "ACCESS_TOKEN", "wsk#abc", true}, // # is not a comment mid-value
+		{"ACCESS_TOKEN=abc\r", "ACCESS_TOKEN", "abc", true},
+		{`exportACCESS_TOKEN=abc`, "exportACCESS_TOKEN", "abc", true}, // no space: a real key name
+		{`export=abc`, "export", "abc", true},
+		{`# ACCESS_TOKEN=abc`, "", "", false},
+		{`no_equals_sign`, "", "", false},
+		{`foo bar=baz`, "", "", false},
+		{`=abc`, "", "", false},
+		{``, "", "", false},
+		{`   `, "", "", false},
+	}
+	for _, c := range cases {
+		key, val, ok := ParseEnvLine(c.line)
+		if ok != c.ok || key != c.key || val != c.val {
+			t.Errorf("ParseEnvLine(%q) = (%q, %q, %v), want (%q, %q, %v)",
+				c.line, key, val, ok, c.key, c.val, c.ok)
+		}
+	}
+}
+
+// A rewrite must land on the line that is already there, whatever shape it was
+// written in — appending a second assignment leaves the loader reading the stale
+// first one. And `export` is preserved: the user may be sourcing the file.
+func TestEnvWritersMatchEveryReadableShape(t *testing.T) {
+	for _, shape := range []string{
+		"export ACCESS_TOKEN=old",
+		"  ACCESS_TOKEN=old",
+		`ACCESS_TOKEN="old"`,
+		"export\tACCESS_TOKEN=old",
+	} {
+		t.Run(shape, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), ".env")
+			if err := os.WriteFile(path, []byte(shape+"\nOTHER=keep\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := updateEnvFile(path, "ACCESS_TOKEN", "new"); err != nil {
+				t.Fatal(err)
+			}
+			body, _ := os.ReadFile(path)
+			if n := countAssignments(string(body), "ACCESS_TOKEN"); n != 1 {
+				t.Fatalf("want exactly one ACCESS_TOKEN line, got %d:\n%s", n, body)
+			}
+			if _, val, _ := ParseEnvLine(firstAssignment(string(body), "ACCESS_TOKEN")); val != "new" {
+				t.Errorf("value not updated in place:\n%s", body)
+			}
+			if wantExport := shape[:len("export")] == "export"; wantExport {
+				if line := firstAssignment(string(body), "ACCESS_TOKEN"); line[:len("export")] != "export" {
+					t.Errorf("the `export` keyword must survive a rewrite, got %q", line)
+				}
+			}
+
+			if err := removeEnvKey(path, "ACCESS_TOKEN"); err != nil {
+				t.Fatal(err)
+			}
+			body, _ = os.ReadFile(path)
+			if n := countAssignments(string(body), "ACCESS_TOKEN"); n != 0 {
+				t.Errorf("removeEnvKey left the key behind:\n%s", body)
+			}
+			if n := countAssignments(string(body), "OTHER"); n != 1 {
+				t.Errorf("an unrelated key was dropped:\n%s", body)
+			}
+		})
+	}
+}
+
+func countAssignments(body, key string) int {
+	n := 0
+	for _, line := range splitLines(body) {
+		if k, _, ok := ParseEnvLine(line); ok && k == key {
+			n++
+		}
+	}
+	return n
+}
+
+func firstAssignment(body, key string) string {
+	for _, line := range splitLines(body) {
+		if k, _, ok := ParseEnvLine(line); ok && k == key {
+			return line
+		}
+	}
+	return ""
+}
+
+func splitLines(s string) []string {
+	var out []string
+	start := 0
+	for i := range len(s) {
+		if s[i] == '\n' {
+			out = append(out, s[start:i])
+			start = i + 1
+		}
+	}
+	return append(out, s[start:])
+}

--- a/plugins/simulator/mcp-server/app/auth/insecure_override_test.go
+++ b/plugins/simulator/mcp-server/app/auth/insecure_override_test.go
@@ -1,0 +1,36 @@
+package auth
+
+import (
+	"os"
+	"testing"
+)
+
+// The override exists for a long-lived key on the wire, so only a true boolean
+// opens it — `=0` and `=false` must keep the guard closed, and anything the flag
+// cannot parse fails safe.
+func TestInsecureAPISecretAllowed(t *testing.T) {
+	cases := []struct {
+		set  string
+		want bool
+	}{
+		{"", false},
+		{"0", false},
+		{"false", false},
+		{"FALSE", false},
+		{"no", false},  // not a bool: fail safe rather than guess
+		{"yes", false}, // ditto
+		{"1", true},
+		{"true", true},
+		{"TRUE", true},
+		{" true ", true}, // a trailing space in .env must not flip the meaning
+	}
+	for _, c := range cases {
+		t.Setenv(AllowInsecureAPISecretEnv, c.set)
+		if c.set == "" {
+			os.Unsetenv(AllowInsecureAPISecretEnv)
+		}
+		if got := InsecureAPISecretAllowed(); got != c.want {
+			t.Errorf("InsecureAPISecretAllowed() with %q = %v, want %v", c.set, got, c.want)
+		}
+	}
+}

--- a/plugins/simulator/mcp-server/app/auth/mode.go
+++ b/plugins/simulator/mcp-server/app/auth/mode.go
@@ -1,0 +1,85 @@
+package auth
+
+import (
+	"os"
+	"strings"
+)
+
+// Authorization header token types. The platform's own OAuth flow issues a JWT
+// sent as "Simulator <jwt>"; a user-supplied workspace API key is sent as the
+// standard "Bearer <key>". pong-server accepts both (checkPublicApiAuth.js —
+// see docs/INTEGRATION.md §1), and the dumped spec declares the header as a
+// generic apiKey scheme with a "Bearer #TOKEN#" sample.
+const (
+	TokenTypeSimulator = "Simulator"
+	TokenTypeBearer    = "Bearer"
+)
+
+// APISecretEnv is the env var that switches the server into API-key mode.
+//
+// It is deliberately prefixed: .mcp.json declares no env allow-list, so the
+// server inherits the host's whole environment. An unprefixed name like
+// API_SECRET is common enough in developer shells that an unrelated third-party
+// secret would silently be sent to the Simulator gateway as a Bearer token.
+const APISecretEnv = "SIMULATOR_API_SECRET" // #nosec G101 — the variable's name, not a credential
+
+// Auth mode names, reported by Mode() for startup logging and diagnostics.
+const (
+	ModeAPIKey    = "api-key"
+	ModeOAuth     = "oauth"
+	ModeStateless = "stateless"
+)
+
+// APISecret returns the configured workspace API key, or "" when unset.
+//
+// The value is user-supplied — hand-written into .env or exported into the
+// environment. It is never written back to .env, never logged, and never
+// included in telemetry.
+func APISecret() string { return strings.TrimSpace(os.Getenv(APISecretEnv)) }
+
+// IsAPIKeyMode reports whether an API key is configured. In this mode the OAuth
+// PKCE flow is disabled end to end: `login` refuses and explains itself, Save
+// refuses to write a token, set-environment refuses to re-point the gateway,
+// and a 401 is reported as a rejected key rather than an expired session.
+func IsAPIKeyMode() bool { return APISecret() != "" }
+
+// Mode returns the active auth mode name for logging.
+func Mode() string {
+	if IsAPIKeyMode() {
+		return ModeAPIKey
+	}
+	return ModeOAuth
+}
+
+// HintFor returns a short, actionable remediation for a rejected request, or ""
+// when the status is not credential-related. It never contains any part of the
+// credential.
+//
+// 401 and 403 need different wording. A 401 is unambiguous: the credential
+// itself was refused. A 403 usually means the object is not yours to touch —
+// the backend returns it for a missing or foreign resource — so it must not
+// assert that the credential is wrong; a workspace-scoped key pointed at
+// another workspace's object produces exactly the same status, which is why the
+// hint is offered at all rather than dropped.
+func HintFor(status int) string {
+	switch status {
+	case 401:
+		if IsAPIKeyMode() {
+			return "the Simulator API rejected your " + APISecretEnv + " — check that the key is correct " +
+				"and not revoked, that WORKSPACE_ID names the workspace the key was issued for, and that " +
+				"the key belongs to this environment (workspace access keys are created at " +
+				"account.corezoid.com → workspace, and are scoped to one workspace on one gateway)"
+		}
+		return "your Simulator session is invalid or expired — run the `login` tool again"
+	case 403:
+		if IsAPIKeyMode() {
+			return "access denied — usually the object does not exist or belongs to another workspace. " +
+				"If you expected access, check that WORKSPACE_ID matches the workspace your " + APISecretEnv +
+				" was issued for, since a key grants nothing outside its own workspace"
+		}
+		return "access denied — usually the object does not exist or you lack permission on it; " +
+			"if you expected access, check that WORKSPACE_ID is the right workspace"
+	default:
+		return ""
+	}
+}

--- a/plugins/simulator/mcp-server/app/auth/mode.go
+++ b/plugins/simulator/mcp-server/app/auth/mode.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"os"
+	"strconv"
 	"strings"
 )
 
@@ -22,6 +23,11 @@ const (
 // API_SECRET is common enough in developer shells that an unrelated third-party
 // secret would silently be sent to the Simulator gateway as a Bearer token.
 const APISecretEnv = "SIMULATOR_API_SECRET" // #nosec G101 — the variable's name, not a credential
+
+// AllowInsecureAPISecretEnv opts out of the refusal to send a long-lived API key
+// over plaintext HTTP to a non-local host. Loopback is already exempt, so this
+// exists only for trusted-network on-prem gateways with no TLS.
+const AllowInsecureAPISecretEnv = "SIMULATOR_ALLOW_INSECURE_API_SECRET"
 
 // Auth mode names, reported by Mode() for startup logging and diagnostics.
 const (
@@ -82,4 +88,18 @@ func HintFor(status int) string {
 	default:
 		return ""
 	}
+}
+
+// InsecureAPISecretAllowed reports whether the plaintext-HTTP refusal is waived.
+//
+// Parsed as a bool rather than "any non-empty value": a guard that
+// SIMULATOR_ALLOW_INSECURE_API_SECRET=0 or =false would switch OFF is a trap, so
+// only a value that actually says yes counts, and anything unparseable is a no.
+func InsecureAPISecretAllowed() bool {
+	v := strings.TrimSpace(os.Getenv(AllowInsecureAPISecretEnv))
+	if v == "" {
+		return false
+	}
+	allowed, err := strconv.ParseBool(v)
+	return err == nil && allowed
 }

--- a/plugins/simulator/mcp-server/app/auth/mode_test.go
+++ b/plugins/simulator/mcp-server/app/auth/mode_test.go
@@ -1,0 +1,96 @@
+package auth
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIsAPIKeyModeAndMode(t *testing.T) {
+	cases := []struct {
+		name     string
+		secret   string
+		wantOn   bool
+		wantMode string
+	}{
+		{"unset", "", false, ModeOAuth},
+		{"set", "wsk_abc123", true, ModeAPIKey},
+		{"whitespace only", "   ", false, ModeOAuth},
+		{"padded value", "  wsk_abc123  ", true, ModeAPIKey},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(APISecretEnv, tc.secret)
+			if got := IsAPIKeyMode(); got != tc.wantOn {
+				t.Errorf("IsAPIKeyMode() = %v, want %v", got, tc.wantOn)
+			}
+			if got := Mode(); got != tc.wantMode {
+				t.Errorf("Mode() = %q, want %q", got, tc.wantMode)
+			}
+		})
+	}
+}
+
+func TestAPISecretTrimsSurroundingSpace(t *testing.T) {
+	t.Setenv(APISecretEnv, "  wsk_abc123\t")
+	if got := APISecret(); got != "wsk_abc123" {
+		t.Errorf("APISecret() = %q, want %q", got, "wsk_abc123")
+	}
+}
+
+// The hint is user-facing and lands in tool results and telemetry-adjacent error
+// strings, so it must never carry credential material — in any mode, any status.
+func TestHintForNeverContainsSecret(t *testing.T) {
+	const secret = "SUPERSECRET-do-not-leak"
+	for _, mode := range []string{secret, ""} {
+		t.Setenv(APISecretEnv, mode)
+		for _, status := range []int{401, 403, 404, 500} {
+			if h := HintFor(status); strings.Contains(h, secret) {
+				t.Fatalf("HintFor(%d) leaked the secret: %q", status, h)
+			}
+		}
+	}
+}
+
+func TestHintForOnlyCoversCredentialStatuses(t *testing.T) {
+	t.Setenv(APISecretEnv, "wsk_key")
+	for _, status := range []int{200, 400, 404, 409, 429, 500} {
+		if h := HintFor(status); h != "" {
+			t.Errorf("HintFor(%d) = %q, want no hint", status, h)
+		}
+	}
+}
+
+func TestHintFor401NamesTheCredential(t *testing.T) {
+	t.Setenv(APISecretEnv, "wsk_key")
+	h := HintFor(401)
+	if !strings.Contains(h, APISecretEnv) {
+		t.Errorf("HintFor(401) should name %s, got %q", APISecretEnv, h)
+	}
+	if !strings.Contains(h, "WORKSPACE_ID") {
+		t.Errorf("HintFor(401) should name WORKSPACE_ID as a suspect, got %q", h)
+	}
+
+	t.Setenv(APISecretEnv, "")
+	if h := HintFor(401); !strings.Contains(h, "login") {
+		t.Errorf("OAuth HintFor(401) should point at `login`, got %q", h)
+	}
+}
+
+// A 403 is returned for a missing or foreign object far more often than for a
+// bad credential, so it must not assert the credential is wrong — that sends the
+// user hunting in the wrong place.
+func TestHintFor403DoesNotBlameTheCredential(t *testing.T) {
+	for _, mode := range []string{"wsk_key", ""} {
+		t.Setenv(APISecretEnv, mode)
+		h := HintFor(403)
+		if h == "" {
+			t.Fatal("HintFor(403) = \"\", want guidance")
+		}
+		if strings.Contains(h, "rejected your") {
+			t.Errorf("HintFor(403) = %q, must not assert the credential was rejected", h)
+		}
+		if !strings.Contains(h, "does not exist") {
+			t.Errorf("HintFor(403) = %q, should lead with the likely cause", h)
+		}
+	}
+}

--- a/plugins/simulator/mcp-server/app/mcpserver/actor.go
+++ b/plugins/simulator/mcp-server/app/mcpserver/actor.go
@@ -3,6 +3,7 @@ package mcpserver
 import (
 	"errors"
 
+	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/app/auth"
 	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/internal/apiclient"
 	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/internal/config"
 	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/internal/engines/ecore"
@@ -25,6 +26,11 @@ import (
 func NewActorServer(actorID string, opts Options) (*server.MCPServer, Info, error) {
 	prof, err := config.Resolve(opts.Profile)
 	if err != nil {
+		return nil, Info{}, err
+	}
+	// This constructor is always stateless and always multi-tenant, so it takes
+	// the same API-key refusal as New(Options{Stateless: true}).
+	if err := errAPIKeyInStatelessMode(); err != nil {
 		return nil, Info{}, err
 	}
 	// Stateless: auth/workspace/baseURL come from request ctx. A non-nil authHeader
@@ -50,5 +56,6 @@ func NewActorServer(actorID string, opts Options) (*server.MCPServer, Info, erro
 		Profile:    prof.Name,
 		APIBaseURL: prof.APIBaseURL,
 		AccountURL: prof.AccountURL,
+		AuthMode:   auth.ModeStateless,
 	}, nil
 }

--- a/plugins/simulator/mcp-server/app/mcpserver/actor_test.go
+++ b/plugins/simulator/mcp-server/app/mcpserver/actor_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	mcpserver "github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/app/mcpserver"
+	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/internal/engines/ecore"
 	"github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/mcp"
 )
@@ -105,4 +106,34 @@ func schemaContains(t *testing.T, tool mcp.Tool, needle string) bool {
 		t.Fatalf("marshal %s schema: %v", tool.Name, err)
 	}
 	return strings.Contains(string(raw), needle)
+}
+
+// NewActorServer is always stateless and always multi-tenant, so it must take
+// the same API-key refusal as New(Options{Stateless: true}) — otherwise a host
+// process holding a key could attach it to every tenant's request.
+func TestNewActorServerRefusesAPIKeyMode(t *testing.T) {
+	t.Setenv(mcpserver.APISecretEnv, "wsk_key")
+
+	_, _, err := mcpserver.NewActorServer("11111111-1111-4111-8111-111111111111", mcpserver.Options{})
+	if err == nil {
+		t.Fatal("NewActorServer() error = nil, want a refusal in API-key mode")
+	}
+	if !strings.Contains(err.Error(), mcpserver.APISecretEnv) {
+		t.Errorf("NewActorServer() error = %q, should name %s", err, mcpserver.APISecretEnv)
+	}
+}
+
+// Info.AuthMode is documented as always carrying one of the three mode names;
+// an embedder logging auth=%s must not get an empty string here.
+func TestNewActorServerReportsStatelessAuthMode(t *testing.T) {
+	t.Setenv(mcpserver.APISecretEnv, "")
+	t.Cleanup(func() { ecore.SetStateless(false) })
+
+	_, info, err := mcpserver.NewActorServer("11111111-1111-4111-8111-111111111111", mcpserver.Options{})
+	if err != nil {
+		t.Fatalf("NewActorServer: %v", err)
+	}
+	if info.AuthMode != mcpserver.AuthModeStateless {
+		t.Errorf("AuthMode = %q, want %q", info.AuthMode, mcpserver.AuthModeStateless)
+	}
 }

--- a/plugins/simulator/mcp-server/app/mcpserver/mcpserver.go
+++ b/plugins/simulator/mcp-server/app/mcpserver/mcpserver.go
@@ -80,6 +80,8 @@ const (
 	AuthModeOAuth     = auth.ModeOAuth
 	AuthModeStateless = auth.ModeStateless
 	APISecretEnv      = auth.APISecretEnv
+	// AllowInsecureAPISecretEnv waives the plaintext-HTTP refusal enforced by New.
+	AllowInsecureAPISecretEnv = auth.AllowInsecureAPISecretEnv
 )
 
 // Info reports the resolved environment for logging / diagnostics.
@@ -103,6 +105,8 @@ func New(opts Options) (*server.MCPServer, Info, error) {
 		if err := errAPIKeyInStatelessMode(); err != nil {
 			return nil, Info{}, err
 		}
+	} else if err := errAPIKeyOverInsecureTransport(prof.APIBaseURL); err != nil {
+		return nil, Info{}, err
 	}
 
 	var (
@@ -243,6 +247,30 @@ func errAPIKeyInStatelessMode() error {
 		"%s is set, but this server is stateless: an API key is process-global and cannot be used "+
 			"for per-request, multi-tenant auth — unset %s and pass credentials per request "+
 			"via apiclient.WithAuthorization", auth.APISecretEnv, auth.APISecretEnv)
+}
+
+// errAPIKeyOverInsecureTransport refuses to send a long-lived API key in
+// cleartext to a non-local host.
+//
+// This lives in the library, not in cmd/server, for the same reason the Save and
+// stateless guards do: an embedder calling New directly gets the invariant too.
+// It applies even when the caller supplies its own Options.AuthHeader — the
+// engine tools read credentials through auth.Load on their own (ecore.EnsureAuth),
+// so the key still goes out over this base URL.
+//
+// A 12h JWT leaked on the wire is a bounded incident; an API key does not expire
+// and has no in-product revocation, so this refuses rather than warns.
+func errAPIKeyOverInsecureTransport(baseURL string) error {
+	if !auth.IsAPIKeyMode() || auth.InsecureAPISecretAllowed() {
+		return nil
+	}
+	if !apiclient.IsInsecureCredentialTransport(baseURL) {
+		return nil
+	}
+	return fmt.Errorf(
+		"refusing to start: %s is a long-lived credential and %q would send it in cleartext to a "+
+			"non-local host — use HTTPS, or set %s=1 to override on a trusted network",
+		auth.APISecretEnv, baseURL, auth.AllowInsecureAPISecretEnv)
 }
 
 func defaultAuthHeader() (string, error) {

--- a/plugins/simulator/mcp-server/app/mcpserver/mcpserver.go
+++ b/plugins/simulator/mcp-server/app/mcpserver/mcpserver.go
@@ -12,6 +12,7 @@ package mcpserver
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 
 	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/app/auth"
@@ -72,11 +73,21 @@ type Options struct {
 	Stateless bool
 }
 
+// Auth-mode names and the API-key env var, re-exported so embedders and
+// cmd/server can report the mode without importing app/auth.
+const (
+	AuthModeAPIKey    = auth.ModeAPIKey
+	AuthModeOAuth     = auth.ModeOAuth
+	AuthModeStateless = auth.ModeStateless
+	APISecretEnv      = auth.APISecretEnv
+)
+
 // Info reports the resolved environment for logging / diagnostics.
 type Info struct {
 	Profile    string // profile name (e.g. "prod", "local")
 	APIBaseURL string // public API root (incl. /papi/1.0)
 	AccountURL string // OAuth2 / SA base URL
+	AuthMode   string // auth.ModeAPIKey / auth.ModeOAuth, or auth.ModeStateless
 }
 
 // New builds and returns an MCP server with every simulator tool and engine
@@ -88,10 +99,17 @@ func New(opts Options) (*server.MCPServer, Info, error) {
 		return nil, Info{}, err
 	}
 
+	if opts.Stateless {
+		if err := errAPIKeyInStatelessMode(); err != nil {
+			return nil, Info{}, err
+		}
+	}
+
 	var (
 		authHeader  func() (string, error)
 		workspaceID string
 	)
+	authMode := auth.ModeStateless
 	if opts.Stateless {
 		// In stateless mode, the default Client values are never used: auth and
 		// workspace are read from request ctx on every call (set by
@@ -110,9 +128,16 @@ func New(opts Options) (*server.MCPServer, Info, error) {
 		if workspaceID == "" {
 			workspaceID = os.Getenv("WORKSPACE_ID")
 		}
+		authMode = auth.Mode()
 	}
 
 	client := apiclient.New(prof.APIBaseURL, workspaceID, authHeader, opts.Insecure)
+	if !opts.Stateless {
+		// Consulted on every rejected reply; it returns "" for statuses that are
+		// not credential-related. Left nil in stateless mode: the credential came
+		// from the caller's header, so this process has no advice to give.
+		client.AuthHint = auth.HintFor
+	}
 
 	name := opts.Name
 	if name == "" {
@@ -150,6 +175,7 @@ func New(opts Options) (*server.MCPServer, Info, error) {
 		Profile:    prof.Name,
 		APIBaseURL: prof.APIBaseURL,
 		AccountURL: prof.AccountURL,
+		AuthMode:   authMode,
 	}, nil
 }
 
@@ -199,6 +225,24 @@ func WithActorID(ctx context.Context, value string) context.Context {
 // to WithAuthorization / WithWorkspaceID. A blank or undecodable value is a no-op.
 func WithUIContext(ctx context.Context, headerValue string) context.Context {
 	return apiclient.WithUIContext(ctx, apiclient.ParseUIContext(headerValue))
+}
+
+// errAPIKeyInStatelessMode rejects an API key in any stateless constructor.
+//
+// An API key is process-global, but stateless mode is per-request and
+// multi-tenant. `ecore`'s stateless flag is itself a process global that a later
+// New / NewActorServer call can flip, after which engine tools would read the
+// process-global auth cache — this process's key — and attach it to every
+// tenant's request. Both stateless constructors call this rather than rely on
+// that flag staying correct.
+func errAPIKeyInStatelessMode() error {
+	if !auth.IsAPIKeyMode() {
+		return nil
+	}
+	return fmt.Errorf(
+		"%s is set, but this server is stateless: an API key is process-global and cannot be used "+
+			"for per-request, multi-tenant auth — unset %s and pass credentials per request "+
+			"via apiclient.WithAuthorization", auth.APISecretEnv, auth.APISecretEnv)
 }
 
 func defaultAuthHeader() (string, error) {

--- a/plugins/simulator/mcp-server/app/mcpserver/unified_test.go
+++ b/plugins/simulator/mcp-server/app/mcpserver/unified_test.go
@@ -3,9 +3,11 @@ package mcpserver_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	mcpserver "github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/app/mcpserver"
+	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/internal/engines/ecore"
 	"github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/mcp"
 )
@@ -126,3 +128,52 @@ func toolMap(list []mcp.Tool) map[string]mcp.Tool {
 	return out
 }
 
+// An API key is process-global; stateless mode is per-request and multi-tenant.
+// Constructing that combination must fail loudly rather than let one process's
+// key be attached to every tenant's request.
+func TestStatelessRefusesAPIKeyMode(t *testing.T) {
+	t.Setenv(mcpserver.APISecretEnv, "wsk_key")
+
+	_, _, err := mcpserver.New(mcpserver.Options{
+		Stateless:  true,
+		AuthHeader: func() (string, error) { return "", errors.New("not used") },
+	})
+	if err == nil {
+		t.Fatal("New() error = nil, want a refusal for stateless + API key")
+	}
+	if !strings.Contains(err.Error(), mcpserver.APISecretEnv) {
+		t.Errorf("New() error = %q, should name %s", err, mcpserver.APISecretEnv)
+	}
+}
+
+// The stateful path reports which credential is in play, so cmd/server can log
+// it without importing app/auth.
+func TestInfoReportsAuthMode(t *testing.T) {
+	t.Setenv("SIMULATOR_WORK_DIR", t.TempDir())
+	// New(Stateless:true) below sets ecore's process-global stateless flag; restore
+	// it so the rest of the binary isn't silently switched into stateless mode.
+	t.Cleanup(func() { ecore.SetStateless(false) })
+
+	t.Setenv(mcpserver.APISecretEnv, "wsk_key")
+	if _, info, err := mcpserver.New(mcpserver.Options{}); err != nil {
+		t.Fatalf("New: %v", err)
+	} else if info.AuthMode != mcpserver.AuthModeAPIKey {
+		t.Errorf("AuthMode = %q, want %q", info.AuthMode, mcpserver.AuthModeAPIKey)
+	}
+
+	t.Setenv(mcpserver.APISecretEnv, "")
+	if _, info, err := mcpserver.New(mcpserver.Options{}); err != nil {
+		t.Fatalf("New: %v", err)
+	} else if info.AuthMode != mcpserver.AuthModeOAuth {
+		t.Errorf("AuthMode = %q, want %q", info.AuthMode, mcpserver.AuthModeOAuth)
+	}
+
+	if _, info, err := mcpserver.New(mcpserver.Options{
+		Stateless:  true,
+		AuthHeader: func() (string, error) { return "", errors.New("not used") },
+	}); err != nil {
+		t.Fatalf("New: %v", err)
+	} else if info.AuthMode != mcpserver.AuthModeStateless {
+		t.Errorf("AuthMode = %q, want %q", info.AuthMode, mcpserver.AuthModeStateless)
+	}
+}

--- a/plugins/simulator/mcp-server/app/mcpserver/unified_test.go
+++ b/plugins/simulator/mcp-server/app/mcpserver/unified_test.go
@@ -177,3 +177,53 @@ func TestInfoReportsAuthMode(t *testing.T) {
 		t.Errorf("AuthMode = %q, want %q", info.AuthMode, mcpserver.AuthModeStateless)
 	}
 }
+
+// The plaintext-HTTP refusal must live in the library, not only in cmd/server:
+// an embedder calling New directly would otherwise send a long-lived key in
+// cleartext with no error and no warning, and SECURITY.md promises otherwise.
+func TestNewRefusesAPIKeyOverPlaintextHTTP(t *testing.T) {
+	t.Setenv("SIMULATOR_WORK_DIR", t.TempDir())
+	t.Setenv(mcpserver.APISecretEnv, "wsk_key")
+	t.Setenv("SIMULATOR_API_BASE_URL", "http://remote-host.example/papi/1.0")
+	t.Setenv(mcpserver.AllowInsecureAPISecretEnv, "")
+
+	_, _, err := mcpserver.New(mcpserver.Options{})
+	if err == nil {
+		t.Fatal("New() error = nil, want a refusal for an API key over plaintext HTTP")
+	}
+	if !strings.Contains(err.Error(), mcpserver.AllowInsecureAPISecretEnv) {
+		t.Errorf("New() error = %q, should name the override env var", err)
+	}
+
+	// It must hold even when the embedder supplies its own AuthHeader: the engine
+	// tools read credentials through auth.Load themselves, so the key still goes out.
+	_, _, err = mcpserver.New(mcpserver.Options{
+		AuthHeader: func() (string, error) { return "Simulator other", nil },
+	})
+	if err == nil {
+		t.Error("New() with a custom AuthHeader error = nil, want the same refusal")
+	}
+}
+
+func TestNewAllowsPlaintextWhenWaivedOrLoopbackOrOAuth(t *testing.T) {
+	cases := []struct {
+		name, secret, baseURL, waiver string
+	}{
+		{"explicitly waived", "wsk_key", "http://remote-host.example/papi/1.0", "1"},
+		{"loopback is exempt", "wsk_key", "http://127.0.0.1:9000/papi/1.0", ""},
+		{"https", "wsk_key", "https://mw.simulator.company/papi/1.0", ""},
+		{"oauth mode is only warned about", "", "http://remote-host.example/papi/1.0", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Setenv("SIMULATOR_WORK_DIR", t.TempDir())
+			t.Setenv(mcpserver.APISecretEnv, c.secret)
+			t.Setenv("SIMULATOR_API_BASE_URL", c.baseURL)
+			t.Setenv(mcpserver.AllowInsecureAPISecretEnv, c.waiver)
+
+			if _, _, err := mcpserver.New(mcpserver.Options{}); err != nil {
+				t.Errorf("New() error = %v, want nil", err)
+			}
+		})
+	}
+}

--- a/plugins/simulator/mcp-server/cmd/server/dotenv_test.go
+++ b/plugins/simulator/mcp-server/cmd/server/dotenv_test.go
@@ -172,36 +172,6 @@ func TestLoadDotEnvReportsItsOwnKeys(t *testing.T) {
 	}
 }
 
-// The override exists for a long-lived key on the wire, so only a true boolean
-// opens it — `=0` and `=false` must keep the guard closed, and anything the flag
-// cannot parse fails safe.
-func TestInsecureAPISecretAllowed(t *testing.T) {
-	cases := []struct {
-		set  string
-		want bool
-	}{
-		{"", false},
-		{"0", false},
-		{"false", false},
-		{"FALSE", false},
-		{"no", false},  // not a bool: fail safe rather than guess
-		{"yes", false}, // ditto
-		{"1", true},
-		{"true", true},
-		{"TRUE", true},
-		{" true ", true}, // a trailing space in .env must not flip the meaning
-	}
-	for _, c := range cases {
-		t.Setenv(allowInsecureAPISecretEnv, c.set)
-		if c.set == "" {
-			os.Unsetenv(allowInsecureAPISecretEnv)
-		}
-		if got := insecureAPISecretAllowed(); got != c.want {
-			t.Errorf("insecureAPISecretAllowed() with %q = %v, want %v", c.set, got, c.want)
-		}
-	}
-}
-
 // countAssignments reports how many lines assign key, as the loader sees them.
 // A rewrite that appends instead of replacing leaves two, and the loader then
 // takes the stale first one.

--- a/plugins/simulator/mcp-server/cmd/server/dotenv_test.go
+++ b/plugins/simulator/mcp-server/cmd/server/dotenv_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/app/auth"
 )
 
 // loadDotEnv is the first thing a hand-pasted secret passes through, and every
@@ -78,25 +80,6 @@ func TestLoadDotEnvMissingFileIsFine(t *testing.T) {
 	loadDotEnv(filepath.Join(t.TempDir(), "does-not-exist"))
 }
 
-func TestTrimMatchingQuotes(t *testing.T) {
-	cases := map[string]string{
-		`"a"`:  "a",
-		`'a'`:  "a",
-		`"a`:   `"a`,
-		`a"`:   `a"`,
-		`"a'`:  `"a'`,
-		`""`:   "",
-		`a`:    "a",
-		``:     "",
-		`"a"b`: `"a"b`,
-	}
-	for in, want := range cases {
-		if got := trimMatchingQuotes(in); got != want {
-			t.Errorf("trimMatchingQuotes(%q) = %q, want %q", in, got, want)
-		}
-	}
-}
-
 func writeAndLoad(t *testing.T, content string) {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), ".env")
@@ -104,4 +87,103 @@ func writeAndLoad(t *testing.T, content string) {
 		t.Fatalf("write .env: %v", err)
 	}
 	loadDotEnv(path)
+}
+
+// The loader and the .env writers must read a line the same way. They did not:
+// the loader accepted `export KEY=…`, the writers matched a bare `KEY=` prefix, so
+// a rewrite appended a duplicate — and the loader takes the FIRST occurrence, so
+// the value the user just changed lost to the stale one on the next start.
+func TestLoadDotEnvAgreesWithTheEnvWriters(t *testing.T) {
+	for _, shape := range []string{
+		"export ACCESS_TOKEN=old",
+		"  ACCESS_TOKEN=old",
+		`ACCESS_TOKEN="old"`,
+		"export\tACCESS_TOKEN=old",
+	} {
+		t.Run(shape, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Setenv("SIMULATOR_WORK_DIR", dir)
+			path := filepath.Join(dir, ".env")
+			if err := os.WriteFile(path, []byte(shape+"\n"), 0o600); err != nil {
+				t.Fatalf("write .env: %v", err)
+			}
+
+			if err := auth.Save(&auth.Credentials{AccessToken: "new"}); err != nil {
+				t.Fatalf("save: %v", err)
+			}
+			os.Unsetenv("ACCESS_TOKEN")
+			loadDotEnv(path)
+			if got := os.Getenv("ACCESS_TOKEN"); got != "new" {
+				body, _ := os.ReadFile(path)
+				t.Errorf("after Save, ACCESS_TOKEN = %q, want %q; .env is:\n%s", got, "new", body)
+			}
+
+			if err := auth.Delete(); err != nil {
+				t.Fatalf("delete: %v", err)
+			}
+			os.Unsetenv("ACCESS_TOKEN")
+			loadDotEnv(path)
+			if got := os.Getenv("ACCESS_TOKEN"); got != "" {
+				body, _ := os.ReadFile(path)
+				t.Errorf("after Delete, ACCESS_TOKEN = %q, want it gone; .env is:\n%s", got, body)
+			}
+		})
+	}
+}
+
+// loadDotEnv reports which keys it supplied, so the startup log can tell a key
+// exported in the shell apart from one read out of the project's .env.
+func TestLoadDotEnvReportsItsOwnKeys(t *testing.T) {
+	t.Setenv("SIMULATOR_API_SECRET", "from_environment")
+	t.Setenv("DOTENV_TEST_KEY", "")
+	os.Unsetenv("DOTENV_TEST_KEY")
+
+	path := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(path, []byte("SIMULATOR_API_SECRET=from_file\nDOTENV_TEST_KEY=value\n"), 0o600); err != nil {
+		t.Fatalf("write .env: %v", err)
+	}
+	fromFile := loadDotEnv(path)
+
+	if fromFile["SIMULATOR_API_SECRET"] {
+		t.Error("the environment already had SIMULATOR_API_SECRET — the file did not supply it")
+	}
+	if !fromFile["DOTENV_TEST_KEY"] {
+		t.Error("DOTENV_TEST_KEY came from the file and should be reported as such")
+	}
+	if got := envSource("SIMULATOR_API_SECRET", fromFile); got != "the process environment" {
+		t.Errorf("envSource = %q, want the process environment", got)
+	}
+	if got := envSource("DOTENV_TEST_KEY", fromFile); got != ".env" {
+		t.Errorf("envSource = %q, want .env", got)
+	}
+}
+
+// The override exists for a long-lived key on the wire, so only a true boolean
+// opens it — `=0` and `=false` must keep the guard closed, and anything the flag
+// cannot parse fails safe.
+func TestInsecureAPISecretAllowed(t *testing.T) {
+	cases := []struct {
+		set  string
+		want bool
+	}{
+		{"", false},
+		{"0", false},
+		{"false", false},
+		{"FALSE", false},
+		{"no", false},  // not a bool: fail safe rather than guess
+		{"yes", false}, // ditto
+		{"1", true},
+		{"true", true},
+		{"TRUE", true},
+		{" true ", true}, // a trailing space in .env must not flip the meaning
+	}
+	for _, c := range cases {
+		t.Setenv(allowInsecureAPISecretEnv, c.set)
+		if c.set == "" {
+			os.Unsetenv(allowInsecureAPISecretEnv)
+		}
+		if got := insecureAPISecretAllowed(); got != c.want {
+			t.Errorf("insecureAPISecretAllowed() with %q = %v, want %v", c.set, got, c.want)
+		}
+	}
 }

--- a/plugins/simulator/mcp-server/cmd/server/dotenv_test.go
+++ b/plugins/simulator/mcp-server/cmd/server/dotenv_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// loadDotEnv is the first thing a hand-pasted secret passes through, and every
+// failure mode below is silent: either the quotes end up inside the
+// Authorization header, or the variable is never set and the user is dropped
+// back to OAuth with no explanation.
+func TestLoadDotEnvParsesHandWrittenValues(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+		key  string
+		want string
+	}{
+		{"plain", `SIMULATOR_API_SECRET=wsk_abc`, "SIMULATOR_API_SECRET", "wsk_abc"},
+		{"double quoted", `SIMULATOR_API_SECRET="wsk_abc"`, "SIMULATOR_API_SECRET", "wsk_abc"},
+		{"single quoted", `SIMULATOR_API_SECRET='wsk_abc'`, "SIMULATOR_API_SECRET", "wsk_abc"},
+		{"export prefix", `export SIMULATOR_API_SECRET=wsk_abc`, "SIMULATOR_API_SECRET", "wsk_abc"},
+		{"export and quotes", `export SIMULATOR_API_SECRET="wsk_abc"`, "SIMULATOR_API_SECRET", "wsk_abc"},
+		{"crlf", "SIMULATOR_API_SECRET=wsk_abc\r", "SIMULATOR_API_SECRET", "wsk_abc"},
+		{"equals inside value", `SIMULATOR_API_SECRET=eyJhbGc=`, "SIMULATOR_API_SECRET", "eyJhbGc="},
+		{"hash is part of the secret", `SIMULATOR_API_SECRET=wsk#abc`, "SIMULATOR_API_SECRET", "wsk#abc"},
+		{"unbalanced quote is kept", `SIMULATOR_API_SECRET="wsk_abc`, "SIMULATOR_API_SECRET", `"wsk_abc`},
+		{"surrounding spaces", `SIMULATOR_API_SECRET =  wsk_abc  `, "SIMULATOR_API_SECRET", "wsk_abc"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(tc.key, "")
+			os.Unsetenv(tc.key)
+			writeAndLoad(t, tc.line+"\n")
+			if got := os.Getenv(tc.key); got != tc.want {
+				t.Errorf("%s = %q, want %q", tc.key, got, tc.want)
+			}
+		})
+	}
+}
+
+// A .env written by Notepad or PowerShell redirection starts with a UTF-8 BOM,
+// which would otherwise become part of the first key's name.
+func TestLoadDotEnvStripsBOM(t *testing.T) {
+	t.Setenv("SIMULATOR_API_SECRET", "")
+	os.Unsetenv("SIMULATOR_API_SECRET")
+
+	writeAndLoad(t, "\uFEFFSIMULATOR_API_SECRET=wsk_abc\n")
+
+	if got := os.Getenv("SIMULATOR_API_SECRET"); got != "wsk_abc" {
+		t.Errorf("SIMULATOR_API_SECRET = %q, want %q", got, "wsk_abc")
+	}
+}
+
+func TestLoadDotEnvDoesNotOverrideExistingValue(t *testing.T) {
+	t.Setenv("SIMULATOR_API_SECRET", "from_environment")
+
+	writeAndLoad(t, "SIMULATOR_API_SECRET=from_file\n")
+
+	if got := os.Getenv("SIMULATOR_API_SECRET"); got != "from_environment" {
+		t.Errorf("SIMULATOR_API_SECRET = %q, want the pre-existing environment value", got)
+	}
+}
+
+func TestLoadDotEnvSkipsCommentsAndJunk(t *testing.T) {
+	t.Setenv("DOTENV_TEST_KEY", "")
+	os.Unsetenv("DOTENV_TEST_KEY")
+
+	writeAndLoad(t, "# a comment\n\nno_equals_sign\nDOTENV_TEST_KEY=value\n")
+
+	if got := os.Getenv("DOTENV_TEST_KEY"); got != "value" {
+		t.Errorf("DOTENV_TEST_KEY = %q, want %q", got, "value")
+	}
+}
+
+func TestLoadDotEnvMissingFileIsFine(t *testing.T) {
+	loadDotEnv(filepath.Join(t.TempDir(), "does-not-exist"))
+}
+
+func TestTrimMatchingQuotes(t *testing.T) {
+	cases := map[string]string{
+		`"a"`:  "a",
+		`'a'`:  "a",
+		`"a`:   `"a`,
+		`a"`:   `a"`,
+		`"a'`:  `"a'`,
+		`""`:   "",
+		`a`:    "a",
+		``:     "",
+		`"a"b`: `"a"b`,
+	}
+	for in, want := range cases {
+		if got := trimMatchingQuotes(in); got != want {
+			t.Errorf("trimMatchingQuotes(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func writeAndLoad(t *testing.T, content string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write .env: %v", err)
+	}
+	loadDotEnv(path)
+}

--- a/plugins/simulator/mcp-server/cmd/server/dotenv_test.go
+++ b/plugins/simulator/mcp-server/cmd/server/dotenv_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/app/auth"
@@ -99,6 +100,9 @@ func TestLoadDotEnvAgreesWithTheEnvWriters(t *testing.T) {
 		"  ACCESS_TOKEN=old",
 		`ACCESS_TOKEN="old"`,
 		"export\tACCESS_TOKEN=old",
+		// A Notepad / PowerShell .env: the BOM sits on the first line, which is
+		// exactly the line the writers have to match.
+		"\uFEFFACCESS_TOKEN=old",
 	} {
 		t.Run(shape, func(t *testing.T) {
 			dir := t.TempDir()
@@ -106,6 +110,16 @@ func TestLoadDotEnvAgreesWithTheEnvWriters(t *testing.T) {
 			path := filepath.Join(dir, ".env")
 			if err := os.WriteFile(path, []byte(shape+"\n"), 0o600); err != nil {
 				t.Fatalf("write .env: %v", err)
+			}
+
+			// Read it first. Asserting only the post-Save value is not enough: if
+			// the loader and the writers are BOTH blind to a shape they stay
+			// consistent with each other while silently never loading the key at
+			// all, and the round-trip below still passes.
+			os.Unsetenv("ACCESS_TOKEN")
+			loadDotEnv(path)
+			if got := os.Getenv("ACCESS_TOKEN"); got != "old" {
+				t.Fatalf("loader did not read this shape: ACCESS_TOKEN = %q, want %q", got, "old")
 			}
 
 			if err := auth.Save(&auth.Credentials{AccessToken: "new"}); err != nil {
@@ -116,6 +130,10 @@ func TestLoadDotEnvAgreesWithTheEnvWriters(t *testing.T) {
 			if got := os.Getenv("ACCESS_TOKEN"); got != "new" {
 				body, _ := os.ReadFile(path)
 				t.Errorf("after Save, ACCESS_TOKEN = %q, want %q; .env is:\n%s", got, "new", body)
+			}
+			if n := countAssignments(t, path, "ACCESS_TOKEN"); n != 1 {
+				body, _ := os.ReadFile(path)
+				t.Errorf("after Save, .env holds %d ACCESS_TOKEN assignments, want 1 (a rewrite must not append); .env is:\n%s", n, body)
 			}
 
 			if err := auth.Delete(); err != nil {
@@ -186,4 +204,22 @@ func TestInsecureAPISecretAllowed(t *testing.T) {
 			t.Errorf("insecureAPISecretAllowed() with %q = %v, want %v", c.set, got, c.want)
 		}
 	}
+}
+
+// countAssignments reports how many lines assign key, as the loader sees them.
+// A rewrite that appends instead of replacing leaves two, and the loader then
+// takes the stale first one.
+func countAssignments(t *testing.T, path, key string) int {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read .env: %v", err)
+	}
+	n := 0
+	for _, line := range strings.Split(string(data), "\n") {
+		if k, _, ok := auth.ParseEnvLine(line); ok && k == key {
+			n++
+		}
+	}
+	return n
 }

--- a/plugins/simulator/mcp-server/cmd/server/dotenv_test.go
+++ b/plugins/simulator/mcp-server/cmd/server/dotenv_test.go
@@ -23,8 +23,6 @@ func TestLoadDotEnvParsesHandWrittenValues(t *testing.T) {
 		{"plain", `SIMULATOR_API_SECRET=wsk_abc`, "SIMULATOR_API_SECRET", "wsk_abc"},
 		{"double quoted", `SIMULATOR_API_SECRET="wsk_abc"`, "SIMULATOR_API_SECRET", "wsk_abc"},
 		{"single quoted", `SIMULATOR_API_SECRET='wsk_abc'`, "SIMULATOR_API_SECRET", "wsk_abc"},
-		{"export prefix", `export SIMULATOR_API_SECRET=wsk_abc`, "SIMULATOR_API_SECRET", "wsk_abc"},
-		{"export and quotes", `export SIMULATOR_API_SECRET="wsk_abc"`, "SIMULATOR_API_SECRET", "wsk_abc"},
 		{"crlf", "SIMULATOR_API_SECRET=wsk_abc\r", "SIMULATOR_API_SECRET", "wsk_abc"},
 		{"equals inside value", `SIMULATOR_API_SECRET=eyJhbGc=`, "SIMULATOR_API_SECRET", "eyJhbGc="},
 		{"hash is part of the secret", `SIMULATOR_API_SECRET=wsk#abc`, "SIMULATOR_API_SECRET", "wsk#abc"},
@@ -91,15 +89,13 @@ func writeAndLoad(t *testing.T, content string) {
 }
 
 // The loader and the .env writers must read a line the same way. They did not:
-// the loader accepted `export KEY=…`, the writers matched a bare `KEY=` prefix, so
+// the loader trimmed a line before splitting it, the writers matched a bare `KEY=` prefix, so
 // a rewrite appended a duplicate — and the loader takes the FIRST occurrence, so
 // the value the user just changed lost to the stale one on the next start.
 func TestLoadDotEnvAgreesWithTheEnvWriters(t *testing.T) {
 	for _, shape := range []string{
-		"export ACCESS_TOKEN=old",
 		"  ACCESS_TOKEN=old",
 		`ACCESS_TOKEN="old"`,
-		"export\tACCESS_TOKEN=old",
 		// A Notepad / PowerShell .env: the BOM sits on the first line, which is
 		// exactly the line the writers have to match.
 		"\uFEFFACCESS_TOKEN=old",

--- a/plugins/simulator/mcp-server/cmd/server/main.go
+++ b/plugins/simulator/mcp-server/cmd/server/main.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"syscall"
 
@@ -25,12 +24,6 @@ import (
 // the plugin manifests by scripts/release.sh.
 const version = mcpserver.DefaultVersion
 
-// allowInsecureAPISecretEnv opts out of the refusal to send a long-lived API key
-// over plaintext HTTP to a non-local host. Loopback is already exempt, so this
-// exists only for trusted-network on-prem gateways with no TLS.
-const allowInsecureAPISecretEnv = "SIMULATOR_ALLOW_INSECURE_API_SECRET"
-
-// apiBaseURLEnv is named here only to report where its value came from.
 const apiBaseURLEnv = "SIMULATOR_API_BASE_URL"
 
 // insecureAPISecretAllowed reports whether the operator really asked to send a
@@ -42,15 +35,6 @@ const apiBaseURLEnv = "SIMULATOR_API_BASE_URL"
 // exact opposite of the intent, for the one credential that never expires and has
 // no in-product revocation. Anything unparseable is treated as "not allowed", so
 // the failure mode is a refusal to start with an explanatory message.
-func insecureAPISecretAllowed() bool {
-	v := strings.TrimSpace(os.Getenv(allowInsecureAPISecretEnv))
-	if v == "" {
-		return false
-	}
-	allowed, err := strconv.ParseBool(v)
-	return err == nil && allowed
-}
-
 // envSource says where a variable's value came from, for the startup log.
 func envSource(key string, fromDotEnv map[string]bool) string {
 	switch {
@@ -112,17 +96,12 @@ func main() {
 			mcpserver.APISecretEnv, envSource(mcpserver.APISecretEnv, fromDotEnv),
 			apiBaseURLEnv, envSource(apiBaseURLEnv, fromDotEnv))
 	}
+	// mcpserver.New already REFUSED this combination unless it was explicitly
+	// waived, so reaching here in API-key mode means the override is on.
 	if mcpserver.IsInsecureCredentialTransport(info.APIBaseURL) {
-		// A 12h JWT leaked on the wire is a bounded incident; an API key does not
-		// expire and has no in-product revocation, so refuse rather than warn.
-		if apiKeyMode && !insecureAPISecretAllowed() {
-			log.Fatalf("refusing to start: %s is a long-lived credential and %q would send it in cleartext to a non-local host. "+
-				"Use HTTPS, or set %s=1 to override on a trusted network.",
-				mcpserver.APISecretEnv, info.APIBaseURL, allowInsecureAPISecretEnv)
-		}
 		if apiKeyMode {
-			log.Printf("WARNING: %s=%s is set — the long-lived API key will be sent in cleartext to %q. Remove the override once the gateway has TLS.",
-				allowInsecureAPISecretEnv, os.Getenv(allowInsecureAPISecretEnv), info.APIBaseURL)
+			log.Printf("WARNING: %s is set — the long-lived API key will be sent in cleartext to %q. Remove the override once the gateway has TLS.",
+				mcpserver.AllowInsecureAPISecretEnv, info.APIBaseURL)
 		}
 		log.Printf("WARNING: API base URL %q uses plaintext HTTP to a non-local host — the auth token will be sent unencrypted. Use HTTPS.", info.APIBaseURL)
 	}

--- a/plugins/simulator/mcp-server/cmd/server/main.go
+++ b/plugins/simulator/mcp-server/cmd/server/main.go
@@ -11,9 +11,11 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 
+	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/app/auth"
 	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/app/mcpserver"
 	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/internal/telemetry"
 	"github.com/mark3labs/mcp-go/server"
@@ -27,6 +29,39 @@ const version = mcpserver.DefaultVersion
 // over plaintext HTTP to a non-local host. Loopback is already exempt, so this
 // exists only for trusted-network on-prem gateways with no TLS.
 const allowInsecureAPISecretEnv = "SIMULATOR_ALLOW_INSECURE_API_SECRET"
+
+// apiBaseURLEnv is named here only to report where its value came from.
+const apiBaseURLEnv = "SIMULATOR_API_BASE_URL"
+
+// insecureAPISecretAllowed reports whether the operator really asked to send a
+// long-lived API key over plaintext HTTP.
+//
+// This is parsed as a boolean rather than the repo's usual "set to anything"
+// convention (SIMULATOR_ANALYTICS_DISABLED): the natural way to turn a switch off
+// is `=0` or `=false`, and under a non-empty test that DISABLES the guard — the
+// exact opposite of the intent, for the one credential that never expires and has
+// no in-product revocation. Anything unparseable is treated as "not allowed", so
+// the failure mode is a refusal to start with an explanatory message.
+func insecureAPISecretAllowed() bool {
+	v := strings.TrimSpace(os.Getenv(allowInsecureAPISecretEnv))
+	if v == "" {
+		return false
+	}
+	allowed, err := strconv.ParseBool(v)
+	return err == nil && allowed
+}
+
+// envSource says where a variable's value came from, for the startup log.
+func envSource(key string, fromDotEnv map[string]bool) string {
+	switch {
+	case fromDotEnv[key]:
+		return ".env"
+	case os.Getenv(key) != "":
+		return "the process environment"
+	default:
+		return "the profile default"
+	}
+}
 
 // installShutdownFlush flushes buffered telemetry events before the process
 // exits on SIGINT/SIGTERM (e.g. the MCP client terminating the server). Go's
@@ -48,11 +83,11 @@ func main() {
 	insecure := flag.Bool("insecure", false, "Skip TLS verification (self-signed on-prem gateways only)")
 	flag.Parse()
 
+	dotEnvPath := ".env"
 	if workDir := os.Getenv("SIMULATOR_WORK_DIR"); workDir != "" {
-		loadDotEnv(filepath.Join(workDir, ".env"))
-	} else {
-		loadDotEnv(".env")
+		dotEnvPath = filepath.Join(workDir, ".env")
 	}
+	fromDotEnv := loadDotEnv(dotEnvPath)
 
 	s, info, err := mcpserver.New(mcpserver.Options{
 		Profile:  *profileFlag,
@@ -68,16 +103,26 @@ func main() {
 	if apiKeyMode {
 		// Mode only — never the key, its length, its prefix or a fingerprint.
 		// This line lands in the host's MCP log pane, which the user may share.
-		log.Printf("auth: %s is set — OAuth login is disabled and ACCESS_TOKEN is ignored; requests use Authorization: Bearer <key>",
-			mcpserver.APISecretEnv)
+		// Naming the SOURCE of each half matters: loadDotEnv never overrides a
+		// value already in the environment, so a key exported in the developer's
+		// shell silently outranks the project's .env while the base URL still comes
+		// from that .env — the key then travels to a gateway it was not issued for,
+		// and nothing in the log used to say so. Sources only; never the value.
+		log.Printf("auth: %s is set — OAuth login is disabled and ACCESS_TOKEN is ignored; requests use Authorization: Bearer <key> (key from %s, %s from %s)",
+			mcpserver.APISecretEnv, envSource(mcpserver.APISecretEnv, fromDotEnv),
+			apiBaseURLEnv, envSource(apiBaseURLEnv, fromDotEnv))
 	}
 	if mcpserver.IsInsecureCredentialTransport(info.APIBaseURL) {
 		// A 12h JWT leaked on the wire is a bounded incident; an API key does not
 		// expire and has no in-product revocation, so refuse rather than warn.
-		if apiKeyMode && os.Getenv(allowInsecureAPISecretEnv) == "" {
+		if apiKeyMode && !insecureAPISecretAllowed() {
 			log.Fatalf("refusing to start: %s is a long-lived credential and %q would send it in cleartext to a non-local host. "+
 				"Use HTTPS, or set %s=1 to override on a trusted network.",
 				mcpserver.APISecretEnv, info.APIBaseURL, allowInsecureAPISecretEnv)
+		}
+		if apiKeyMode {
+			log.Printf("WARNING: %s=%s is set — the long-lived API key will be sent in cleartext to %q. Remove the override once the gateway has TLS.",
+				allowInsecureAPISecretEnv, os.Getenv(allowInsecureAPISecretEnv), info.APIBaseURL)
 		}
 		log.Printf("WARNING: API base URL %q uses plaintext HTTP to a non-local host — the auth token will be sent unencrypted. Use HTTPS.", info.APIBaseURL)
 	}
@@ -99,53 +144,31 @@ func main() {
 // loadDotEnv loads KEY=VALUE lines from path into the process environment,
 // without overriding values already set. Best-effort: a missing file is fine.
 //
-// The parser stays deliberately small, but it handles the shapes a *hand-written*
-// secret arrives in — quoted values, an `export ` prefix, and a UTF-8 BOM from
-// Notepad / PowerShell redirection. Machine-written keys (ACCESS_TOKEN and
-// friends) never hit those, but SIMULATOR_API_SECRET is pasted by a human and
-// each of them otherwise fails silently: a quoted key becomes part of the
-// Authorization header, while an `export ` prefix or a BOM makes the variable
-// simply not exist and drops the user back to OAuth with no explanation.
+// Returns the set of keys it actually set, so the startup log can say whether a
+// credential came from the file or from the process environment.
 //
-// Inline comments are NOT stripped: `#` is legal inside a secret, and treating
-// it as a delimiter would corrupt the value.
-func loadDotEnv(path string) {
+// The line shapes a *hand-written* secret arrives in — quoted values, an `export `
+// prefix, surrounding spaces — are handled by auth.ParseEnvLine, which the .env
+// WRITERS in that package match against too. Keeping one parser is the point: when
+// the reader accepted a shape the writer did not, a rewrite appended a duplicate
+// line and the stale first occurrence kept winning. The UTF-8 BOM that Notepad and
+// PowerShell redirection prepend is stripped here, before the first line is parsed.
+func loadDotEnv(path string) map[string]bool {
+	fromFile := map[string]bool{}
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return
+		return fromFile
 	}
 	content := strings.TrimPrefix(string(data), "\uFEFF")
 	for _, line := range strings.Split(content, "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-		key, val, ok := strings.Cut(line, "=")
+		key, val, ok := auth.ParseEnvLine(line)
 		if !ok {
 			continue
 		}
-		key, val = strings.TrimSpace(key), strings.TrimSpace(val)
-		key = strings.TrimSpace(strings.TrimPrefix(key, "export "))
-		if key == "" || strings.ContainsAny(key, " \t") {
-			continue
-		}
-		val = trimMatchingQuotes(val)
 		if _, exists := os.LookupEnv(key); !exists {
 			_ = os.Setenv(key, val)
+			fromFile[key] = true
 		}
 	}
-}
-
-// trimMatchingQuotes removes one matching pair of surrounding single or double
-// quotes. A value that is quoted on one side only is left alone — that is more
-// likely to be part of the secret than a typo we should silently repair.
-func trimMatchingQuotes(val string) string {
-	if len(val) < 2 {
-		return val
-	}
-	first, last := val[0], val[len(val)-1]
-	if first == last && (first == '"' || first == '\'') {
-		return val[1 : len(val)-1]
-	}
-	return val
+	return fromFile
 }

--- a/plugins/simulator/mcp-server/cmd/server/main.go
+++ b/plugins/simulator/mcp-server/cmd/server/main.go
@@ -159,8 +159,9 @@ func loadDotEnv(path string) map[string]bool {
 	if err != nil {
 		return fromFile
 	}
-	content := strings.TrimPrefix(string(data), "\uFEFF")
-	for _, line := range strings.Split(content, "\n") {
+	// No BOM strip here: auth.ParseEnvLine does it, so the loader and the .env
+	// writers cannot drift apart on the first line of the file.
+	for _, line := range strings.Split(string(data), "\n") {
 		key, val, ok := auth.ParseEnvLine(line)
 		if !ok {
 			continue

--- a/plugins/simulator/mcp-server/cmd/server/main.go
+++ b/plugins/simulator/mcp-server/cmd/server/main.go
@@ -23,6 +23,11 @@ import (
 // the plugin manifests by scripts/release.sh.
 const version = mcpserver.DefaultVersion
 
+// allowInsecureAPISecretEnv opts out of the refusal to send a long-lived API key
+// over plaintext HTTP to a non-local host. Loopback is already exempt, so this
+// exists only for trusted-network on-prem gateways with no TLS.
+const allowInsecureAPISecretEnv = "SIMULATOR_ALLOW_INSECURE_API_SECRET"
+
 // installShutdownFlush flushes buffered telemetry events before the process
 // exits on SIGINT/SIGTERM (e.g. the MCP client terminating the server). Go's
 // default signal handling terminates immediately without running deferred
@@ -57,8 +62,23 @@ func main() {
 	if err != nil {
 		log.Fatalf("config: %v", err)
 	}
-	log.Printf("simulator MCP server %s — profile=%s api=%s account=%s", version, info.Profile, info.APIBaseURL, info.AccountURL)
+	log.Printf("simulator MCP server %s — profile=%s api=%s account=%s auth=%s",
+		version, info.Profile, info.APIBaseURL, info.AccountURL, info.AuthMode)
+	apiKeyMode := info.AuthMode == mcpserver.AuthModeAPIKey
+	if apiKeyMode {
+		// Mode only — never the key, its length, its prefix or a fingerprint.
+		// This line lands in the host's MCP log pane, which the user may share.
+		log.Printf("auth: %s is set — OAuth login is disabled and ACCESS_TOKEN is ignored; requests use Authorization: Bearer <key>",
+			mcpserver.APISecretEnv)
+	}
 	if mcpserver.IsInsecureCredentialTransport(info.APIBaseURL) {
+		// A 12h JWT leaked on the wire is a bounded incident; an API key does not
+		// expire and has no in-product revocation, so refuse rather than warn.
+		if apiKeyMode && os.Getenv(allowInsecureAPISecretEnv) == "" {
+			log.Fatalf("refusing to start: %s is a long-lived credential and %q would send it in cleartext to a non-local host. "+
+				"Use HTTPS, or set %s=1 to override on a trusted network.",
+				mcpserver.APISecretEnv, info.APIBaseURL, allowInsecureAPISecretEnv)
+		}
 		log.Printf("WARNING: API base URL %q uses plaintext HTTP to a non-local host — the auth token will be sent unencrypted. Use HTTPS.", info.APIBaseURL)
 	}
 	log.Printf("registered %d curated API tools + auth helpers + engine tools", mcpserver.ToolCount())
@@ -78,12 +98,24 @@ func main() {
 
 // loadDotEnv loads KEY=VALUE lines from path into the process environment,
 // without overriding values already set. Best-effort: a missing file is fine.
+//
+// The parser stays deliberately small, but it handles the shapes a *hand-written*
+// secret arrives in — quoted values, an `export ` prefix, and a UTF-8 BOM from
+// Notepad / PowerShell redirection. Machine-written keys (ACCESS_TOKEN and
+// friends) never hit those, but SIMULATOR_API_SECRET is pasted by a human and
+// each of them otherwise fails silently: a quoted key becomes part of the
+// Authorization header, while an `export ` prefix or a BOM makes the variable
+// simply not exist and drops the user back to OAuth with no explanation.
+//
+// Inline comments are NOT stripped: `#` is legal inside a secret, and treating
+// it as a delimiter would corrupt the value.
 func loadDotEnv(path string) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return
 	}
-	for _, line := range strings.Split(string(data), "\n") {
+	content := strings.TrimPrefix(string(data), "\uFEFF")
+	for _, line := range strings.Split(content, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
@@ -93,8 +125,27 @@ func loadDotEnv(path string) {
 			continue
 		}
 		key, val = strings.TrimSpace(key), strings.TrimSpace(val)
+		key = strings.TrimSpace(strings.TrimPrefix(key, "export "))
+		if key == "" || strings.ContainsAny(key, " \t") {
+			continue
+		}
+		val = trimMatchingQuotes(val)
 		if _, exists := os.LookupEnv(key); !exists {
 			_ = os.Setenv(key, val)
 		}
 	}
+}
+
+// trimMatchingQuotes removes one matching pair of surrounding single or double
+// quotes. A value that is quoted on one side only is left alone — that is more
+// likely to be part of the secret than a typo we should silently repair.
+func trimMatchingQuotes(val string) string {
+	if len(val) < 2 {
+		return val
+	}
+	first, last := val[0], val[len(val)-1]
+	if first == last && (first == '"' || first == '\'') {
+		return val[1 : len(val)-1]
+	}
+	return val
 }

--- a/plugins/simulator/mcp-server/cmd/server/main.go
+++ b/plugins/simulator/mcp-server/cmd/server/main.go
@@ -147,12 +147,12 @@ func main() {
 // Returns the set of keys it actually set, so the startup log can say whether a
 // credential came from the file or from the process environment.
 //
-// The line shapes a *hand-written* secret arrives in — quoted values, an `export `
-// prefix, surrounding spaces — are handled by auth.ParseEnvLine, which the .env
-// WRITERS in that package match against too. Keeping one parser is the point: when
-// the reader accepted a shape the writer did not, a rewrite appended a duplicate
-// line and the stale first occurrence kept winning. The UTF-8 BOM that Notepad and
-// PowerShell redirection prepend is stripped here, before the first line is parsed.
+// The line shapes a *hand-written* secret arrives in — quoted values, an indent,
+// spaces around the `=`, and the UTF-8 BOM that Notepad and PowerShell
+// redirection prepend — are all handled by auth.ParseEnvLine, which the .env
+// WRITERS in that package match against too. Keeping one parser is the point:
+// when the reader accepted a shape the writer did not, a rewrite appended a
+// duplicate line and the stale first occurrence kept winning.
 func loadDotEnv(path string) map[string]bool {
 	fromFile := map[string]bool{}
 	data, err := os.ReadFile(path)

--- a/plugins/simulator/mcp-server/internal/apiclient/authhint_test.go
+++ b/plugins/simulator/mcp-server/internal/apiclient/authhint_test.go
@@ -1,0 +1,121 @@
+package apiclient
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// The client must be scheme-agnostic: whatever AuthHeader returns goes on the
+// wire verbatim, so API-key mode needs no change here.
+func TestBearerSchemeIsForwardedVerbatim(t *testing.T) {
+	var capt capture
+	srv := newServer(200, &capt)
+	defer srv.Close()
+
+	c := New(srv.URL, "ws1", func() (string, error) { return "Bearer wsk_sekret", nil }, false)
+	if _, err := c.Do(context.Background(), "GET", "/forms", nil, nil); err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	if capt.auth != "Bearer wsk_sekret" {
+		t.Errorf("auth = %q, want %q", capt.auth, "Bearer wsk_sekret")
+	}
+}
+
+func TestAuthHintAppendedOnAuthFailures(t *testing.T) {
+	for _, status := range []int{401, 403} {
+		t.Run(http1Name(status), func(t *testing.T) {
+			var capt capture
+			srv := newServer(status, &capt)
+			defer srv.Close()
+
+			c := New(srv.URL, "ws1", func() (string, error) { return "Bearer k", nil }, false)
+			c.AuthHint = func(int) string { return "check your API key" }
+
+			_, err := c.Do(context.Background(), "GET", "/forms", nil, nil)
+			if err == nil {
+				t.Fatal("Do() error = nil, want an APIError")
+			}
+			if !strings.Contains(err.Error(), "check your API key") {
+				t.Errorf("error = %q, want it to carry the hint", err)
+			}
+
+			// Downstream code type-asserts on *APIError; the hint must not disturb that.
+			var apiErr *APIError
+			if !errors.As(err, &apiErr) {
+				t.Fatalf("error = %T, want *APIError", err)
+			}
+			if apiErr.Status != status {
+				t.Errorf("Status = %d, want %d", apiErr.Status, status)
+			}
+			if apiErr.Hint == "" {
+				t.Error("Hint is empty")
+			}
+		})
+	}
+}
+
+// The Client asks for every status and appends only what it gets back, so a
+// hint function that declines (returns "") leaves the error untouched.
+func TestAuthHintNotAppendedWhenHintDeclines(t *testing.T) {
+	var capt capture
+	srv := newServer(404, &capt)
+	defer srv.Close()
+
+	c := New(srv.URL, "ws1", func() (string, error) { return "Bearer k", nil }, false)
+	c.AuthHint = func(status int) string {
+		if status == 404 {
+			return ""
+		}
+		return "check your API key"
+	}
+
+	_, err := c.Do(context.Background(), "GET", "/forms", nil, nil)
+	if err == nil {
+		t.Fatal("Do() error = nil, want an APIError")
+	}
+	if strings.Contains(err.Error(), "check your API key") {
+		t.Errorf("error = %q, want no hint when the hint function declines", err)
+	}
+}
+
+func TestNoHintWhenAuthHintNil(t *testing.T) {
+	var capt capture
+	srv := newServer(401, &capt)
+	defer srv.Close()
+
+	c := New(srv.URL, "ws1", func() (string, error) { return "Bearer k", nil }, false)
+
+	_, err := c.Do(context.Background(), "GET", "/forms", nil, nil)
+	if err == nil {
+		t.Fatal("Do() error = nil, want an APIError")
+	}
+	if got, want := err.Error(), `API returned 401: {"ok":true}`; got != want {
+		t.Errorf("error = %q, want %q", got, want)
+	}
+}
+
+func TestDoRawAppendsAuthHint(t *testing.T) {
+	var capt capture
+	srv := newServer(403, &capt)
+	defer srv.Close()
+
+	c := New(srv.URL, "ws1", func() (string, error) { return "Bearer k", nil }, false)
+	c.AuthHint = func(int) string { return "check your API key" }
+
+	_, err := c.DoRaw(context.Background(), "GET", "/files/1", nil, nil, 1024)
+	if err == nil {
+		t.Fatal("DoRaw() error = nil, want an APIError")
+	}
+	if !strings.Contains(err.Error(), "check your API key") {
+		t.Errorf("error = %q, want it to carry the hint", err)
+	}
+}
+
+func http1Name(status int) string {
+	if status == 401 {
+		return "401 unauthorized"
+	}
+	return "403 forbidden"
+}

--- a/plugins/simulator/mcp-server/internal/apiclient/client.go
+++ b/plugins/simulator/mcp-server/internal/apiclient/client.go
@@ -21,8 +21,15 @@ import (
 
 // Client performs authenticated requests against one API base URL.
 type Client struct {
-	AuthHeader func() (string, error) // returns the full Authorization value, e.g. "Simulator <jwt>"
+	AuthHeader func() (string, error) // returns the full Authorization value, e.g. "Simulator <jwt>" or "Bearer <key>"
 	HTTP       *http.Client
+
+	// AuthHint, when set, is consulted on a rejected reply to append a short,
+	// actionable remediation to the returned *APIError. The advice differs by
+	// status and by auth mode ("check your API key" vs "run `login` again"), and
+	// this package deliberately knows nothing about modes — it just asks. It
+	// must never return credential material; "" means no advice. Nil disables it.
+	AuthHint func(status int) string
 
 	mu          sync.RWMutex // guards baseURL + workspaceID (set-environment / set-workspace mutate them at runtime)
 	baseURL     string       // e.g. http://localhost:9000/papi/1.0
@@ -232,9 +239,13 @@ func IsInsecureCredentialTransport(baseURL string) bool {
 type APIError struct {
 	Status int
 	Body   string
+	Hint   string // optional remediation supplied by the Client's AuthHint; "" when it had no advice
 }
 
 func (e *APIError) Error() string {
+	if e.Hint != "" {
+		return fmt.Sprintf("API returned %d: %s — %s", e.Status, e.Body, e.Hint)
+	}
 	return fmt.Sprintf("API returned %d: %s", e.Status, e.Body)
 }
 
@@ -258,7 +269,7 @@ func (c *Client) Do(ctx context.Context, method, path string, query url.Values, 
 		return nil, fmt.Errorf("read response from %s %s: %w", method, path, err)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, &APIError{Status: resp.StatusCode, Body: string(respBody)}
+		return nil, c.apiError(resp.StatusCode, string(respBody))
 	}
 	return respBody, nil
 }
@@ -302,7 +313,7 @@ func (c *Client) DoRaw(ctx context.Context, method, path string, query url.Value
 		truncated = true
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return RawResponse{}, &APIError{Status: resp.StatusCode, Body: string(data)}
+		return RawResponse{}, c.apiError(resp.StatusCode, string(data))
 	}
 	return RawResponse{
 		Body:        data,
@@ -352,4 +363,16 @@ func (c *Client) buildRequest(ctx context.Context, method, path string, query ur
 		}
 	}
 	return req, nil
+}
+
+// apiError builds the *APIError for a non-2xx reply, letting AuthHint decide
+// whether this status warrants advice. Without it a bad key surfaces as a bare
+// "API returned 401", which tells the user nothing about which of the key, the
+// workspace or the environment is wrong.
+func (c *Client) apiError(status int, body string) *APIError {
+	e := &APIError{Status: status, Body: body}
+	if c.AuthHint != nil {
+		e.Hint = c.AuthHint(status)
+	}
+	return e
 }

--- a/plugins/simulator/mcp-server/internal/engines/ecore/helpers.go
+++ b/plugins/simulator/mcp-server/internal/engines/ecore/helpers.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"regexp"
 
+	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/app/auth"
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
@@ -59,6 +60,23 @@ func RequireUUID(name, v string) *mcp.CallToolResult {
 // such an ID contains "/", "?" or "#".
 func Seg(s string) string { return url.PathEscape(s) }
 
+// HTTPStatusError renders a non-2xx engine reply as an error, appending an
+// actionable hint when the status is credential-related, so a rejected request
+// says which of the key, the workspace or the environment to check. Engine
+// sub-packages share it so that remediation text lives in one place.
+//
+// The hint is suppressed in stateless mode, mirroring AuthHeaderForContext:
+// there the credential arrived from the caller's header, so this process has no
+// advice to give about it.
+func HTTPStatusError(method, apiURL string, status int, body []byte) error {
+	if !IsStateless() {
+		if hint := auth.HintFor(status); hint != "" {
+			return fmt.Errorf("%s %s: HTTP %d: %.300s — %s", method, apiURL, status, body, hint)
+		}
+	}
+	return fmt.Errorf("%s %s: HTTP %d: %.300s", method, apiURL, status, body)
+}
+
 // PapiGET sends an authenticated GET and returns the response body.
 // The ctx supplies the per-request Authorization in stateless mode.
 func PapiGET(ctx context.Context, apiURL string) ([]byte, error) {
@@ -80,7 +98,7 @@ func PapiGET(ctx context.Context, apiURL string) ([]byte, error) {
 	// {"data":[...]} payload; without this guard the caller would silently parse
 	// it as an empty result (e.g. an empty layer export). Matches GraphSyncer.get.
 	if resp.StatusCode >= 400 {
-		return nil, fmt.Errorf("GET %s: HTTP %d: %.300s", apiURL, resp.StatusCode, data)
+		return nil, HTTPStatusError("GET", apiURL, resp.StatusCode, data)
 	}
 	return data, nil
 }
@@ -103,7 +121,7 @@ func PapiPOST(ctx context.Context, apiURL string, body []byte) ([]byte, error) {
 		return nil, err
 	}
 	if resp.StatusCode >= 400 {
-		return nil, fmt.Errorf("POST %s: HTTP %d: %.300s", apiURL, resp.StatusCode, data)
+		return nil, HTTPStatusError("POST", apiURL, resp.StatusCode, data)
 	}
 	return data, nil
 }
@@ -126,7 +144,7 @@ func PapiPUT(ctx context.Context, apiURL string, body []byte) ([]byte, error) {
 		return nil, err
 	}
 	if resp.StatusCode >= 400 {
-		return nil, fmt.Errorf("PUT %s: HTTP %d: %.300s", apiURL, resp.StatusCode, data)
+		return nil, HTTPStatusError("PUT", apiURL, resp.StatusCode, data)
 	}
 	return data, nil
 }

--- a/plugins/simulator/mcp-server/internal/engines/ecore/httperror_test.go
+++ b/plugins/simulator/mcp-server/internal/engines/ecore/httperror_test.go
@@ -1,0 +1,53 @@
+package ecore
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/app/auth"
+)
+
+func TestHTTPStatusErrorAddsHintOnAuthFailures(t *testing.T) {
+	t.Setenv(auth.APISecretEnv, "wsk_key")
+
+	for _, status := range []int{401, 403} {
+		err := HTTPStatusError("GET", "https://example.test/papi/1.0/forms", status, []byte(`{"msg":"nope"}`))
+		if !strings.Contains(err.Error(), auth.APISecretEnv) {
+			t.Errorf("status %d: error = %q, want the API-key hint", status, err)
+		}
+		if !strings.Contains(err.Error(), "GET https://example.test/papi/1.0/forms") {
+			t.Errorf("status %d: error = %q, lost the request context", status, err)
+		}
+	}
+}
+
+func TestHTTPStatusErrorNoHintOnServerError(t *testing.T) {
+	t.Setenv(auth.APISecretEnv, "wsk_key")
+
+	err := HTTPStatusError("POST", "https://example.test/x", 500, []byte("boom"))
+	if strings.Contains(err.Error(), auth.APISecretEnv) {
+		t.Errorf("error = %q, hint must be confined to 401/403", err)
+	}
+}
+
+// In stateless mode the credential came from the caller's header, so this
+// process has no advice to give — and must not hint at its own env vars.
+func TestHTTPStatusErrorSuppressedWhenStateless(t *testing.T) {
+	t.Setenv(auth.APISecretEnv, "wsk_key")
+	SetStateless(true)
+	t.Cleanup(func() { SetStateless(false) })
+
+	err := HTTPStatusError("GET", "https://example.test/x", 401, []byte("nope"))
+	if strings.Contains(err.Error(), auth.APISecretEnv) {
+		t.Errorf("error = %q, want no hint in stateless mode", err)
+	}
+}
+
+func TestHTTPStatusErrorOAuthHint(t *testing.T) {
+	t.Setenv(auth.APISecretEnv, "")
+
+	err := HTTPStatusError("GET", "https://example.test/x", 401, []byte("nope"))
+	if !strings.Contains(err.Error(), "login") {
+		t.Errorf("error = %q, want the OAuth hint to point at `login`", err)
+	}
+}

--- a/plugins/simulator/mcp-server/internal/engines/ecore/runtime.go
+++ b/plugins/simulator/mcp-server/internal/engines/ecore/runtime.go
@@ -171,12 +171,23 @@ func EnsureAuth(ctx context.Context) *mcp.CallToolResult {
 		}
 		return nil
 	}
+	// Authoritative: the cache mirrors whatever Load reports right now, including
+	// "nothing usable". Only overwriting on success would leave a revoked or
+	// removed credential cached forever — the guard below would not fire, engine
+	// tools would keep sending the stale header, and the curated tools (which
+	// re-read credentials per request) would disagree about whether the user is
+	// authenticated at all.
+	header := ""
 	if creds, _ := auth.Load(); creds != nil && !auth.IsExpired(creds) {
-		cfgMu.Lock()
-		Cfg.Authorization = creds.AuthorizationHeader()
-		cfgMu.Unlock()
+		header = creds.AuthorizationHeader()
 	}
-	if AuthHeader() == "" {
+	cfgMu.Lock()
+	Cfg.Authorization = header
+	cfgMu.Unlock()
+
+	// Only reachable in OAuth mode: an API key always yields a non-empty header
+	// (a non-blank secret, and a zero ExpiresAt that IsExpired reports as valid).
+	if header == "" {
 		return mcp.NewToolResultError("[Error] not authenticated — run the `login` tool first")
 	}
 	return nil

--- a/plugins/simulator/mcp-server/internal/engines/graph/chart.go
+++ b/plugins/simulator/mcp-server/internal/engines/graph/chart.go
@@ -131,7 +131,7 @@ func chartHTTPGet(ctx context.Context, apiURL, auth string) ([]byte, error) {
 	defer resp.Body.Close()
 	data, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode >= 400 {
-		return nil, fmt.Errorf("GET %s: HTTP %d: %.300s", apiURL, resp.StatusCode, data)
+		return nil, ecore.HTTPStatusError("GET", apiURL, resp.StatusCode, data)
 	}
 	return data, nil
 }
@@ -154,7 +154,7 @@ func chartHTTPJSON(ctx context.Context, method, apiURL, auth string, body interf
 	defer resp.Body.Close()
 	data, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode >= 400 {
-		return nil, fmt.Errorf("%s %s: HTTP %d: %.300s", method, apiURL, resp.StatusCode, data)
+		return nil, ecore.HTTPStatusError(method, apiURL, resp.StatusCode, data)
 	}
 	return data, nil
 }

--- a/plugins/simulator/mcp-server/internal/engines/graph/push.go
+++ b/plugins/simulator/mcp-server/internal/engines/graph/push.go
@@ -127,7 +127,7 @@ func (s *GraphSyncer) get(ctx context.Context, apiURL string) ([]byte, error) {
 		return nil, err
 	}
 	if resp.StatusCode >= 400 {
-		return nil, fmt.Errorf("GET %s: HTTP %d: %.300s", apiURL, resp.StatusCode, data)
+		return nil, ecore.HTTPStatusError("GET", apiURL, resp.StatusCode, data)
 	}
 	return data, nil
 }
@@ -153,7 +153,7 @@ func (s *GraphSyncer) doJSON(ctx context.Context, method, apiURL string, body in
 		return nil, err
 	}
 	if resp.StatusCode >= 400 {
-		return nil, fmt.Errorf("%s %s: HTTP %d: %.300s", method, apiURL, resp.StatusCode, data)
+		return nil, ecore.HTTPStatusError(method, apiURL, resp.StatusCode, data)
 	}
 	return data, nil
 }

--- a/plugins/simulator/mcp-server/internal/tools/auth_mode_test.go
+++ b/plugins/simulator/mcp-server/internal/tools/auth_mode_test.go
@@ -1,0 +1,197 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/app/auth"
+	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/internal/apiclient"
+	"github.com/corezoid/simulator-ai-plugin/plugins/simulator/mcp-server/internal/config"
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// apiKeyEnv points .env at an empty temp dir and turns API-key mode on, so a
+// handler that wrongly falls through to the OAuth path is caught by an
+// unexpectedly non-empty directory rather than by opening a browser.
+func apiKeyEnv(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("SIMULATOR_WORK_DIR", dir)
+	t.Setenv("ACCESS_TOKEN", "")
+	t.Setenv(auth.APISecretEnv, "wsk_key")
+	return dir
+}
+
+func assertDirEmpty(t *testing.T, dir string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("%s should be untouched, found %d entries", dir, len(entries))
+	}
+}
+
+func TestLoginRefusesInAPIKeyMode(t *testing.T) {
+	dir := apiKeyEnv(t)
+
+	// s is nil on purpose: the guard must return before telemetry.AskForEmailOnce.
+	res, err := loginHandler(nil, config.Profile{Name: "prod"})(context.Background(), mcp.CallToolRequest{})
+	if err != nil {
+		t.Fatalf("loginHandler error = %v", err)
+	}
+	if res.IsError {
+		t.Error("login should return an explanation, not an error — an error invites the model to retry")
+	}
+
+	text := resultText(t, res)
+	if !strings.Contains(text, auth.APISecretEnv) {
+		t.Errorf("result = %q, should name %s", text, auth.APISecretEnv)
+	}
+	if !strings.Contains(text, "WORKSPACE_ID") {
+		t.Errorf("result = %q, should mention the workspace-scoping caveat", text)
+	}
+
+	// No token written, no .env created.
+	assertDirEmpty(t, dir)
+	if _, err := os.Stat(filepath.Join(dir, ".env")); !os.IsNotExist(err) {
+		t.Errorf(".env exists after login in API-key mode (stat err = %v)", err)
+	}
+	if os.Getenv("ACCESS_TOKEN") != "" {
+		t.Error("login set ACCESS_TOKEN in API-key mode")
+	}
+}
+
+func TestSetEnvironmentRefusesInAPIKeyMode(t *testing.T) {
+	dir := apiKeyEnv(t)
+	envPath := filepath.Join(dir, ".env")
+	original := auth.APISecretEnv + "=wsk_key\nSIMULATOR_API_BASE_URL=https://mw.simulator.company/papi/1.0\n"
+	if err := os.WriteFile(envPath, []byte(original), 0o600); err != nil {
+		t.Fatalf("seed .env: %v", err)
+	}
+
+	s := server.NewMCPServer("test", "0.0.0")
+	c := apiclient.New("https://mw.simulator.company/papi/1.0", "ws1", func() (string, error) { return "Bearer k", nil }, false)
+	registerSetEnvironment(s, c, config.Profile{Name: "prod"}, false)
+
+	res, err := callTool(t, s, "set-environment", map[string]any{"url": "evil.example.com"})
+	if err != nil {
+		t.Fatalf("set-environment error = %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("set-environment should refuse in API-key mode")
+	}
+	if text := resultText(t, res); !strings.Contains(text, auth.APISecretEnv) {
+		t.Errorf("result = %q, should explain the API-key constraint", text)
+	}
+
+	// The refusal must happen before anything is persisted or cleared.
+	data, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatalf("read .env: %v", err)
+	}
+	if string(data) != original {
+		t.Errorf(".env was modified:\n got %q\nwant %q", data, original)
+	}
+	if got := c.BaseURL(); got != "https://mw.simulator.company/papi/1.0" {
+		t.Errorf("base URL = %q, want it unchanged", got)
+	}
+}
+
+// The tool list is fixed for the session, so `login` stays registered and
+// explains itself rather than vanishing (a missing tool invites the model to
+// claim it cannot authenticate at all).
+func TestLoginStaysRegisteredAndIsMarkedDisabled(t *testing.T) {
+	apiKeyEnv(t)
+
+	s := server.NewMCPServer("test", "0.0.0")
+	c := apiclient.New("https://mw.simulator.company/papi/1.0", "ws1", func() (string, error) { return "Bearer k", nil }, false)
+	registerAuth(s, c, config.Profile{Name: "prod"}, false)
+
+	desc := toolDescription(t, s, "login")
+	if desc == "" {
+		t.Fatal("login is not registered in API-key mode")
+	}
+	if !strings.Contains(desc, "DISABLED") {
+		t.Errorf("login description = %q, want it marked DISABLED", desc)
+	}
+}
+
+// newClient wires an in-process MCP client to s and initializes it, so tests can
+// exercise a registered tool through the same path a host would.
+func newClient(t *testing.T, s *server.MCPServer) *client.Client {
+	t.Helper()
+	cli, err := client.NewInProcessClient(s)
+	if err != nil {
+		t.Fatalf("new in-process client: %v", err)
+	}
+	t.Cleanup(func() { _ = cli.Close() })
+
+	ctx := context.Background()
+	if err := cli.Start(ctx); err != nil {
+		t.Fatalf("start client: %v", err)
+	}
+	var init mcp.InitializeRequest
+	init.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+	init.Params.ClientInfo = mcp.Implementation{Name: "auth-mode-test", Version: "0"}
+	if _, err := cli.Initialize(ctx, init); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+	return cli
+}
+
+func callTool(t *testing.T, s *server.MCPServer, name string, args map[string]any) (*mcp.CallToolResult, error) {
+	t.Helper()
+	var req mcp.CallToolRequest
+	req.Params.Name = name
+	req.Params.Arguments = args
+	return newClient(t, s).CallTool(context.Background(), req)
+}
+
+func toolDescription(t *testing.T, s *server.MCPServer, name string) string {
+	t.Helper()
+	list, err := newClient(t, s).ListTools(context.Background(), mcp.ListToolsRequest{})
+	if err != nil {
+		t.Fatalf("list tools: %v", err)
+	}
+	for i := range list.Tools {
+		if list.Tools[i].Name == name {
+			return list.Tools[i].Description
+		}
+	}
+	return ""
+}
+
+func resultText(t *testing.T, res *mcp.CallToolResult) string {
+	t.Helper()
+	var sb strings.Builder
+	for _, c := range res.Content {
+		if tc, ok := mcp.AsTextContent(c); ok {
+			sb.WriteString(tc.Text)
+		}
+	}
+	return sb.String()
+}
+
+func TestLoginDescriptionIsNormalInOAuthMode(t *testing.T) {
+	t.Setenv("SIMULATOR_WORK_DIR", t.TempDir())
+	t.Setenv(auth.APISecretEnv, "")
+
+	s := server.NewMCPServer("test", "0.0.0")
+	c := apiclient.New("https://mw.simulator.company/papi/1.0", "ws1", func() (string, error) { return "Simulator j", nil }, false)
+	registerAuth(s, c, config.Profile{Name: "prod"}, false)
+
+	desc := toolDescription(t, s, "login")
+	if strings.Contains(desc, "DISABLED") {
+		t.Errorf("login description = %q, should not be disabled in OAuth mode", desc)
+	}
+	if !strings.Contains(desc, "OAuth2 PKCE") {
+		t.Errorf("login description = %q, want the normal OAuth description", desc)
+	}
+}

--- a/plugins/simulator/mcp-server/internal/tools/build.go
+++ b/plugins/simulator/mcp-server/internal/tools/build.go
@@ -107,31 +107,57 @@ func BuildUnified(s *server.MCPServer, c *apiclient.Client, includeActorMode boo
 // Count reports how many curated API tools are registered (auth helpers excluded).
 func Count() int { return len(allOps()) }
 
+// apiKeyLoginNotice is what `login` returns when an API key is configured. It is
+// a success result, not an error: nothing is broken — OAuth simply is not the
+// active auth mode — and the model needs to stop and explain that, not retry.
+const apiKeyLoginNotice = "OAuth login is disabled: this server is running in API-key mode " +
+	"(" + auth.APISecretEnv + " is set in your .env or environment). Every request is authenticated " +
+	"with `Authorization: Bearer <key>`; there is no browser sign-in, no token is written to .env, " +
+	"and ACCESS_TOKEN is ignored.\n\n" +
+	"If the key is wrong you will see 401s — fix it and restart the MCP server, because .env is read " +
+	"once at startup.\n" +
+	"To use OAuth instead: remove " + auth.APISecretEnv + " from .env, restart, then run `login`.\n\n" +
+	"Note: a Simulator API key is scoped to ONE workspace. Make sure WORKSPACE_ID names that same " +
+	"workspace — try getWorkspaces + set-workspace; if the key is not allowed to list workspaces, " +
+	"copy the workspace id from account.corezoid.com and put WORKSPACE_ID in .env by hand."
+
+// loginHandler runs the OAuth2 PKCE flow, unless an API key is configured — in
+// which case it explains why it is doing nothing. Split out of registerAuth so
+// tests can drive it directly.
+func loginHandler(s *server.MCPServer, prof config.Profile) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		if auth.IsAPIKeyMode() {
+			return mcp.NewToolResultText(apiKeyLoginNotice), nil
+		}
+		// Prefer the account URL derived by set-environment (saved as ACCOUNT_URL)
+		// over the startup profile default, so login follows the chosen environment.
+		accountURL := firstNonEmpty(os.Getenv("ACCOUNT_URL"), prof.AccountURL)
+		creds, err := auth.PKCEFlow(accountURL, prof.OAuthClientID, nil)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("[Error] OAuth2 login failed: %v", err)), nil
+		}
+		if err := auth.Save(creds); err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("[Error] failed to save token: %v", err)), nil
+		}
+		// One-time opt-in: ask for email to include in telemetry. Only
+		// shown once per installation, and only if the client supports
+		// elicitation; skipping is always valid.
+		telemetry.AskForEmailOnce(ctx, s)
+		return mcp.NewToolResultText("Authenticated. Token saved to .env. Next: call getWorkspaces to list your workspaces, show them to the user to pick one, then call set-workspace (by accId or name)."), nil
+	}
+}
+
 func registerAuth(s *server.MCPServer, c *apiclient.Client, prof config.Profile, insecure bool) {
 	registerSetEnvironment(s, c, prof, insecure)
 
-	s.AddTool(
-		mcp.NewTool("login",
-			mcp.WithDescription("Authenticate to Simulator via OAuth2 PKCE (opens a browser). Saves the token to .env. Run set-environment first if you haven't chosen an environment. After login, call set-workspace to choose a workspace."),
-		),
-		func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			// Prefer the account URL derived by set-environment (saved as ACCOUNT_URL)
-			// over the startup profile default, so login follows the chosen environment.
-			accountURL := firstNonEmpty(os.Getenv("ACCOUNT_URL"), prof.AccountURL)
-			creds, err := auth.PKCEFlow(accountURL, prof.OAuthClientID, nil)
-			if err != nil {
-				return mcp.NewToolResultError(fmt.Sprintf("[Error] OAuth2 login failed: %v", err)), nil
-			}
-			if err := auth.Save(creds); err != nil {
-				return mcp.NewToolResultError(fmt.Sprintf("[Error] failed to save token: %v", err)), nil
-			}
-			// One-time opt-in: ask for email to include in telemetry. Only
-			// shown once per installation, and only if the client supports
-			// elicitation; skipping is always valid.
-			telemetry.AskForEmailOnce(ctx, s)
-			return mcp.NewToolResultText("Authenticated. Token saved to .env. Next: call getWorkspaces to list your workspaces, show them to the user to pick one, then call set-workspace (by accId or name)."), nil
-		},
-	)
+	loginDesc := "Authenticate to Simulator via OAuth2 PKCE (opens a browser). Saves the token to .env. " +
+		"Run set-environment first if you haven't chosen an environment. After login, call set-workspace to choose a workspace."
+	if auth.IsAPIKeyMode() {
+		loginDesc = "DISABLED — this server runs in API-key mode (" + auth.APISecretEnv + " is set), so OAuth login " +
+			"is not used and calling this tool only explains that. Requests are already authenticated. " +
+			"The next step is set-workspace, not login."
+	}
+	s.AddTool(mcp.NewTool("login", mcp.WithDescription(loginDesc)), loginHandler(s, prof))
 
 	s.AddTool(
 		mcp.NewTool("set-workspace",
@@ -177,13 +203,38 @@ func registerSetEnvironment(s *server.MCPServer, c *apiclient.Client, prof confi
 	}
 	names := presetNames(presets)
 
+	setEnvDesc := "Choose the Simulator environment to work with BEFORE login. Pass `preset` for a listed gateway (" +
+		strings.TrimRight(presetLines.String(), "; ") + ") or `url` for a custom / on-prem / local server (host or full URL; " +
+		"/papi/1.0 is added if omitted). It fetches the gateway's public config to derive the correct OAuth account URL, " +
+		"saves the choice to .env, and clears any existing token + workspace — so you must run login (then set-workspace) " +
+		"afterwards. Use it again at any time to switch environments."
+	// Description only: the handler re-checks the mode, so the refusal holds
+	// regardless of what was baked in at registration time.
+	if auth.IsAPIKeyMode() {
+		setEnvDesc = "DISABLED — this server runs in API-key mode (" + auth.APISecretEnv + " is set). The key is scoped to " +
+			"one workspace on one gateway, so the environment cannot be switched at runtime; change it in .env and restart. " +
+			"Calling this tool returns that explanation."
+	}
+
 	s.AddTool(
 		mcp.NewTool("set-environment",
-			mcp.WithDescription("Choose the Simulator environment to work with BEFORE login. Pass `preset` for a listed gateway ("+strings.TrimRight(presetLines.String(), "; ")+") or `url` for a custom / on-prem / local server (host or full URL; /papi/1.0 is added if omitted). It fetches the gateway's public config to derive the correct OAuth account URL, saves the choice to .env, and clears any existing token + workspace — so you must run login (then set-workspace) afterwards. Use it again at any time to switch environments."),
+			mcp.WithDescription(setEnvDesc),
 			mcp.WithString("preset", mcp.Description("Environment selector. One of: "+names+". Provide preset or url.")),
 			mcp.WithString("url", mcp.Description("Custom/local server URL or host (e.g. http://localhost:9000 or my-onprem.example.com). Provide preset or url.")),
 		),
 		func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			// Refuse before doing anything. Re-pointing the gateway would send a
+			// long-lived key — which this process holds but does not own — to a
+			// host chosen at call time, and `url` accepts any host. It would also
+			// clear WORKSPACE_ID, which a workspace-scoped key may not be able to
+			// re-discover via getWorkspaces, stranding the session.
+			if auth.IsAPIKeyMode() {
+				return mcp.NewToolResultError("[Error] set-environment is disabled in API-key mode: a Simulator API key " +
+					"is scoped to one workspace on one gateway, so pointing this server at a different environment would " +
+					"send your key to a host it was not issued for. To switch environments, edit " + auth.APISecretEnv +
+					" and SIMULATOR_API_BASE_URL in .env (plus WORKSPACE_ID for the new workspace) and restart the MCP server."), nil
+			}
+
 			args := req.GetArguments()
 			preset, _ := args["preset"].(string)
 			rawURL, _ := args["url"].(string)

--- a/plugins/simulator/skills/simulator-init/SKILL.md
+++ b/plugins/simulator/skills/simulator-init/SKILL.md
@@ -43,7 +43,14 @@ token + workspace**, so you must `login` again afterwards.
 
 ## Step 1 — Authenticate
 
-Call MCP tool **`login`** with no arguments:
+**If `SIMULATOR_API_SECRET` is set in `.env`, skip this step entirely.** The server is in
+API-key mode: requests are already authenticated with `Authorization: Bearer <key>`, `login`
+is disabled, and Step 0 is unavailable too (the key is bound to one gateway). Go straight to
+Step 2 — the workspace still matters, because a Simulator API key is scoped to ONE workspace
+and `WORKSPACE_ID` must name that same one. If you are unsure which mode is active, calling
+`login` is harmless: in API-key mode it returns an explanation instead of opening a browser.
+
+Otherwise, call MCP tool **`login`** with no arguments:
 
 ```
 login()
@@ -99,3 +106,4 @@ and `set-workspace` afterwards.
 | `ACCESS_TOKEN` | Step 1 — OAuth2 authentication |
 | `ACCESS_TOKEN_EXPIRES_AT` | Step 1 — Token expiry |
 | `WORKSPACE_ID` | Step 2 — Workspace selection |
+| `SIMULATOR_API_SECRET` | Set by the **user**, never by these tools — enables API-key mode |


### PR DESCRIPTION
## What

Adds a second, non-interactive auth mode. Put a workspace access key in `.env` as `SIMULATOR_API_SECRET` and every request goes out as `Authorization: Bearer <key>` instead of the OAuth `Simulator <jwt>`. For CI, headless runs and service integrations.

```bash
SIMULATOR_API_BASE_URL=https://mw.simulator.company/papi/1.0
SIMULATOR_API_SECRET=your_workspace_key
WORKSPACE_ID=the_key_s_workspace_accId
```

Precedence: `SIMULATOR_API_SECRET` > `ACCESS_TOKEN` > saved OAuth credentials.

## Why it's small

Both HTTP stacks already forwarded an opaque header string, and that string is assembled in exactly one place (`Credentials.AuthorizationHeader`). So the feature is **one leading branch in `auth.Load`** plus the existing per-credential `TokenType` — **none of the ~20 header call sites changed**.

The per-credential scheme was required, not a convenience. Verified against the live gateway:

| Header | Result |
|---|---|
| `Bearer atn_…` | **200** + data |
| `Simulator atn_…` | **401** `jwt malformed` |

The key is not a JWT; a single hardcoded scheme could not serve both.

## Guards

OAuth is disabled end to end: `login` explains itself instead of opening a browser (so the one-time telemetry-email elicitation never fires), `auth.Save` refuses to write a token, and `set-environment` refuses. The plugin only ever *reads* the key — never written back to `.env`, logged, or sent to telemetry.

Every guard lives in the library (`app/auth` / `app/mcpserver`), not only in the tool handler or `cmd/server`, so an embedder calling `mcpserver.New` directly gets the same invariants:

- **`set-environment` refuses.** It takes a free-form `url` and the model can call it unprompted, so re-pointing the gateway would send a long-lived key to a host it was not issued for. It also clears `WORKSPACE_ID`, which a workspace-scoped key may not be able to re-discover.
- **Stateless constructors refuse** (`New(Stateless)` *and* `NewActorServer`). A key is process-global; `ecore`'s stateless flag is itself a process global a later constructor can flip, after which engine tools would attach this process's key to every tenant's request.
- **`New` refuses plaintext HTTP** to a non-local host (loopback exempt), waived by `SIMULATOR_ALLOW_INSECURE_API_SECRET=1` — parsed as a bool, so `=0` cannot switch the guard *off*. A leaked 12h JWT is bounded; a leaked non-expiring key is not. It holds even when the caller supplies its own `Options.AuthHeader`, because the engine tools resolve credentials through `auth.Load` themselves.

### Naming

`SIMULATOR_API_SECRET`, not `API_SECRET`. `.mcp.json` declares no `env` allow-list, so the server inherits the host's whole environment — a bare `API_SECRET` is common enough in developer shells that an unrelated third-party secret would be sent to `mw.simulator.company` as a Bearer token.

## Pre-existing bugs this also fixes

Two of these predate the API-key work and bite plain OAuth users; they surfaced because the new key travels the same paths.

- **A `.env` line the loader could read but the writers could not find.** `loadDotEnv` trims a line before splitting it, so it has always read `  KEY=value` and `KEY = value`; the writers matched a bare `KEY=` prefix and did not. A rewrite therefore **appended a second assignment**, and the loader takes the *first* — so on any indented `.env`, `login` / `set-workspace` / `set-environment` silently lost their new value on the next start, and `auth.Delete` left the line in place so a "cleared" token came back. Both sides now go through one `auth.ParseEnvLine`, covered by a cross-package test that drives loader and writers against each other.
- **Quoted and BOM'd values were mangled.** `ACCESS_TOKEN="abc"` put the quotes inside the header (`Bearer "abc"` → an unexplained 401), and a UTF-8 BOM (Notepad / PowerShell) left the first line's variable unset with no diagnostic.
- **`ecore.EnsureAuth` never cleared its auth cache.** It only overwrote on success, so a removed or revoked credential kept being sent by engine tools while the curated tools reported "not authenticated". Now authoritative.
- **Bare 401/403 errors.** A rejected credential surfaced as `API returned 401: …` with no clue whether the key, `WORKSPACE_ID` or the environment was wrong. Both stacks now append a status-aware hint — 401 blames the credential, 403 leads with *"the object does not exist or belongs to another workspace"*, since 403 is returned for a missing or foreign object far more often. Never carries credential material; suppressed in stateless mode.

`.env` is deliberately **not** treated as a shell script: `export KEY=value` is not an assignment, and both the loader and the writers skip such a line alike. The README's static-token example was split into a `.env` block and a shell block so it stops implying otherwise.

## Tests

`app/auth` had **no tests at all**; it gets its first ones — precedence, header scheme (including the empty-`TokenType` default that protects every call site), a stale `ACCESS_TOKEN_EXPIRES_AT` not bleeding onto the key, `Save` refusing, `Delete` leaving the key intact. Plus new suites for the hints, the `.env` parser, the tool guards, both stateless constructors and the plaintext-HTTP refusal.

**No existing test needed changing.** The only one asserting the scheme supplies the header itself via an injected callback.

## Verification

`make build`, `make vet`, `make test`, `-race`, `-shuffle=on`, `make discovery` (`public/` unchanged) — all green. Lint: `gosec` and `gofmt` did not grow; the only delta is in-package test files, matching the existing convention (the new tests need unexported access).

End to end against `mw.simulator.company` with a real workspace key:

- `getWorkspaces`, `getForms` with `accId` auto-injected, and `pullGraphFile` on a real layer — proving both HTTP stacks
- `login` and `set-environment` refusing, with `.env` byte-identical afterwards and no `ACCESS_TOKEN` written
- precedence over a garbage `ACCESS_TOKEN`; a bad key producing an actionable 401
- quoted keys parsing correctly
- no fragment of the key in logs, tool results or written files

**Not covered:** the engine *write* path (`pushGraphFile` / `compactGraphLayout` → `PapiPOST`/`PapiPUT`). It syncs by removing extras, so it was not run against a live production graph.

## Notes for review

- The mode is fixed at startup (`.env` is read once), matching `SIMULATOR_PROFILE` and friends. Both the `login` notice and the startup log say a restart is required.
- `Info` and `apiclient.Client` gain fields additively; `apiclient.New`'s signature is unchanged. Embedders should know `SIMULATOR_API_SECRET` does **not** work for stateless/SSE and now fails construction rather than silently leaking.
- Version deliberately not bumped — only a bullet under `## [Unreleased]`, per the house rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
