### PR TITLE
docs(smart-forms): document the page-level browser tab title

### DIFF
--- a/plugins/simulator/docs/user-flows/cdu-page-protocol.md
+++ b/plugins/simulator/docs/user-flows/cdu-page-protocol.md
@@ -85,6 +85,7 @@ Corezoid with `path: '/get'` or `'/send'` plus `{ page, query, context }` and `s
 {
   "code": 200,
   "data": {
+    "title": "My orders",       // optional; browser tab title of the page
     "grid":  { /* Grid — layout */ },
     "forms": [ /* Form[] — content */ ],
     "query": { /* echoed/updated query */ },
@@ -141,6 +142,7 @@ The render tree is **Page → Grid → Form → Section → Item**:
 
 ```
 Page
+ ├─ title?          browser tab title; falls back to a host-composed name
  ├─ grid            layout: column model, header, sidebar, region→form mapping
  └─ forms[]         one or more Form
        ├─ (grid?)   a form may carry its own nested grid

--- a/plugins/simulator/mcp-server/internal/tools/smartforms.go
+++ b/plugins/simulator/mcp-server/internal/tools/smartforms.go
@@ -21,7 +21,7 @@ var smartFormOps = []Operation{
 	{
 		Name: "appGetPage", Method: "GET", Path: "/pages/{accId}/{ref}/{envTitle}/{page}",
 		Summary: "Render one page of a Smart Form (CDU / Script application) — the runtime equivalent of opening " +
-			"the app's page in the UI. Returns a Page `{ grid, forms[], notifications[], query, language }` " +
+			"the app's page in the UI. Returns a Page `{ title, grid, forms[], notifications[], query, language }` " +
 			"(code 200); the env's Corezoid process supplies the dynamic viewModel/data. Read `forms[].sections[].content[]` " +
 			"to see the components (items) to fill, and `notifications[]` for messages from the process. Then submit with " +
 			"appSendForm. Start a flow at page `index`. Smart Forms are addressed by (accId, ref, envTitle); use the " +

--- a/plugins/simulator/skills/simulator-smart-forms/SKILL.md
+++ b/plugins/simulator/skills/simulator-smart-forms/SKILL.md
@@ -209,6 +209,25 @@ The page `config` is the layout template. Structure: **Page → Grid → Form �
 }
 ```
 
+### Page (root of `config`)
+
+```jsonc
+{
+  "title": "My orders",        // browser tab title; see below
+  "grid":  { /* layout */ },
+  "forms": [ /* content */ ],
+  "language": "uk",            // base locale for [[…]] and date formatting
+  "styleClass": "orders-page",
+  "query": { "ref": "{{ref}}" },
+  "notifications": [ /* shown when the page opens */ ]
+}
+```
+
+`title` names the browser tab. Omit it and the tab is named by the host
+application — `<page> - <script ref>`, or the script ref alone on the `index`
+page. A Smart Form embedded into another screen (a modal, a section header)
+never renames the browser tab, whether a title is set or not.
+
 ### Grid
 
 ```jsonc

--- a/plugins/simulator/skills/simulator-smart-forms/SKILL.md
+++ b/plugins/simulator/skills/simulator-smart-forms/SKILL.md
@@ -228,6 +228,25 @@ application — `<page> - <script ref>`, or the script ref alone on the `index`
 page. A Smart Form embedded into another screen (a modal, a section header)
 never renames the browser tab, whether a title is set or not.
 
+**A whole value may be a placeholder.** `query`, `notifications` and `extra` are
+resolved server-side, so any of them can be written as a single `{{viewModel}}`
+or `[[locale]]` token and arrive as an object or an array:
+
+```jsonc
+"query":         "{{query}}",      // → object
+"notifications": "{{messages}}",   // → array
+"extra":         "{{pageExtra}}"   // → object
+```
+
+The token has to be the entire string — with text around it the result is
+always a string. The same holds inside `grid.header`, where every nested key is
+resolved (`"extra": { "steps": "{{steps}}" }`).
+
+Not everything is resolved, and a placeholder written in the wrong place is
+silently left as literal text: `grid.type`, `grid.styleClass`, `grid.sideBar`,
+`grid.header.class` and the keys **inside** a page-level `extra` are all taken
+as written.
+
 ### Grid
 
 ```jsonc


### PR DESCRIPTION
## What

A CDU page config may now carry a root-level `title`, which becomes the browser tab title of the page, and `appGetPage` returns it alongside the rest of the Page. Without this the agent has no way to know the field exists — it would neither read it from a rendered page nor write it when authoring one.

## Changes

- **`appGetPage` summary** advertised the Page as `{ grid, forms[], notifications[], query, language }`. `title` joins that list.
- **`docs/user-flows/cdu-page-protocol.md`** — the field in the GET response shape (§2.2) and in the page model tree (§3).
- **`skills/simulator-smart-forms/SKILL.md`** — the "Page Config Format" section had no block for the root of a `config` at all; it went straight from the minimal example to `Grid`. Adds a compact one covering the root-level keys, with `title` explained.

## Behaviour being documented

`title` names the browser tab. Omit it and the host names the tab `<page> - <script ref>`, or the script ref alone on the `index` page. A Smart Form embedded into another screen (a modal, a section header) never renames the browser tab, whether a title is set or not.

pong-server resolves `[[locale]]` keys and `{{viewModel}}` values inside the title, so it can be localised or built at runtime — `Order {{orderId}}`.

## Platform side

Shipping with control-cdu `v0.51.8` plus the matching pong-server and pong-front-end changes (internal, CE-15862). The field travels through the public `/papi/1.0/pages/...` route, which is why the tool surface needed updating.

## Checks

`go build ./...` and `go test ./internal/tools/` pass; the drift test is unaffected, since no method, path or operationId changed.